### PR TITLE
Rewrite HTTP 403 to 404 for index.crates.io

### DIFF
--- a/terraform/crates-io/impl/cloudfront-index.tf
+++ b/terraform/crates-io/impl/cloudfront-index.tf
@@ -41,6 +41,14 @@ resource "aws_cloudfront_distribution" "index" {
     }
   }
 
+  // Rewrite 403 (access denied) to 404 (not found). S3 returns 403 when an
+  // object is not found, which leads to confusing errors in Cargo if a 
+  // crate does not exist.
+  custom_error_response {
+    error_code    = 403
+    response_code = 404
+  }
+
   origin {
     origin_id   = "main"
     domain_name = aws_s3_bucket.index.bucket_regional_domain_name


### PR DESCRIPTION
S3 returns HTTP 403 when an object is not found, which leads to confusing errors in Cargo if a crate does not exist. 

This change causes CloudFront to rewrite the HTTP 403 from S3 to HTTP 404, which makes cargo handle it appropriately.