### PR TITLE
Give crates.io team members ListObjectsV2 permission on crates.io S3 buckets

### DIFF
--- a/terraform/team-members-access/crates-io.tf
+++ b/terraform/team-members-access/crates-io.tf
@@ -85,6 +85,7 @@ resource "aws_iam_group_policy" "crates_io" {
           "s3:PutObject",
           "s3:PutObjectAcl",
           "s3:DeleteObject",
+          "s3:ListObjectsV2",
         ]
         Resource = [for _, bucket in data.aws_s3_bucket.crates_io_buckets : "${bucket.arn}/*"]
       },


### PR DESCRIPTION
👋🏻 Hi, I'm back again... still working on deleting crates... turns out that to use `aws s3 rm --recursive`, I need ListObjectsV2 permissions.