### PR TITLE
Update monitoring-related software on our instance

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -6,14 +6,14 @@ global_collect_metrics_from:
 # Version of https://github.com/prometheus/node_exporter to install on our
 # instances. The checksum is the hash of the downloadable tarball for the
 # specified architecture, found in the GitHub releases.
-node_exporter_version: 1.0.1
+node_exporter_version: 1.1.2
 node_exporter_archs:
   x86_64:
     name: amd64
-    checksum: sha256:3369b76cd2b0ba678b6d618deab320e565c3d93ccb5c2a0d5db51a53857768ae
+    checksum: sha256:8c1f6a317457a658e0ae68ad710f6b4098db2cad10204649b51e3c043aa3e70d
   aarch64:
     name: arm64
-    checksum: sha256:017514906922fcc4b7d727655690787faed0562bc7a17aa9f72b0651cb1b47fb
+    checksum: sha256:eb5e7d16f18bb3272d0d832986fc8ac6cb0b6c42d487c94e15dabb10feae8e04
 
 # Version of https://github.com/prometheus/prometheus to install on our
 # instances. The checksum is the hash of the downloadable tarball for the

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -32,9 +32,9 @@ alertmanager_checksum: sha256:5f17155d669a8d2243b0d179fa46e609e0566876afd0afb093
 # Version of https://grafana.com to install in our instances. The checksum is
 # the hash of the .deb for the specified architecture, found here:
 # https://grafana.com/grafana/download
-grafana_version: 6.3.3
+grafana_version: 7.5.5
 grafana_arch: amd64
-grafana_checksum: sha256:7e2c05fb8c2b2595b7230cb34c3cd761891a4c3346e6d45518669d3946755e2d
+grafana_checksum: sha256:a6342dc645da72a92ac50ff053f9a9ca591f8334797174b9c70521bdcd349fe9
 
 # Version of https://github.com/letsencrypt/pebble to install on our instances.
 # The checksum is the hash of the downloadable binary for the specific

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -25,9 +25,9 @@ prometheus_checksum: sha256:8dd6786c338dc62728e8891c13b62eda66c7f28a01398869f2b3
 # Version of https://github.com/prometheus/alertmanager to install on our
 # instances. The checksum is the hash of the downloadable tarball for the
 # specified architecture, found in the GitHub releases.
-alertmanager_version: 0.18.0
+alertmanager_version: 0.21.0
 alertmanager_arch: amd64
-alertmanager_checksum: sha256:5f17155d669a8d2243b0d179fa46e609e0566876afd0afb09311a8bc7987ab15
+alertmanager_checksum: sha256:9ccd863937436fd6bfe650e22521a7f2e6a727540988eef515dde208f9aef232
 
 # Version of https://grafana.com to install in our instances. The checksum is
 # the hash of the .deb for the specified architecture, found here:

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -18,9 +18,9 @@ node_exporter_archs:
 # Version of https://github.com/prometheus/prometheus to install on our
 # instances. The checksum is the hash of the downloadable tarball for the
 # specified architecture, found in the GitHub releases.
-prometheus_version: 2.12.0
+prometheus_version: 2.26.0
 prometheus_arch: amd64
-prometheus_checksum: sha256:b9f57b6e64fb3048742cfa7dbcc727e1df906d8020ef246a5e81b7959ae97e08
+prometheus_checksum: sha256:8dd6786c338dc62728e8891c13b62eda66c7f28a01398869f2b3712895b441b9
 
 # Version of https://github.com/prometheus/alertmanager to install on our
 # instances. The checksum is the hash of the downloadable tarball for the

--- a/ansible/roles/monitoring-server/tasks/grafana.yml
+++ b/ansible/roles/monitoring-server/tasks/grafana.yml
@@ -33,7 +33,7 @@
 
   when: |
     grafana_capture.rc != 0 or not grafana_capture.stdout.startswith(
-      "Grafana cli version " + grafana_version
+      "Grafana CLI version " + grafana_version
     )
 
 - name: check if a grafana secret key was generated

--- a/ansible/roles/monitoring-server/tasks/prometheus.yml
+++ b/ansible/roles/monitoring-server/tasks/prometheus.yml
@@ -34,7 +34,7 @@
         state: absent
 
   when: |
-    prometheus_capture.rc != 0 or not prometheus_capture.stderr.startswith(
+    prometheus_capture.rc != 0 or not prometheus_capture.stdout.startswith(
       "prometheus, version " + prometheus_version
     )
 


### PR DESCRIPTION
As we discussed during a past infra team meeting, this PR upgrades the Prometheus version so that in the future we can start using the Remote Write API. While I was at it I also upgraded other monitoring-related software versions:

* **Prometheus:** 2.12.0 => 2.26.0
  * No changes affecting us, nor deprecations
* **Grafana:** 6.3.3 => 7.5.5
  * [We'll probably need to tweak how we authenticate with AWS CloudWatch in production](https://grafana.com/docs/grafana/latest/installation/upgrading/#aws-cloudwatch-data-source). CloudWatch is only used for a few dashboards, so I can look at it after we upgrade.
  * There is a new UI theme (screenshots below)
* **Alertmanager:** 0.18.0 => 0.21.0
  * No breaking changes affecting us
* **node_exporter:** 1.0.1 => 1.1.2
  * There is a deprecation but it doesn't affect us

r? @Mark-Simulacrum 

---

| Grafana 6.3.3 | Grafana 7.5.5 |
| --- | --- |
| ![Screenshot 2021-04-28 at 16-55-46 Instance metrics - Grafana](https://user-images.githubusercontent.com/2299951/116431962-8b1d5880-a848-11eb-9b1c-4e2c26d10114.png) | ![Screenshot 2021-04-28 at 16-55-25 Instance metrics - Grafana](https://user-images.githubusercontent.com/2299951/116431969-8bb5ef00-a848-11eb-9daf-7ceebe863bbc.png) |
