### PR TITLE
Overwrite and unset passphrase variable

### DIFF
--- a/with-rust-key.sh
+++ b/with-rust-key.sh
@@ -51,6 +51,10 @@ cleanup() {
 
     # Flush the gpg agent cache to remove the password
     echo RELOADAGENT | gpg-connect-agent
+
+    # Overwrite and unset `passphrase` variable
+    passphrase=$(printf '=%.0s' {1..1024})
+    unset passphrase
 }
 trap cleanup EXIT
 

--- a/with-rust-security-key.sh
+++ b/with-rust-security-key.sh
@@ -50,6 +50,10 @@ cleanup() {
 
     # Flush the gpg agent cache to remove the password
     echo RELOADAGENT | gpg-connect-agent
+
+    # Overwrite and unset `passphrase` variable
+    passphrase=$(printf '=%.0s' {1..1024})
+    unset passphrase
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
When the `with-rust-key` scripts exit, cleanup should include the data in the `passphrase` variable. We can do this by writing over the data then calling `unset`.