### PR TITLE
Security / Public PEM Key

### DIFF
--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -13,9 +13,14 @@ data "aws_ami" "ubuntu_bionic" {
   }
 }
 
+data "aws_ssm_parameter" "buildbot_west_slave_key" {
+  name            = "/buildabot/ec2_key/public"
+  with_decryption = true
+}
+
 resource "aws_key_pair" "buildbot_west_slave_key" {
   key_name   = "buildbot-west-slave-key"
-  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCdGoRV9XPamZwqCMr4uk1oHWPnknzwOOSjuRBnu++WRkn7TtCM4ndDfqtKnvzlX5mzPhdvO1KKx1K8TiJ3wiq7WS4AFLGKQmPHWjg8qxGW7x4S8DHrb4ctmaujZ1+XCNSK3nsCl1lLW8DOrRlKbfeHIAllbMBZxIRmQ+XICVvhKAmSmxzTmYC8tBqvqQprG/uIuKonjLxL/ljtBxXBNECXl/JFCYG0AsB0aiuiMVeHLVzMiEppQ7YP/5Ml1Rpmn6h0dDzFtoD7xenroS98BIQF5kQWhakHbtWcNMz7DVFghWgi9wYr0gtoIshhqWYorC4yJq6HGXd0qdNHuLWNz39h buildbot-west-slave-key.pem"
+  public_key = data.aws_ssm_parameter.buildbot_west_slave_key.value
 }
 
 resource "aws_security_group" "legacy_common" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -10,11 +10,13 @@ terraform {
 }
 
 provider "aws" {
+  version = "~> 2.43"
   profile = "default"
   region  = "us-west-1"
 }
 
 provider "aws" {
+  version = "~> 2.43"
   profile = "default"
   region  = "us-east-1"
   alias   = "east1"


### PR DESCRIPTION
- Remove public pem key string contents and replace with SSM parameter data resource for lookup at deploy time.

Note: This change requires someone with access to the AWS environment to create a SSM secure string parmater named `/buildabot/ec2_key/public` with the public key contents