### PR TITLE
dont cache the index longer then 1min untill we add invalidations

### DIFF
--- a/terraform/crates-io/impl/cloudfront-index.tf
+++ b/terraform/crates-io/impl/cloudfront-index.tf
@@ -28,7 +28,7 @@ resource "aws_cloudfront_distribution" "index" {
 
     default_ttl = 60
     min_ttl     = 1
-    max_ttl     = 31536000
+    max_ttl     = 60
 
     forwarded_values {
       headers = [


### PR DESCRIPTION
https://github.com/rust-lang/crates.io/issues/4913
https://internals.rust-lang.org/t/call-for-testing-cargo-sparse-registry/16862/10

10 minute TTL is way too long for the index, given how we currently do publishes.