### PR TITLE
Upgrade some actions to Node.js 16

### DIFF
--- a/github-actions/cancel-outdated-builds/README.md
+++ b/github-actions/cancel-outdated-builds/README.md
@@ -22,12 +22,12 @@ seconds to wait between checks:
 - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
   with:
     github_token: "${{ secrets.github_token }}"
-    check_every_seconds: 120  # 2 minutes
+    check_every_seconds: 120 # 2 minutes
 ```
 
 ## Development
 
-The action is written in NodeJS 12, and you can install the dependencies with:
+The action is written in NodeJS 16, and you can install the dependencies with:
 
 ```
 npm install

--- a/github-actions/cancel-outdated-builds/action.yml
+++ b/github-actions/cancel-outdated-builds/action.yml
@@ -11,5 +11,5 @@ inputs:
     default: "60"
 
 runs:
-  using: node12
+  using: node16
   main: dist/index.js

--- a/github-actions/simple-ci/README.md
+++ b/github-actions/simple-ci/README.md
@@ -43,7 +43,7 @@ jobs:
 
 ## Development
 
-The action is written in NodeJS 12, and you can install the dependencies with:
+The action is written in NodeJS 16, and you can install the dependencies with:
 
 ```sh
 npm install

--- a/github-actions/simple-ci/action.yml
+++ b/github-actions/simple-ci/action.yml
@@ -7,5 +7,5 @@ inputs:
     required: false
 
 runs:
-  using: node12
+  using: node16
   main: dist/index.js

--- a/github-actions/upload-docker-image/README.md
+++ b/github-actions/upload-docker-image/README.md
@@ -39,7 +39,7 @@ on that service.
 
 ## Development
 
-The action is written in NodeJS 12, and you can install the dependencies with:
+The action is written in NodeJS 16, and you can install the dependencies with:
 
 ```
 npm install

--- a/github-actions/upload-docker-image/action.yml
+++ b/github-actions/upload-docker-image/action.yml
@@ -28,5 +28,5 @@ inputs:
     required: true
 
 runs:
-  using: node12
+  using: node16
   main: dist/index.js


### PR DESCRIPTION
GHA now shows warnings if we use Node.js 12 on actions: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
That adds a bunch of warnings on the libc repo: https://github.com/rust-lang/libc/actions/runs/3236239538
This updates actions that use Node.js to 16 to get rid of them.
Signed-off-by: Yuki Okushi <jtitor@2k36.org>