### PR TITLE
Manage team members on Fastly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /terraform/shared/modules/lambda/packages
 /terraform/rds-databases/.forward-ports-cache-*.json
 .terraform
+*.tfvars
 node_modules
 __pycache__
 *.py[co]

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 /terraform/shared/modules/lambda/packages
 /terraform/rds-databases/.forward-ports-cache-*.json
 .terraform
-*.tfvars
 node_modules
 __pycache__
 *.py[co]

--- a/terraform/team-members-fastly/.terraform.lock.hcl
+++ b/terraform/team-members-fastly/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/fastly/fastly" {
+  version     = "2.4.0"
+  constraints = "2.4.0"
+  hashes = [
+    "h1:1Qn/eL2jnrWE6iUyvpLaBqgJLM456RO/ffFWoyZEBqE=",
+    "zh:1ef79460d5805ca2074e859694331951ab689371ed359dd2730bc6bd76bd997a",
+    "zh:25e2d2c64527ea9a4b4f8b616377dab459f5152b527f8c6b823e222fd763d400",
+    "zh:2ed0ece471bf655aac951235a877a62ab92022e84b33c57c213e275851880fec",
+    "zh:42a94f0b0df30b982222cbc3d38ae18be8781abe6610f524cbc174627ee8991a",
+    "zh:485762cec3c5d125163711056d70284c0a5104cf0692b2db836bbee56f9749a0",
+    "zh:6114c159b1c2367d954c433d3e4859c6627e05fd9988589776faf5c9f8542680",
+    "zh:62b401567678ce2e2f2467b0419ac69a6a1ddf2fe923d88a3f437c2002891668",
+    "zh:7b63075521f3122b3e17d112d85eabfd16a80af6e41c62f4e09371a2b7c7e40f",
+    "zh:848ab7c895e30ee980d00fa2195cd31b248aea3883be36619491f6abceac59ba",
+    "zh:acfb52ba765ceaa452b0de75c2e9aa660d55e2a78b226fb19f45e664a54a6f51",
+    "zh:bd39f27f7c6b103a7d65d8b8738034bd3e84a9e9edaf09478845724b3b0c547b",
+    "zh:cd65dd759f5b335fd79ac549878ed983aca1d8fc6b4b4ca12c32f47407505203",
+    "zh:eaed4020a7911b917050124b18f7a0612b80a012b357cbc04eab5aa8809982e3",
+    "zh:f1baa0c014a7f9056a94b080102b390e377f3bb0bff3aeff9e8b89bcb42b304e",
+  ]
+}

--- a/terraform/team-members-fastly/README.md
+++ b/terraform/team-members-fastly/README.md
@@ -1,0 +1,42 @@
+# Team Members on Fastly
+
+This Terraform configuration manages user accounts on Fastly. When a user is
+added to [`users.tf`](users.tf), they get invited to join our Fastly account.
+
+## Roles
+
+Fastly uses _roles_ to manage who can do what on the platform.
+
+Members of the infra-admins team are assigned the `superuser` role. Members of
+other teams get the `users` role and specific permissions for the staging
+environment of the service they maintain. For example, the crates team gets
+permission to test configuration changes on their staging environment.
+
+Learn more about user roles here:
+<https://docs.fastly.com/en/guides/configuring-user-roles-and-permissions>
+
+## Usage
+
+Applying the Terraform configuration requires a [Personal API token] with the
+`global` scope. Go to <https://manage.fastly.com/account/personal/tokens> and
+generate a token with the following settings:
+
+- Choose a descriptive **Name**, e.g. `terraform`
+- Set **Service Access** to `All Services`
+- Select `global` as the **Scope** and make sure to disable read-only access
+- Leave the **Expiration** date at 3 months in the future
+
+Create a file called `_terraform.auto.tfvars` in this directory and paste the
+generated token into it:
+
+```terraform
+fastly_api_key = "<your token>"
+```
+
+Then run any Terraform command as you normally would:
+
+```shell
+terraform plan
+```
+
+[personal api token]: https://manage.fastly.com/account/personal/tokens

--- a/terraform/team-members-fastly/README.md
+++ b/terraform/team-members-fastly/README.md
@@ -26,16 +26,11 @@ generate a token with the following settings:
 - Select `global` as the **Scope** and make sure to disable read-only access
 - Leave the **Expiration** date at 3 months in the future
 
-Create a file called `_terraform.auto.tfvars` in this directory and paste the
-generated token into it:
-
-```terraform
-fastly_api_key = "<your token>"
-```
-
-Then run any Terraform command as you normally would:
+Then export the token as an environment variable and run any Terraform command
+like you normally would:
 
 ```shell
+export FASTLY_API_KEY="afastlyapikey"
 terraform plan
 ```
 

--- a/terraform/team-members-fastly/_terraform.tf
+++ b/terraform/team-members-fastly/_terraform.tf
@@ -19,11 +19,4 @@ terraform {
   }
 }
 
-provider "fastly" {
-  api_key = var.fastly_api_key
-}
-
-variable "fastly_api_key" {
-  description = "Personal API token for Fastly"
-  type        = string
-}
+provider "fastly" {}

--- a/terraform/team-members-fastly/_terraform.tf
+++ b/terraform/team-members-fastly/_terraform.tf
@@ -1,0 +1,29 @@
+// Configuration for Terraform itself.
+
+terraform {
+  required_version = "~> 1"
+
+  required_providers {
+    fastly = {
+      source  = "fastly/fastly"
+      version = "2.4.0"
+    }
+  }
+
+  backend "s3" {
+    bucket         = "rust-terraform"
+    key            = "simpleinfra/team-members-fastly.tfstate"
+    region         = "us-west-1"
+    dynamodb_table = "terraform-state-lock"
+    encrypt        = true
+  }
+}
+
+provider "fastly" {
+  api_key = var.fastly_api_key
+}
+
+variable "fastly_api_key" {
+  description = "Personal API token for Fastly"
+  type        = string
+}

--- a/terraform/team-members-fastly/users.tf
+++ b/terraform/team-members-fastly/users.tf
@@ -1,0 +1,44 @@
+locals {
+  users = {
+    "jdn" = {
+      login = "jandavidnose@rustfoundation.org"
+      name  = "Jan David Nose"
+      role  = "superuser"
+
+    }
+    "joel" = {
+      login = "joelmarcey@rustfoundation.org"
+      name  = "Joel Marcey"
+      role  = "superuser"
+
+    }
+    "mark" = {
+      login = "mark.simulacrum@gmail.com"
+      name  = "Mark Rousskov"
+      role  = "superuser"
+    }
+    "pietro" = {
+      login = "pietro@pietroalbini.org"
+      name  = "Pietro Albini"
+      role  = "superuser"
+    }
+    "rustadmin" = {
+      login = "admin@rust-lang.org"
+      name  = "Rust Admin"
+      role  = "superuser"
+    }
+    "rustfoundation" = {
+      login = "infra@rustfoundation.org"
+      name  = "Rust Foundation Infrastructure"
+      role  = "superuser"
+    }
+  }
+}
+
+resource "fastly_user" "users" {
+  for_each = local.users
+
+  login = each.value.login
+  name  = each.value.name
+  role  = each.value.role
+}


### PR DESCRIPTION
A new Terraform configuration has been added to manage team members on Fastly. Members of the infra-team have been invited to the account, and we'll add more teams as we start using the service.