### PR TITLE
Remove default for the platform version

### DIFF
--- a/terraform/shared/modules/ecs-service/variables.tf
+++ b/terraform/shared/modules/ecs-service/variables.tf
@@ -5,7 +5,6 @@ variable "name" {
 
 variable "platform_version" {
   type        = string
-  default     = "LATEST"
   description = "The fargate version to use"
 }
 


### PR DESCRIPTION
The upgrade to Fargate platform 1.4.0 showed us that it's not always regression-free to upgrade, so it's better to explicitly pin the platform version used by each task. To enforce that, this commit removes the default value for the module variable.

r? @Mark-Simulacrum 