### PR TITLE
docs.rs: add new alert when the queue is locked

### DIFF
--- a/ansible/playbooks/monitoring.yml
+++ b/ansible/playbooks/monitoring.yml
@@ -161,6 +161,15 @@
                 summary: "docs.rs is down"
                 description: "Prometheus wasn't able to reach the docs.rs website for more than a minute."
 
+            - alert: DocsRsQueueLocked
+              expr: docsrs_queue_is_locked{job="docsrs"} == 1
+              for: 1m
+              labels:
+                dispatch: docsrs
+              annotations:
+                summary: "docs.rs queue is locked"
+                description: "the build queue is marked as locked for more than a minute."
+
             - alert: LongQueue
               expr: docsrs_prioritized_crates_count{job="docsrs"} >= 50
               for: 12h


### PR DESCRIPTION
We do want a new alert when the build queue is locked. While in some cases we do it manually and intentionally, there are situations when we want to be alerted about that. 