### PR TITLE
Add crates io ops bot terraform

### DIFF
--- a/terraform/crates-io-ops-bot/_terraform.tf
+++ b/terraform/crates-io-ops-bot/_terraform.tf
@@ -1,0 +1,29 @@
+// Configuration for Terraform itself.
+
+terraform {
+  required_version = ">= 0.12"
+
+  backend "s3" {
+    bucket         = "rust-terraform"
+    key            = "simpleinfra/crates-io-ops-bot.tfstate"
+    region         = "us-west-1"
+    dynamodb_table = "terraform-state-lock"
+    encrypt        = true
+  }
+}
+
+data "terraform_remote_state" "shared" {
+  backend = "s3"
+  config = {
+    bucket = "rust-terraform"
+    key    = "simpleinfra/shared.tfstate"
+    region = "us-west-1"
+  }
+}
+
+provider "aws" {
+  version = "~> 2.44"
+
+  profile = "default"
+  region  = "us-west-1"
+}

--- a/terraform/crates-io-ops-bot/ci.tf
+++ b/terraform/crates-io-ops-bot/ci.tf
@@ -1,0 +1,59 @@
+// Definition of the resources the CI of rust-lang/discord-mods-bot needs.
+
+// ECR repository used to store the containers built by CI.
+
+module "ecr" {
+  source = "../shared/modules/ecr-repo"
+  name   = "crates-io-ops-bot"
+}
+
+// IAM User used by CI to push images to the repository created above. The user
+// has permissions to pull and push to the repository created earlier, and to
+// redeploy the ECS service of the bot.
+//
+// The IAM Access Key is stored in AWS SSM Parameter Store under the key:
+//
+//    /iam-users/ci--rust-lang--discord-mods-bot/access-keys/ACCESS_KEY_ID
+//
+
+resource "aws_iam_user" "ci" {
+  name = "ci--rust-lang--crates-io-ops-bot"
+}
+
+resource "aws_iam_user_policy" "update_service" {
+  name = "update-ecs-service"
+  user = aws_iam_user.ci.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "AllowUpdate"
+        Effect   = "Allow"
+        Action   = "ecs:UpdateService"
+        Resource = aws_ecs_service.service.id
+      }
+    ]
+  })
+}
+
+resource "aws_iam_user_policy_attachment" "ci_push" {
+  user       = aws_iam_user.ci.name
+  policy_arn = module.ecr.policy_push_arn
+}
+
+resource "aws_iam_user_policy_attachment" "ci_pull" {
+  user       = aws_iam_user.ci.name
+  policy_arn = module.ecr.policy_pull_arn
+}
+
+resource "aws_iam_access_key" "ci" {
+  user = aws_iam_user.ci.name
+}
+
+resource "aws_ssm_parameter" "ci_access_key" {
+  name  = "/iam-users/ci--rust-lang--crates-io-ops-bot/access-keys/${aws_iam_access_key.ci.id}"
+  value = aws_iam_access_key.ci.secret
+
+  type = "SecureString"
+}

--- a/terraform/crates-io-ops-bot/deployment.tf
+++ b/terraform/crates-io-ops-bot/deployment.tf
@@ -18,7 +18,7 @@ data "aws_ssm_parameter" "crates_io_ops_bot" {
       "github_repo",
       "github_token"
   ])
-  name     = "prod/ecs/crates_io_ops_bot/${each.value}"
+  name     = "/prod/ecs/crates_io_ops_bot/${each.value}"
 }
 
 module "ecs_task" {

--- a/terraform/crates-io-ops-bot/deployment.tf
+++ b/terraform/crates-io-ops-bot/deployment.tf
@@ -1,12 +1,5 @@
 // Deploys the bot to the production ECS cluster
 
-// The ECR repository is used by CI to store the container image, which will
-// then be fetched by the ECS service.
-module "ecr" {
-  source = "../shared/modules/ecr-repo"
-  name   = "crates-io-ops-bot"
-}
-
 // This just loads the data for each of these secrets
 // The values are added to SSM parameter store manually
 data "aws_ssm_parameter" "crates-io-ops-bot" {

--- a/terraform/crates-io-ops-bot/deployment.tf
+++ b/terraform/crates-io-ops-bot/deployment.tf
@@ -8,23 +8,23 @@ module "ecr" {
 }
 
 // This just loads the data for each of these secrets
-// The values are added to ASM manually
-data "aws_ssm_parameter" "crates_io_ops_bot" {
+// The values are added to SSM parameter store manually
+data "aws_ssm_parameter" "crates-io-ops-bot" {
   for_each = toset([
-    "discord_token",
-    "heroku_api_key",
-    "build_check_interval",
-    "github_org",
-    "github_repo",
-    "github_token"
+    "discord-token",
+    "heroku-api-key",
+    "build-check-interval",
+    "github-org",
+    "github-repo",
+    "github-token"
   ])
-  name = "/prod/ecs/crates_io_ops_bot/${each.value}"
+  name = "/prod/ecs/crates-io-ops-bot/${each.value}"
 }
 
 module "ecs_task" {
   source = "../shared/modules/ecs-task"
 
-  name               = "crates_io_ops"
+  name               = "crates-io-ops-bot"
   cpu                = 256
   memory             = 512
   log_retention_days = 7
@@ -49,33 +49,33 @@ module "ecs_task" {
       "options": {
         "awslogs-group": "/ecscratesioops",
         "awslogs-region": "us-west-1",
-        "awslogs-stream-prefix": "cratesioops"
+        "awslogs-stream-prefix": "crates-io-ops-bot"
       }
     },
     "secrets": [
       {
         "name": "DISCORD_TOKEN",
-        "valueFrom": "${data.aws_ssm_parameter.crates_io_ops_bot["discord_token"].arn}"
+        "valueFrom": "${data.aws_ssm_parameter.crates-io-ops-bot["discord-token"].arn}"
       },
       {
         "name": "HEROKU_API_KEY",
-        "valueFrom": "${data.aws_ssm_parameter.crates_io_ops_bot["heroku_api_key"].arn}"
+        "valueFrom": "${data.aws_ssm_parameter.crates-io-ops-bot["heroku-api-key"].arn}"
       },
       {
         "name": "BUILD_CHECK_INTERVAL",
-        "valueFrom": "${data.aws_ssm_parameter.crates_io_ops_bot["build_check_interval"].arn}"
+        "valueFrom": "${data.aws_ssm_parameter.crates-io-ops-bot["build-check-interval"].arn}"
       },
       {
         "name": "GITHUB_ORG",
-        "valueFrom": "${data.aws_ssm_parameter.crates_io_ops_bot["github_org"].arn}"
+        "valueFrom": "${data.aws_ssm_parameter.crates-io-ops-bot["github-org"].arn}"
       },
       {
         "name": "GITHUB_REPO",
-        "valueFrom": "${data.aws_ssm_parameter.crates_io_ops_bot["github_repo"].arn}"
+        "valueFrom": "${data.aws_ssm_parameter.crates-io-ops-bot["github-repo"].arn}"
       },
       {
         "name": "GITHUB_TOKEN",
-        "valueFrom": "${data.aws_ssm_parameter.crates_io_ops_bot["github_token"].arn}"
+        "valueFrom": "${data.aws_ssm_parameter.crates-io-ops-bot["github-token"].arn}"
       }
     ]
   }

--- a/terraform/crates-io-ops-bot/deployment.tf
+++ b/terraform/crates-io-ops-bot/deployment.tf
@@ -11,23 +11,23 @@ module "ecr" {
 // The values are added to ASM manually
 data "aws_ssm_parameter" "crates_io_ops_bot" {
   for_each = toset([
-      "discord_token",
-      "heroku_api_key",
-      "build_check_interval",
-      "github_org",
-      "github_repo",
-      "github_token"
+    "discord_token",
+    "heroku_api_key",
+    "build_check_interval",
+    "github_org",
+    "github_repo",
+    "github_token"
   ])
-  name     = "/prod/ecs/crates_io_ops_bot/${each.value}"
+  name = "/prod/ecs/crates_io_ops_bot/${each.value}"
 }
 
 module "ecs_task" {
-    source = "../shared/modules/ecs-task"
+  source = "../shared/modules/ecs-task"
 
-    name   = "crates_io_ops"
-    cpu    = 256
-    memory = 512
-      log_retention_days = 7
+  name               = "crates_io_ops"
+  cpu                = 256
+  memory             = 512
+  log_retention_days = 7
   ecr_repositories_arns = [
     module.ecr.arn,
   ]

--- a/terraform/crates-io-ops-bot/deployment.tf
+++ b/terraform/crates-io-ops-bot/deployment.tf
@@ -2,7 +2,7 @@
 
 // This just loads the data for each of these secrets
 // The values are added to SSM parameter store manually
-data "aws_ssm_parameter" "crates-io-ops-bot" {
+data "aws_ssm_parameter" "crates_io_ops_bot" {
   for_each = toset([
     "discord-token",
     "heroku-api-key",
@@ -40,7 +40,7 @@ module "ecs_task" {
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {
-        "awslogs-group": "/ecscratesioops",
+        "awslogs-group": "/ecs/crates-io-ops-bot",
         "awslogs-region": "us-west-1",
         "awslogs-stream-prefix": "crates-io-ops-bot"
       }
@@ -48,27 +48,27 @@ module "ecs_task" {
     "secrets": [
       {
         "name": "DISCORD_TOKEN",
-        "valueFrom": "${data.aws_ssm_parameter.crates-io-ops-bot["discord-token"].arn}"
+        "valueFrom": "${data.aws_ssm_parameter.crates_io_ops_bot["discord-token"].arn}"
       },
       {
         "name": "HEROKU_API_KEY",
-        "valueFrom": "${data.aws_ssm_parameter.crates-io-ops-bot["heroku-api-key"].arn}"
+        "valueFrom": "${data.aws_ssm_parameter.crates_io_ops_bot["heroku-api-key"].arn}"
       },
       {
         "name": "BUILD_CHECK_INTERVAL",
-        "valueFrom": "${data.aws_ssm_parameter.crates-io-ops-bot["build-check-interval"].arn}"
+        "valueFrom": "${data.aws_ssm_parameter.crates_io_ops_bot["build-check-interval"].arn}"
       },
       {
         "name": "GITHUB_ORG",
-        "valueFrom": "${data.aws_ssm_parameter.crates-io-ops-bot["github-org"].arn}"
+        "valueFrom": "${data.aws_ssm_parameter.crates_io_ops_bot["github-org"].arn}"
       },
       {
         "name": "GITHUB_REPO",
-        "valueFrom": "${data.aws_ssm_parameter.crates-io-ops-bot["github-repo"].arn}"
+        "valueFrom": "${data.aws_ssm_parameter.crates_io_ops_bot["github-repo"].arn}"
       },
       {
         "name": "GITHUB_TOKEN",
-        "valueFrom": "${data.aws_ssm_parameter.crates-io-ops-bot["github-token"].arn}"
+        "valueFrom": "${data.aws_ssm_parameter.crates_io_ops_bot["github-token"].arn}"
       }
     ]
   }

--- a/terraform/crates-io-ops-bot/deployment.tf
+++ b/terraform/crates-io-ops-bot/deployment.tf
@@ -1,0 +1,101 @@
+// Deploys the bot to the production ECS cluster
+
+// The ECR repository is used by CI to store the container image, which will
+// then be fetched by the ECS service.
+module "ecr" {
+  source = "../../modules/ecr-repo"
+  name   = "crates-io-ops-bot"
+}
+
+// This just loads the data for each of these secrets
+// The values are added to ASM manually
+data "aws_ssm_parameter" "crates_io_ops_bot" {
+  for_each = to_set([
+      "discord_token",
+      "heroku_api_key",
+      "build_check_interval",
+      "github_org",
+      "github_repo",
+      "github_token"
+  ])
+  name     = "prod/ecs/crates_io_ops_bot/${each.value}"
+}
+
+module "ecs_task" {
+    source = "../../modules/ecs-task"
+
+    name   = "crates_io_ops"
+    cpu    = 256
+    memory = 512
+      log_retention_days = 7
+  ecr_repositories_arns = [
+    module.ecr.arn,
+  ]
+
+  containers = <<EOF
+[
+  {
+    "name": "app",
+    "image": "${module.ecr.url}",
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 80,
+        "hostPort": 80
+      }
+    ],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "/ecscratesioops",
+        "awslogs-region": "us-west-1",
+        "awslogs-stream-prefix": "cratesioops"
+      }
+    },
+    "secrets": [
+      {
+        "name": "DISCORD_TOKEN",
+        "valueFrom": "${data.aws_ssm_parameter.highfive["discord_token"].arn}"
+      },
+      {
+        "name": "HEROKU_API_KEY",
+        "valueFrom": "${data.aws_ssm_parameter.highfive["heroku_api_key"].arn}"
+      },
+      {
+        "name": "BUILD_CHECK_INTERVAL",
+        "valueFrom": "${data.aws_ssm_parameter.highfive["build_check_interval"].arn}"
+      },
+      {
+        "name": "GITHUB_ORG",
+        "valueFrom": "${data.aws_ssm_parameter.highfive["github_org"].arn}"
+      },
+      {
+        "name": "GITHUB_REPO",
+        "valueFrom": "${data.aws_ssm_parameter.highfive["github_repo"].arn}"
+      },
+      {
+        "name": "GITHUB_TOKEN",
+        "valueFrom": "${data.aws_ssm_parameter.highfive["github_token"].arn}"
+      }
+    ]
+  }
+]
+EOF
+}
+
+module "ecs_service" {
+    source         = "../../modules/ecs-service"
+    cluster_config = var.cluster_config
+
+    name           = "cratesioops"
+    task_arn       = module.ecs_task.arn
+    tasks_count    = 1
+
+    http_counter   = "app"
+    http_port      = 80
+
+
+    domains = [
+        var.domain_name
+    ]
+}


### PR DESCRIPTION
In progress config for the soon to be deployed [crates-io-ops-bot](https://github.com/rust-lang/crates-io-ops-bot/).

Before this can be deployed I need to:

- [x] Push the crates-io-ops-bot container image to ECR
- [x] Obtain a Discord token for the bot
- [x] Obtain a Heroku API key with access to staging-crates-io
- [x] Obtain a GitHub token
- [x] Add discord_token to ssm parameter store
- [x] Add heroku_api_key to  ssm parameter store
- [x] Add build_check_interval to  ssm parameter store
- [x] Add github_org ("rust-lang") to  ssm parameter store
- [x] Add github_repo ("crates.io") to  ssm parameter store
- [x] Add github_token to  ssm parameter store
- [x] Add the bot to the rust-lang Discord server