### PR TITLE
Enable response header policy for crates.io

### DIFF
--- a/terraform/crates-io/envs.tf
+++ b/terraform/crates-io/envs.tf
@@ -21,6 +21,8 @@ module "prod" {
   webapp_origin_domain = "crates-io.herokuapp.com"
 
   iam_prefix = "crates-io"
+
+  strict_security_headers = true
 }
 
 module "staging" {


### PR DESCRIPTION
The new HSTS header that sets the `includeSubdomains` directive has been rolled out to production, after having been tested on staging [^1].

[^1]: https://github.com/rust-lang/simpleinfra/pull/136