### PR TITLE
setup_rustup.sh: source rustup environment before linking stages

### DIFF
--- a/ansible/roles/dev-desktop/files/scripts/setup_rustup.sh
+++ b/ansible/roles/dev-desktop/files/scripts/setup_rustup.sh
@@ -4,6 +4,8 @@ set -x
 
 rustup --version || curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
+source "$HOME/.cargo/env"
+
 for D in rust*; do
     if [ -d "${D}" ]; then
         rustup toolchain link "$D"_stage1 "$D/build/x86_64-unknown-linux-gnu/stage1"


### PR DESCRIPTION
this fixes the issue when `rustup` is called but it is not currently in `$PATH`.