### PR TITLE
Run team sync every hour

### DIFF
--- a/terraform/team-repo/sync-team.tf
+++ b/terraform/team-repo/sync-team.tf
@@ -77,7 +77,7 @@ resource "aws_codebuild_project" "sync_team" {
 resource "aws_cloudwatch_event_rule" "start_daily" {
   name                = "cloudbuild--sync-team"
   description         = "Run the sync-team CodeBuild every day."
-  schedule_expression = "cron(0 0 * * ? *)"
+  schedule_expression = "cron(0 * * * ? *)"
 }
 
 resource "aws_cloudwatch_event_target" "start_daily" {


### PR DESCRIPTION
We're syncing quite a bit of configuration. Since manual configuration is still possible, one failure mode might be for someone to accidentally configure something manually only to have it reversed by the sync tool. Having the tool sync every hour will hopefully make such situations more apparent. 