### PR TITLE
Fix Terraform configuration for dev desktops

### DIFF
--- a/terraform/dev-desktops/.terraform.lock.hcl
+++ b/terraform/dev-desktops/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "~> 3.59"
   hashes = [
     "h1:x0gluX9ZKEmz+JJW3Ut5GgWDFOq/lhs2vkqJ+xt57zs=",
+    "h1:xXeHg5KDyH3rn2mrFh+iuvO2d9CEx8ryvOWRUMC3aWg=",
     "zh:0e75fb14ec42d69bc46461dd54016bb2487d38da324222cec20863918b8954c4",
     "zh:30831a1fe29f005d8b809250b43d09522288db45d474c9d238b26f40bdca2388",
     "zh:36163d625ab2999c9cd31ef2475d978f9f033a8dfa0d585f1665f2d6492fac4b",
@@ -24,6 +25,7 @@ provider "registry.terraform.io/hashicorp/aws" {
 provider "registry.terraform.io/hashicorp/dns" {
   version = "3.2.3"
   hashes = [
+    "h1:ALe1bPHF550GAEdEDgujL1Ea0UQ7O5KEL/jQWlCfemY=",
     "h1:ODcR+vWOhCAJ2iCChZMVdRglNCx07VNr67OPLRPZyDY=",
     "zh:03a304f4b76ac6c8bebffddcdf555bf77578a7f638948a681589def32e140cb8",
     "zh:08c7d2498b747054e9c9df7838bfa4e4a6b5d63e2d29f0457247e384f792d56c",

--- a/terraform/dev-desktops/aws-region/_terraform.tf
+++ b/terraform/dev-desktops/aws-region/_terraform.tf
@@ -10,6 +10,7 @@ terraform {
 variable "instances" {
   type = map(object({
     instance_type = string
+    instance_arch = string
     storage       = number
   }))
 }

--- a/terraform/dev-desktops/aws-region/instances.tf
+++ b/terraform/dev-desktops/aws-region/instances.tf
@@ -3,7 +3,7 @@
 resource "aws_instance" "instance" {
   for_each = var.instances
 
-  ami                     = data.aws_ami.instance.id
+  ami                     = data.aws_ami.instance[each.value.instance_arch].id
   instance_type           = each.value.instance_type
   key_name                = aws_key_pair.instance.key_name
   ebs_optimized           = true
@@ -32,12 +32,14 @@ resource "aws_instance" "instance" {
 }
 
 data "aws_ami" "instance" {
+  for_each = toset(values(var.instances)[*].instance_arch)
+
   most_recent = true
   owners      = ["099720109477"] # Canonical
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-*"]
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-${each.key}-server-*"]
   }
 
   filter {

--- a/terraform/dev-desktops/aws-region/instances.tf
+++ b/terraform/dev-desktops/aws-region/instances.tf
@@ -37,7 +37,7 @@ data "aws_ami" "instance" {
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-*"]
   }
 
   filter {

--- a/terraform/dev-desktops/regions.tf
+++ b/terraform/dev-desktops/regions.tf
@@ -10,7 +10,7 @@ module "aws_eu_central_1" {
       storage       = 25
     }
     "dev-desktop-eu-1" = {
-      instance_type = "c7g.8xlarge"
+      instance_type = "c6g.8xlarge"
       storage       = 1000
     }
   }

--- a/terraform/dev-desktops/regions.tf
+++ b/terraform/dev-desktops/regions.tf
@@ -7,10 +7,12 @@ module "aws_eu_central_1" {
   instances = {
     "dev-desktop-staging" = {
       instance_type = "t3a.micro"
+      instance_arch = "amd64"
       storage       = 25
     }
     "dev-desktop-eu-1" = {
       instance_type = "c6g.8xlarge"
+      instance_arch = "arm64"
       storage       = 1000
     }
   }
@@ -25,6 +27,7 @@ module "aws_us_east_1" {
   instances = {
     "dev-desktop-us-1" = {
       instance_type = "c7g.8xlarge"
+      instance_arch = "arm64"
       storage       = 1000
     }
   }


### PR DESCRIPTION
The instance type `c7g` is not yet available in Frankfurt, and the AMI didn't match the machines architecture.