### PR TITLE
Add WG_AND_TEAMS env var

### DIFF
--- a/terraform/discord-mods-bot/deployment.tf
+++ b/terraform/discord-mods-bot/deployment.tf
@@ -71,6 +71,10 @@ module "ecs_task" {
       {
         "name": "TALK_ID",
         "value": "531929276086484992"
+      },
+      {
+        "name": "WG_AND_TEAMS",
+        "value": "590248810127818752"
       }
     ],
     "secrets": [

--- a/terraform/discord-mods-bot/deployment.tf
+++ b/terraform/discord-mods-bot/deployment.tf
@@ -73,7 +73,7 @@ module "ecs_task" {
         "value": "531929276086484992"
       },
       {
-        "name": "WG_AND_TEAMS",
+        "name": "WG_AND_TEAMS_ID",
         "value": "590248810127818752"
       }
     ],


### PR DESCRIPTION
This PR adds the WG_AND_TEAMS env var to the discords-mod-bot deployment environment so that we can limit certain commands to members of that role.   