### PR TITLE
Set a filesystem quota for dev desktop users

### DIFF
--- a/ansible/roles/dev-desktop/defaults/main.yml
+++ b/ansible/roles/dev-desktop/defaults/main.yml
@@ -2,3 +2,6 @@
 
 vars_team_login_path: "/root/team_login"
 allow_ssh_extra_groups: "dev-desktop-allow-ssh"
+
+# Filesystem quota per user in GB
+user_quota: 50

--- a/ansible/roles/dev-desktop/defaults/main.yml
+++ b/ansible/roles/dev-desktop/defaults/main.yml
@@ -4,7 +4,7 @@ vars_team_login_path: "/root/team_login"
 allow_ssh_extra_groups: "dev-desktop-allow-ssh"
 
 # Filesystem quota per user in GB
-vars_user_quota: 50
+vars_user_quota_gb: 50
 
 # For Ubuntu hosts, change this in a host variable to:
 # "linux-modules-extra-virtual"

--- a/ansible/roles/dev-desktop/defaults/main.yml
+++ b/ansible/roles/dev-desktop/defaults/main.yml
@@ -4,4 +4,8 @@ vars_team_login_path: "/root/team_login"
 allow_ssh_extra_groups: "dev-desktop-allow-ssh"
 
 # Filesystem quota per user in GB
-user_quota: 50
+vars_user_quota: 50
+
+# For Ubuntu hosts, change this in a host variable to:
+# "linux-modules-extra-virtual"
+vars_user_quota_linux_package: "linux-modules-extra-aws"

--- a/ansible/roles/dev-desktop/files/team_login/Cargo.lock
+++ b/ansible/roles/dev-desktop/files/team_login/Cargo.lock
@@ -9,10 +9,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "cc"
 version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
+
+[[package]]
+name = "clap"
+version = "3.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+dependencies = [
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
 
 [[package]]
 name = "curl"
@@ -42,6 +84,28 @@ dependencies = [
  "pkg-config",
  "vcpkg",
  "winapi",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
+name = "indexmap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+dependencies = [
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -97,6 +161,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,10 +186,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c9b1041b4387893b91ee6746cddfc28516aff326a3519fb2adf820932c5e6cb"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -180,9 +280,16 @@ dependencies = [
 name = "team_login"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "curl",
  "miniserde",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "unicode-xid"
@@ -195,6 +302,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "winapi"

--- a/ansible/roles/dev-desktop/files/team_login/Cargo.toml
+++ b/ansible/roles/dev-desktop/files/team_login/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 
 [dependencies]
 miniserde = "0.1"
+clap = { version = "3", default-features = false, features = ["std", "derive"] }
 curl = "0.4"
 
 [workspace]

--- a/ansible/roles/dev-desktop/files/team_login/src/main.rs
+++ b/ansible/roles/dev-desktop/files/team_login/src/main.rs
@@ -90,6 +90,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .success(),
             "failed to set the default shell"
         );
+
+        // Set a user quota
+        assert!(
+            cmd("setquota", &["-u", &username, "50G", "51G", "0", "0", "/"])?
+                .status
+                .success(),
+            "failed to set a user quota"
+        );
     }
     // Delete all keys for users that weren't on the list
     for entry in std::fs::read_dir(KEY_DIR)? {

--- a/ansible/roles/dev-desktop/files/team_login/src/main.rs
+++ b/ansible/roles/dev-desktop/files/team_login/src/main.rs
@@ -92,12 +92,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         );
 
         // Set a user quota
-        assert!(
-            cmd("setquota", &["-u", &username, "50G", "51G", "0", "0", "/"])?
-                .status
-                .success(),
-            "failed to set a user quota"
-        );
+        if let Ok(user_quota_var) = std::env::var("USER_QUOTA") {
+            if let Ok(soft_limit) = user_quota_var.parse::<u32>() {
+                let hard_limit = format!("{}G", soft_limit + 1);
+                let soft_limit = format!("{}G", soft_limit);
+
+                assert!(
+                    cmd(
+                        "setquota",
+                        &["-u", &username, &soft_limit, &hard_limit, "0", "0", "/"]
+                    )?
+                    .status
+                    .success(),
+                    "failed to set a user quota"
+                );
+            }
+        }
     }
     // Delete all keys for users that weren't on the list
     for entry in std::fs::read_dir(KEY_DIR)? {

--- a/ansible/roles/dev-desktop/files/team_login/src/main.rs
+++ b/ansible/roles/dev-desktop/files/team_login/src/main.rs
@@ -20,7 +20,7 @@ const KEY_DIR: &str = "/etc/ssh/authorized_keys/";
 #[derive(Parser)]
 struct Args {
     #[clap(long, value_parser)]
-    user_quota: u32,
+    user_quota_gb: u32,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/ansible/roles/dev-desktop/tasks/main.yml
+++ b/ansible/roles/dev-desktop/tasks/main.yml
@@ -9,6 +9,8 @@
       - python3-pip
       - python3-jwt
       - python3-cryptography
+      - quota
+      - linux-image-extra-virtual
     state: present
 
 - name: install rustup in userspace for root
@@ -28,6 +30,37 @@
     replace: 'kernel.yama.ptrace_scope = 0'
   notify:
     - reboot-machine
+
+- name: Enable kernel modules for quota
+  command: "{{ item }}"
+  with_items:
+    - "modprobe quota_v1"
+    - "modprobe quota_v2"
+
+- name: Determine name of root volume
+  shell:
+    cmd: cat /etc/fstab | grep -E '\s+/\s+' | awk -F ' ' '{ print $1 }'
+  register: fstab_root_volume_name
+
+- name: Enable quotas for the root volume
+  mount:
+    path: "/"
+    src: "{{ fstab_root_volume_name.stdout }}"
+    fstype: ext4
+    opts: "usrquota"
+    state: mounted
+
+- name: Check if quota system is already enabled
+  command: "quotaon -up /"
+  register: user_quota_check
+  failed_when: user_quota_check.rc != 0 and user_quota_check.rc != 1
+
+- name: Enable the quota system for users
+  command: "{{ item }}"
+  with_items:
+    - "quotacheck -um /"
+    - "quotaon -uv /"
+  when: user_quota_check.rc == 0
 
 - name: Configure update script service
   copy:

--- a/ansible/roles/dev-desktop/tasks/main.yml
+++ b/ansible/roles/dev-desktop/tasks/main.yml
@@ -10,7 +10,7 @@
       - python3-jwt
       - python3-cryptography
       - quota
-      - linux-image-extra-virtual
+      - "{{ vars_user_quota_linux_package }}"
     state: present
 
 - name: install rustup in userspace for root

--- a/ansible/roles/dev-desktop/templates/crontab_append
+++ b/ansible/roles/dev-desktop/templates/crontab_append
@@ -1,2 +1,2 @@
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-*/5 * * * * root /etc/cron.team_login --user-quota={{ user_quota }}
+*/5 * * * * root /etc/cron.team_login --user-quota={{ vars_user_quota }}

--- a/ansible/roles/dev-desktop/templates/crontab_append
+++ b/ansible/roles/dev-desktop/templates/crontab_append
@@ -1,2 +1,2 @@
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-*/5 * * * * root /etc/cron.team_login --user-quota={{ vars_user_quota }}
+*/5 * * * * root /etc/cron.team_login --user-quota-gb={{ vars_user_quota_gb }}

--- a/ansible/roles/dev-desktop/templates/crontab_append
+++ b/ansible/roles/dev-desktop/templates/crontab_append
@@ -1,3 +1,2 @@
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-USER_QUOTA={{ user_quota }}
-*/5 * * * * root /etc/cron.team_login
+*/5 * * * * root /etc/cron.team_login --user-quota={{ user_quota }}

--- a/ansible/roles/dev-desktop/templates/crontab_append
+++ b/ansible/roles/dev-desktop/templates/crontab_append
@@ -1,2 +1,3 @@
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+USER_QUOTA={{ user_quota }}
 */5 * * * * root /etc/cron.team_login


### PR DESCRIPTION
The Ansible role for dev desktops has been expanded to enable filesystem quotas for users. The actual quotas are set when a user is created by the team login feature.