### PR TITLE
Allow heroku to delete objects from s3

### DIFF
--- a/terraform/crates-io/impl/iam.tf
+++ b/terraform/crates-io/impl/iam.tf
@@ -20,6 +20,7 @@ resource "aws_iam_policy" "static_write" {
           "s3:GetObjectAcl",
           "s3:PutObject",
           "s3:PutObjectAcl",
+          "s3:DeleteObject",
         ]
         Resource = [
           "${aws_s3_bucket.static.arn}/*",


### PR DESCRIPTION
We have [an admin tool in crates.io](https://github.com/rust-lang/crates.io/blob/74a41e6fd2e86910484770a65224f628ec76d71d/src/admin/delete_crate.rs) that lets us remove crates in certain circumstances.

As part of the HTTP index work, [removing the crate from the HTTP index was added to this admin tool](https://github.com/rust-lang/crates.io/commit/acb38cb6a9eefc377c9bdde74b0289e3f9c1d797#diff-464e2ad5d7f91f317a36db0c511fb60c6fa4bf38c5a8e1530d4c17d5b527c833R51). This currently fails because the heroku AWS creds don't have s3 DeleteObject permissions.

If you don't want the heroku creds to have DeleteObject permissions, please close this. Instead, I'll remove that line from the admin tool and we'll clean up the HTTP index with individual credentials.

If I've done this incorrectly, please let me know what to fix and I'd be happy to!