### PR TITLE
Enable response header policy for staging.crates.io

### DIFF
--- a/terraform/crates-io/.terraform.lock.hcl
+++ b/terraform/crates-io/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.20.1"
   constraints = "~> 4.20"
   hashes = [
+    "h1:1JbjdrwUCLTNVVhlE+acEPnJFJ/FqBTHy5Ooll6nwjI=",
     "h1:HHfwMYY0FDtMzaGgITqsPIBlUWnQNZ5+bTF1dyscsnw=",
     "zh:21d064d8fac08376c633e002e2f36e83eb7958535e251831feaf38f51c49dafd",
     "zh:3a37912ff43d89ce8d559ec86265d7506801bccb380c7cfb896e8ff24e3fe79d",

--- a/terraform/crates-io/envs.tf
+++ b/terraform/crates-io/envs.tf
@@ -42,4 +42,6 @@ module "staging" {
   webapp_origin_domain = "staging-crates-io.herokuapp.com"
 
   iam_prefix = "staging-crates-io"
+
+  strict_security_headers = true
 }

--- a/terraform/crates-io/impl/_terraform.tf
+++ b/terraform/crates-io/impl/_terraform.tf
@@ -59,3 +59,8 @@ variable "dns_apex" {
   type    = bool
   default = false
 }
+
+variable "strict_security_headers" {
+  type    = bool
+  default = false
+}

--- a/terraform/crates-io/impl/cloudfront-webapp.tf
+++ b/terraform/crates-io/impl/cloudfront-webapp.tf
@@ -128,6 +128,8 @@ resource "aws_route53_record" "webapp_apex" {
   }
 }
 
+# Set strict-transport-security headers for crates.io and its subdomains
+# See https://github.com/rust-lang/crates.io/issues/5332 for details
 resource "aws_cloudfront_response_headers_policy" "webapp" {
   count = var.strict_security_headers ? 1 : 0
 


### PR DESCRIPTION
A response header policy has been added to the CloudFront distribution for crates.io to enable the `includeSubdomains` directive in the strict transport security header.

The policy is hidden behind a variable right now to allow us to test it on staging first. When we decide to roll it out to production, we can remove the variable again.