### PR TITLE
Reduce TTL for docs.rs and static.docs.rs

### DIFF
--- a/terraform/docs-rs/cloudfront.tf
+++ b/terraform/docs-rs/cloudfront.tf
@@ -41,7 +41,7 @@ resource "aws_cloudfront_distribution" "webapp" {
     compress               = true
     viewer_protocol_policy = "redirect-to-https"
 
-    default_ttl = 86400 // 1 day
+    default_ttl = 900 // 15 minutes
     min_ttl     = 0
     max_ttl     = 31536000 // 1 year
 

--- a/terraform/docs-rs/static-cloudfront.tf
+++ b/terraform/docs-rs/static-cloudfront.tf
@@ -17,7 +17,7 @@ module "static_certificate" {
 
 resource "aws_cloudfront_cache_policy" "static_docs_rs" {
   name        = "static-docs-rs"
-  default_ttl = 86400
+  default_ttl = 900 // 15 minutes
   min_ttl     = 0
   max_ttl     = 86400
   parameters_in_cache_key_and_forwarded_to_origin {


### PR DESCRIPTION
Issues with cache invalidations were reported on GitHub [^1], and the team requested to revert a recent change to increase the TTL from 15 minutes to 1 day [^2].

[^1]: https://github.com/rust-lang/docs.rs/issues/1913
[^2]: https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/docs.2Ers.20.2F.20more.20CloudFront.20caching/near/310753638