### PR TITLE
Allow users to debug their processes

### DIFF
--- a/ansible/roles/dev-desktop/handlers/main.yml
+++ b/ansible/roles/dev-desktop/handlers/main.yml
@@ -3,3 +3,6 @@
   service:
     name: firewall
     state: restarted
+
+- name: reboot-machine
+  reboot:

--- a/ansible/roles/dev-desktop/tasks/main.yml
+++ b/ansible/roles/dev-desktop/tasks/main.yml
@@ -26,7 +26,8 @@
     path: /etc/sysctl.d/10-ptrace.conf
     regexp: '^kernel.yama.ptrace_scope = [\d]$'
     replace: 'kernel.yama.ptrace_scope = 0'
-  register: ptrace_scope
+  notify:
+    - reboot-machine
 
 - name: Configure update script service
   copy:
@@ -179,18 +180,3 @@
     src: sudoers
     dest: /etc/sudoers.d/dev-desktop
     mode: 0440
-
-- name: Reboot to apply sysctl changes
-  command: reboot now
-  async: true
-  poll: false
-  when: ptrace_scope is changed
-
-- name: Wait for server to start again
-  wait_for_connection:
-    connect_timeout: 20
-    sleep: 5
-    delay: 5
-    timeout: 300
-  when: ptrace_scope is changed
-

--- a/ansible/roles/dev-desktop/tasks/main.yml
+++ b/ansible/roles/dev-desktop/tasks/main.yml
@@ -21,6 +21,13 @@
     echo "${RUSTUP_SHA}  rustup-init.sh" | sha256sum --check --
     sh rustup-init.sh --default-toolchain nightly -y --component rust-src
 
+- name: Allow users to debug their own processes
+  replace:
+    path: /etc/sysctl.d/10-ptrace.conf
+    regexp: '^kernel.yama.ptrace_scope = [\d]$'
+    replace: 'kernel.yama.ptrace_scope = 0'
+  register: ptrace_scope
+
 - name: Configure update script service
   copy:
     src: team_login/
@@ -172,3 +179,18 @@
     src: sudoers
     dest: /etc/sudoers.d/dev-desktop
     mode: 0440
+
+- name: Reboot to apply sysctl changes
+  command: reboot now
+  async: true
+  poll: false
+  when: ptrace_scope is changed
+
+- name: Wait for server to start again
+  wait_for_connection:
+    connect_timeout: 20
+    sleep: 5
+    delay: 5
+    timeout: 300
+  when: ptrace_scope is changed
+


### PR DESCRIPTION
Ubuntu restricts ptrace by default, and only allows a process to debug its own child processes. This is limiting the ability of developers to use the dev desktops to analyze and debug their work.

The default scope for ptrace has been changed to `0`, allowing users to debug their own processes. This carries with it the risk that malicious code can interact with any process that a user created. We deem this to be acceptable in this specific use case, as the dev desktops are intended to be used only for the development of Rust and have, by design, no user data or credentials that could be extracted.

Requested in #113 