### PR TITLE
Add checksum verification for `deploy.rs`

### DIFF
--- a/azure-configs/static-websites.yml
+++ b/azure-configs/static-websites.yml
@@ -26,7 +26,10 @@ steps:
       # be included in the pages.
       touch $DEPLOY_DIR/.nojekyll
       # Download, compile and run the deploy script
-      curl -LsSf https://raw.githubusercontent.com/rust-lang/simpleinfra/master/setup-deploy-keys/src/deploy.rs | rustc - -o /tmp/deploy
+      curl -LsSf -O https://raw.githubusercontent.com/rust-lang/simpleinfra/master/setup-deploy-keys/src/deploy.rs
+      DEPLOY_SHA=bef09c1cac587271d0352b0ae59949d2cab93b3d1c9dc45366a42fbe51f6221a
+      echo "${DEPLOY_SHA}  deploy.rs" | sha256sum --check -
+      rustc - -o /tmp/deploy
       (cd $DEPLOY_DIR && /tmp/deploy)
     env:
       DEPLOY_DIR: ${{ parameters.deploy_dir }}

--- a/azure-configs/static-websites.yml
+++ b/azure-configs/static-websites.yml
@@ -29,7 +29,7 @@ steps:
       curl -LsSf -O https://raw.githubusercontent.com/rust-lang/simpleinfra/master/setup-deploy-keys/src/deploy.rs
       DEPLOY_SHA=bef09c1cac587271d0352b0ae59949d2cab93b3d1c9dc45366a42fbe51f6221a
       echo "${DEPLOY_SHA}  deploy.rs" | sha256sum --check -
-      rustc - -o /tmp/deploy
+      rustc -o /tmp/deploy deploy.rs
       (cd $DEPLOY_DIR && /tmp/deploy)
     env:
       DEPLOY_DIR: ${{ parameters.deploy_dir }}

--- a/travis-configs/static-websites.yml
+++ b/travis-configs/static-websites.yml
@@ -30,7 +30,12 @@ before_deploy:
 # Deploy the content of $RUSTINFRA_DEPLOY_DIR to GitHub Pages using deploy keys.
 deploy:
   provider: script
-  script: curl -LsSf https://raw.githubusercontent.com/rust-lang/simpleinfra/master/setup-deploy-keys/src/deploy.rs | rustc - -o /tmp/deploy && (cd $RUSTINFRA_DEPLOY_DIR && /tmp/deploy)
+  script: |
+    set -e
+    curl -LsSfO https://raw.githubusercontent.com/rust-lang/simpleinfra/master/setup-deploy-keys/src/deploy.rs
+    DEPLOY_SHA=bef09c1cac587271d0352b0ae59949d2cab93b3d1c9dc45366a42fbe51f6221a
+    echo "${DEPLOY_SHA}  deploy.rs" | sha256sum --check -
+    rustc - -o /tmp/deploy && (cd $RUSTINFRA_DEPLOY_DIR && /tmp/deploy)
   skip_cleanup: true
   on:
     branch: master

--- a/travis-configs/static-websites.yml
+++ b/travis-configs/static-websites.yml
@@ -35,7 +35,7 @@ deploy:
     curl -LsSfO https://raw.githubusercontent.com/rust-lang/simpleinfra/master/setup-deploy-keys/src/deploy.rs
     DEPLOY_SHA=bef09c1cac587271d0352b0ae59949d2cab93b3d1c9dc45366a42fbe51f6221a
     echo "${DEPLOY_SHA}  deploy.rs" | sha256sum --check -
-    rustc - -o /tmp/deploy && (cd $RUSTINFRA_DEPLOY_DIR && /tmp/deploy)
+    rustc -o /tmp/deploy deploy.rs && (cd $RUSTINFRA_DEPLOY_DIR && /tmp/deploy)
   skip_cleanup: true
   on:
     branch: master


### PR DESCRIPTION
Since 1) we're downloading `deploy.rs` over the network, 2) it appears to handle secrets, and 3) the file doesn't seem to change very often, it makes sense to add an integrity check.