### PR TITLE
Add guard for x86 packages

### DIFF
--- a/ansible/roles/dev-desktop/tasks/main.yml
+++ b/ansible/roles/dev-desktop/tasks/main.yml
@@ -183,8 +183,14 @@
       - llvm
       - valgrind
       - ninja-build
+    state: present
+
+- name: Install tools for x86
+  apt:
+    name:
       - gcc-multilib # for 32 bit cross compiles of libstd and tests
     state: present
+  when: ansible_architecture == "x86_64"
 
 - name: Check if Node is installed
   command: node --version


### PR DESCRIPTION
Some packages that are installed on the dev desktops are only available in certain CPU architectures, specifically on x86. These have been moved to their own task that only gets executed on a matching CPU architecture.