### PR TITLE
Install Mosh on dev desktops

### DIFF
--- a/ansible/roles/dev-desktop/handlers/main.yml
+++ b/ansible/roles/dev-desktop/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart-firewall
+  service:
+    name: firewall
+    state: restarted

--- a/ansible/roles/dev-desktop/tasks/main.yml
+++ b/ansible/roles/dev-desktop/tasks/main.yml
@@ -98,6 +98,20 @@
     dest: /usr/local/bin/
     mode: a+x
 
+- name: Install mosh
+  apt:
+    name:
+      - mosh
+    state: present
+
+- name: Upload firewall rules for mosh
+  template:
+    src: firewall.sh
+    dest: /etc/firewall/mosh.sh
+    mode: 0750
+  notify:
+    - restart-firewall
+
 - name: install common tooling
   apt:
     name:

--- a/ansible/roles/dev-desktop/templates/firewall.sh
+++ b/ansible/roles/dev-desktop/templates/firewall.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#
+# {{ ansible_managed }}
+#
+
+cmd -A public_input_udp -p udp --dport "60000:61000" -j ACCEPT

--- a/terraform/dev-desktops/aws-region/instances.tf
+++ b/terraform/dev-desktops/aws-region/instances.tf
@@ -75,6 +75,15 @@ resource "aws_security_group" "dev_desktops" {
   }
 
   ingress {
+    from_port        = 60000
+    to_port          = 61000
+    protocol         = "udp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+    description      = "Mosh access from the world"
+  }
+
+  ingress {
     from_port   = 8
     to_port     = -1
     protocol    = "icmp"


### PR DESCRIPTION
Mosh has been added to the dev desktops. The ports that it uses have been allowed in the security group on AWS as well as the local firewall on the machine.

Requested in https://github.com/rust-lang/simpleinfra/issues/113