### PR TITLE
Redirect /rustup to the rustup book

### DIFF
--- a/terraform/releases/impl/lambdas/doc-router/index.js
+++ b/terraform/releases/impl/lambdas/doc-router/index.js
@@ -64,6 +64,9 @@ exports.handler = (event, context, callback) => {
     // Redirect `/` to the rust-lang.org website
     if (request.uri === '/' || request.uri === '/index.html') {
         return temp_redirect('https://www.rust-lang.org/learn', callback);
+    // Redirect `/rustup` to the Rustup book
+    } else if (['/rustup', '/rustup/', '/rustup/index.html'].includes(request.uri)) {
+        return temp_redirect('https://rust-lang.github.io/rustup/', callback);
     }
 
     // Forward versioned documentation as-is.


### PR DESCRIPTION
Rustup lives on a different website than everything else. Make it easy to find
by adding a redirect to the main doc.rust-lang.org site.

See also https://github.com/rust-lang/rustup/issues/2714#issuecomment-818245894,
which proposes including the docs in releases themselves. This would have to
reverted if so.