### PR TITLE
Enable perf on dev desktops

### DIFF
--- a/ansible/roles/dev-desktop/defaults/main.yml
+++ b/ansible/roles/dev-desktop/defaults/main.yml
@@ -6,10 +6,5 @@ allow_ssh_extra_groups: "dev-desktop-allow-ssh"
 # Filesystem quota per user in GB
 vars_user_quota_gb: 50
 
-# For Ubuntu hosts, change this in a host variable to:
-# "linux-modules-extra-virtual"
-vars_user_quota_linux_package: "linux-modules-extra-aws"
-
-# For Ubuntu hosts, change this in a host variable to:
-# "linux-tools-common"
-vars_perf_linux_package: "linux-tools-aws"
+# Set the flavor of the linux kernel, e.g. "aws" or "virtual"
+vars_linux_kernel_flavor: "aws"

--- a/ansible/roles/dev-desktop/defaults/main.yml
+++ b/ansible/roles/dev-desktop/defaults/main.yml
@@ -9,3 +9,7 @@ vars_user_quota_gb: 50
 # For Ubuntu hosts, change this in a host variable to:
 # "linux-modules-extra-virtual"
 vars_user_quota_linux_package: "linux-modules-extra-aws"
+
+# For Ubuntu hosts, change this in a host variable to:
+# "linux-tools-common"
+vars_perf_linux_package: "linux-tools-aws"

--- a/ansible/roles/dev-desktop/tasks/main.yml
+++ b/ansible/roles/dev-desktop/tasks/main.yml
@@ -11,6 +11,7 @@
       - python3-cryptography
       - quota
       - "{{ vars_user_quota_linux_package }}"
+      - "{{ vars_perf_linux_package }}"
     state: present
 
 - name: install rustup in userspace for root
@@ -28,6 +29,14 @@
     path: /etc/sysctl.d/10-ptrace.conf
     regexp: '^kernel.yama.ptrace_scope = [\d]$'
     replace: 'kernel.yama.ptrace_scope = 0'
+  notify:
+    - reboot-machine
+
+- name: Allow users to run perf on their own processes
+  template:
+    src: 10-perf-event-paranoid.conf
+    dest: /etc/sysctl.d/10-perf-event-paranoid.conf
+    mode: 0644
   notify:
     - reboot-machine
 

--- a/ansible/roles/dev-desktop/tasks/main.yml
+++ b/ansible/roles/dev-desktop/tasks/main.yml
@@ -10,8 +10,8 @@
       - python3-jwt
       - python3-cryptography
       - quota
-      - "{{ vars_user_quota_linux_package }}"
-      - "{{ vars_perf_linux_package }}"
+      - "linux-modules-extra-{{ vars_linux_kernel_flavor }}"
+      - "linux-tools-{{ vars_linux_kernel_flavor }}"
     state: present
 
 - name: install rustup in userspace for root

--- a/ansible/roles/dev-desktop/templates/10-perf-event-paranoid.conf
+++ b/ansible/roles/dev-desktop/templates/10-perf-event-paranoid.conf
@@ -1,0 +1,16 @@
+# From the Linux kernel documentation:
+# https://www.kernel.org/doc/Documentation/sysctl/kernel.txt
+#
+# Controls use of the performance events system by unprivileged
+# users (without CAP_SYS_ADMIN). The default value is 2.
+#
+# -1:  Allow use of (almost) all events by all users
+#      Ignore mlock limit after perf_event_mlock_kb without CAP_IPC_LOCK
+# >=0: Disallow ftrace function tracepoint by users without CAP_SYS_ADMIN
+#      Disallow raw tracepoint access by users without CAP_SYS_ADMIN
+# >=1: Disallow CPU event access by users without CAP_SYS_ADMIN
+# >=2: Disallow kernel profiling by users without CAP_SYS_ADMIN
+#
+# Ubuntu has two more settings, which have been reverse-engineered here:
+# https://askubuntu.com/questions/1400874/what-does-perf-paranoia-level-four-do
+kernel.perf_event_paranoid = 2


### PR DESCRIPTION
The package for the `perf` utility has been added to the configuration for the dev desktops. The kernel setting that enables perf has been set to 2, which should provide a good mix of functionality and safety.