### PR TITLE
Give infra team members read only access to route53

### DIFF
--- a/terraform/team-members-access/infra-team.tf
+++ b/terraform/team-members-access/infra-team.tf
@@ -19,3 +19,9 @@ resource "aws_iam_group_policy_attachment" "infra_team_iam_access" {
   group      = aws_iam_group.infra_team.name
   policy_arn = "arn:aws:iam::aws:policy/IAMReadOnlyAccess"
 }
+
+// Infra team members are allowed to have read access to Route53
+resource "aws_iam_group_policy_attachment" "infra_team_route53_access" {
+  group      = aws_iam_group.infra_team.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonRoute53ReadOnlyAccess"
+}


### PR DESCRIPTION
The policy is as follows:

```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "route53:Get*",
                "route53:List*",
                "route53:TestDNSAnswer"
            ],
            "Resource": [
                "*"
            ]
        }
    ]
}
```