### PR TITLE
Create production instances for dev desktops

### DIFF
--- a/terraform/dev-desktops/_terraform.tf
+++ b/terraform/dev-desktops/_terraform.tf
@@ -38,3 +38,10 @@ provider "aws" {
   profile = "default"
   region  = "eu-central-1"
 }
+
+provider "aws" {
+  alias   = "us-east-1"
+  profile = "default"
+  region  = "us-east-1"
+}
+

--- a/terraform/dev-desktops/regions.tf
+++ b/terraform/dev-desktops/regions.tf
@@ -9,5 +9,23 @@ module "aws_eu_central_1" {
       instance_type = "t3a.micro"
       storage       = 25
     }
+    "dev-desktop-eu-1" = {
+      instance_type = "c7g.8xlarge"
+      storage       = 1000
+    }
+  }
+}
+
+module "aws_us_east_1" {
+  source = "./aws-region"
+  providers = {
+    aws = aws.us-east-1
+  }
+
+  instances = {
+    "dev-desktop-us-1" = {
+      instance_type = "c7g.8xlarge"
+      storage       = 1000
+    }
   }
 }


### PR DESCRIPTION
Two production instances for the dev desktops have been added to Terraform. They use an instance type that supports performance counters, and are deployed to the US and EU respectively.