### PR TITLE
doc.rust-lang.org: set a long cache-control for fonts

### DIFF
--- a/terraform/releases/impl/cache.tf
+++ b/terraform/releases/impl/cache.tf
@@ -1,0 +1,11 @@
+resource "aws_cloudfront_response_headers_policy" "cache-immutable" {
+  name = "cache-immutable"
+
+  custom_headers_config {
+    items {
+      header   = "Cache-Control"
+      override = true
+      value    = "immutable, max-age=9999999"
+    }
+  }
+}

--- a/terraform/releases/impl/cloudfront-doc.tf
+++ b/terraform/releases/impl/cloudfront-doc.tf
@@ -49,6 +49,29 @@ resource "aws_cloudfront_distribution" "doc" {
     }
   }
 
+  ordered_cache_behavior {
+    path_pattern     = "*.woff2"
+    cache_policy_id  = "cache-immutable"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "main"
+
+    forwarded_values {
+      headers      = []
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
   origin {
     origin_id   = "main"
     domain_name = aws_s3_bucket.static.website_endpoint


### PR DESCRIPTION
Context: On all rustdoc pages there are 6+ custom fonts. These are on the critical rendering path; text can't start being displayed without them. On docs.rs, they are served with a very long Cache-Control max-age, so they are almost never requested by the browser. On doc.rust-lang.org, they are served with no Cache-Control header. They do have an ETag, so in practice most page navigations result in an HTTP 304 Not Modified and the fonts don't have to be redownloaded. But the time waiting for that request and response still delays rendering, and it would be better if the browser could immediately load the fonts from its local cache.

The CSS and the storage JS are also on the critical path, but their cache policy is a little less straightforward since they can change with each release. I figured I'd start with the fonts, which never change, and see if this is a good approach and works well.