### PR TITLE
Push the cargo commit from the cargo repository

### DIFF
--- a/release-scripts/master-to-beta.sh
+++ b/release-scripts/master-to-beta.sh
@@ -12,7 +12,7 @@ CURRENT_MASTER=`git ls-remote -q git@github.com:rust-lang/rust master | awk '{ p
 BRANCH_POINT=`git log --merges --first-parent --format="%P" -1 $CURRENT_MASTER -- src/version | awk '{print($1)}'`
 NEW_BETA_VERSION=`git show $BRANCH_POINT:src/version`
 CARGO_SHA=`git rev-parse $BRANCH_POINT:src/tools/cargo`
-git push git@github.com:rust-lang/cargo $CARGO_SHA:refs/heads/rust-$NEW_BETA_VERSION
+git -C src/tools/cargo push git@github.com:rust-lang/cargo $CARGO_SHA:refs/heads/rust-$NEW_BETA_VERSION
 
 echo "Disable branch protection for beta on rust-lang/rust, then press enter."
 read


### PR DESCRIPTION
Without this change the script would fail as it'd try to push the cargo commit from the rust repo, where the commit object was not available.