### PR TITLE
Push latest perf changes

### DIFF
--- a/terraform/rds-databases/databases.tf
+++ b/terraform/rds-databases/databases.tf
@@ -2,6 +2,7 @@ locals {
   databases = [
     "discord-mods-bot",
     "triagebot",
+    "rustc-perf",
   ]
 }
 

--- a/terraform/rds-databases/instance.tf
+++ b/terraform/rds-databases/instance.tf
@@ -55,7 +55,7 @@ resource "aws_db_instance" "shared" {
   backup_retention_period      = 3
   storage_type                 = "gp2"
   engine                       = "postgres"
-  engine_version               = "11.5"
+  engine_version               = "11.6"
   instance_class               = "db.t3.micro"
   identifier                   = "shared"
   username                     = "root"

--- a/terraform/rustc-perf/main.tf
+++ b/terraform/rustc-perf/main.tf
@@ -66,6 +66,10 @@ module "ecs_task" {
       {
         "name": "PORT",
         "value": "80"
+      },
+      {
+        "name": "PERSISTENT_PATH",
+        "value": "/opt/database/persistent.json"
       }
     ],
     "secrets": [

--- a/terraform/shared/modules/ecs-service/main.tf
+++ b/terraform/shared/modules/ecs-service/main.tf
@@ -4,7 +4,7 @@ resource "aws_ecs_service" "service" {
   task_definition  = var.task_arn
   desired_count    = var.tasks_count
   launch_type      = "FARGATE"
-  platform_version = "1.4.0"
+  platform_version = var.platform_version
 
   enable_ecs_managed_tags = true
 

--- a/terraform/shared/modules/ecs-service/variables.tf
+++ b/terraform/shared/modules/ecs-service/variables.tf
@@ -3,6 +3,12 @@ variable "name" {
   description = "Name of the service to create"
 }
 
+variable "platform_version" {
+  type        = string
+  default     = "LATEST"
+  description = "The fargate version to use"
+}
+
 variable "task_arn" {
   type        = string
   description = "ARN of the task to spawn in the service"

--- a/terraform/shared/modules/ecs-task/main.tf
+++ b/terraform/shared/modules/ecs-task/main.tf
@@ -25,11 +25,11 @@ resource "aws_ecs_task_definition" "task" {
   dynamic "volume" {
     for_each = var.volume == null ? toset([]) : toset([1])
     content {
-      name = "service-storage"
       efs_volume_configuration {
-        file_system_id = var.volume.file_system_id
-        root_directory = var.volume.root_directory
+        file_system_id = var.volume.dns_name
+        root_directory = "/"
       }
+      name = "service-storage"
     }
   }
 }

--- a/terraform/shared/modules/ecs-task/variables.tf
+++ b/terraform/shared/modules/ecs-task/variables.tf
@@ -22,7 +22,7 @@ variable "containers" {
 }
 
 variable "volume" {
-  type        = object({ file_system_id = string, root_directory = string })
+  type        = object({ dns_name = string })
   description = "optional efs volume"
   default     = null
 }


### PR DESCRIPTION
This brings master up to date with the latest changes from rustc-perf's progress towards ECS.

Notably, it removes the EFS configuration for rustc-perf but retains the support code in the ecs-task module; we can remove it eventually if we choose to but for now there's no particular reason to do so (and it seems likely other services may want it).