### PR TITLE
Fix formatting of Terraform file

### DIFF
--- a/terraform/docs-rs/web-server.tf
+++ b/terraform/docs-rs/web-server.tf
@@ -69,8 +69,8 @@ resource "aws_iam_role_policy" "web" {
         ]
       },
       {
-        Effect   = "Allow"
-        Action   = "cloudfront:CreateInvalidation"
+        Effect = "Allow"
+        Action = "cloudfront:CreateInvalidation"
         Resource = [
           aws_cloudfront_distribution.webapp.arn,
           aws_cloudfront_distribution.static.arn,


### PR DESCRIPTION
The formatting of a Terraform file was accidentally broken in a previous commit [^1], which has been fixed by running `terraform fmt` on the file.

[^1]: https://github.com/rust-lang/simpleinfra/commit/e0119b68127755d41f8c3dd607a16c26e03a0622