### PR TITLE
Add a few release process scripts

### DIFF
--- a/release-scripts/master-to-beta.sh
+++ b/release-scripts/master-to-beta.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+if [ ! -e x.py ]; then
+    echo "Should be run from a rust-lang/rust checkout"
+    exit 1
+fi
+
+git fetch git@github.com:rust-lang/rust
+CURRENT_MASTER=`git ls-remote -q git@github.com:rust-lang/rust master | awk '{ print $1 }'`
+BRANCH_POINT=`git log --merges --first-parent --format="%P" -1 $CURRENT_MASTER -- src/version | awk '{print($1)}'`
+NEW_BETA_VERSION=`git show $BRANCH_POINT:src/version`
+CARGO_SHA=`git rev-parse $BRANCH_POINT:src/tools/cargo`
+git push git@github.com:rust-lang/cargo $CARGO_SHA:refs/heads/tmp-rust-$NEW_BETA_VERSION
+
+echo "Disable branch protection for beta on rust-lang/rust, then press enter."
+read
+
+git push git@github.com:rust-lang/rust $BRANCH_POINT:refs/heads/beta -f
+
+echo "Please reenable branch protection for beta on rust-lang/rust, then press enter."
+read

--- a/release-scripts/tag-cargo.sh
+++ b/release-scripts/tag-cargo.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+if [ ! -e x.py ]; then
+    echo "Should be run from a rust-lang/rust checkout"
+    exit 1
+fi
+
+SIMPLEINFRA_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && basename `pwd` )/.."
+
+git fetch git@github.com:rust-lang/rust
+CURRENT_STABLE=`git ls-remote -q git@github.com:rust-lang/rust stable | awk '{ print $1 }'`
+git checkout $CURRENT_STABLE
+
+git submodule update --init -- src/tools/cargo
+
+cd src/tools/cargo
+
+./publish.py
+CARGO_VERSION=$(cargo read-manifest | jq -r .version)
+$SIMPLEINFRA_DIR/with-rust-key.sh git tag -m "$CARGO_VERSION release" -u FA1BE5FE $CARGO_VERSION


### PR DESCRIPTION
This adds the two more interesting blocks of code, with some slight alterations, from https://forge.rust-lang.org/release/process.html to this repository. My hope is that we can use this as a baseline step for the next release, and then hopefully gradually start moving this infrastructure into the remote release process (i.e., start-release.py's invoked cloud build resources). Even in this repository, I think it'll be much nicer to invoke scripts rather than copy/pasting line-by-line and hoping to not get anything wrong.

Obviously, there are more release steps that this doesn't yet cover, but it seems like a good start, and covers the ones I worry about the most -- at least to some extent.

r? @pietroalbini 