### PR TITLE
crates.io indexes should be cached

### DIFF
--- a/terraform/crates-io/impl/cloudfront-index.tf
+++ b/terraform/crates-io/impl/cloudfront-index.tf
@@ -22,6 +22,10 @@ resource "aws_cloudfront_distribution" "index" {
     compress               = true
     viewer_protocol_policy = "redirect-to-https"
 
+    default_ttl = 60
+    min_ttl     = 1
+    max_ttl     = 31536000
+
     forwarded_values {
       headers = [
         // Following the spec, AWS S3 only replies with the CORS headers when


### PR DESCRIPTION
[default_ttl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#default_ttl) defines how long CloudFront should cached files that do not come with caching headers.
[min_ttl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#min_ttl) overrides headers on files that claim they should have short or no caching.
[max_ttl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#max_ttl) which overrides headers that claim they should be cashed for too long an interval. This one's really important because when left blank it's treated as 0, meaning that all caching is disabled even when the file asks for caching!

We can adjust the exact values of these, as we see what problems people have. But for now this should be enough to let people test HTTP indexes.