### PR TITLE
Add semverver to bors Terraform configuration file

### DIFF
--- a/terraform/bors/_config.auto.tfvars
+++ b/terraform/bors/_config.auto.tfvars
@@ -14,5 +14,6 @@ repositories = {
   miri      = "miri"
   rls       = "rls"
   rust      = "rust"
+  semverver = "rust-semverver"
   stdarch   = "stdarch"
 }


### PR DESCRIPTION
Step no. 4 of https://forge.rust-lang.org/infra/docs/bors.html#adding-a-new-repository-to-bors.

Step no. 2: https://github.com/rust-lang/rust-semverver/pull/134
Step no. 3: https://github.com/rust-lang/team/pull/470