### PR TITLE
Reduce level of access to our infrastructure

### DIFF
--- a/terraform/bastion/firewall.tf
+++ b/terraform/bastion/firewall.tf
@@ -8,13 +8,8 @@ locals {
   //     /prod/bastion/allowed-ips/${user}
   //
   allowed_users = [
-    "acrichto",
     "aidanhs",
-    "guillaumegomez",
     "joshua",
-    "mozilla-mountain-view",
-    "mozilla-portland",
-    "mozilla-san-francisco",
     "onur",
     "pietro",
     "shep",

--- a/terraform/shared/main.tf
+++ b/terraform/shared/main.tf
@@ -28,27 +28,5 @@ provider "dns" {
   version = "~> 2.2"
 }
 
-locals {
-  // Users allowed to connect to the bastion through SSH. Each user needs to
-  // have the CIDR of the static IP they want to connect from stored in AWS SSM
-  // Parameter Store (us-west-1), in a string key named:
-  //
-  //     /prod/bastion/allowed-ips/${user}
-  //
-  allowed_users = [
-    "acrichto",
-    "aidanhs",
-    "guillaumegomez",
-    "joshua",
-    "mozilla-mountain-view",
-    "mozilla-portland",
-    "mozilla-san-francisco",
-    "onur",
-    "pietro",
-    "shep",
-    "simulacrum",
-  ]
-}
-
 data "aws_caller_identity" "current" {}
 data "aws_canonical_user_id" "current" {}

--- a/terraform/shared/outputs.tf
+++ b/terraform/shared/outputs.tf
@@ -18,10 +18,6 @@ output "prod_vpc" {
   }
 }
 
-output "allowed_users" {
-  value = local.allowed_users
-}
-
 output "ecs_cluster_config" {
   value = module.service_ecs_cluster.config
 }


### PR DESCRIPTION
This PR reduces the level of access to our infrastructure:

* Now that the RDS instance is available from the bastion over the private network, and Terraform is configured to proxy through it, we don't need to grant access from the public internet to allowed IPs.
* Removed some IPs from the bastion security group, as those people don't have access to the bastion anymore.

r? @Mark-Simulacrum 