### PR TITLE
Grant docs.rs access to get and list invalidations

### DIFF
--- a/terraform/docs-rs/web-server.tf
+++ b/terraform/docs-rs/web-server.tf
@@ -72,7 +72,11 @@ resource "aws_iam_role_policy" "web" {
       },
       {
         Effect = "Allow"
-        Action = "cloudfront:CreateInvalidation"
+        Action = [
+          "cloudfront:CreateInvalidation",
+          "cloudfront:GetInvalidation",
+          "cloudfront:ListInvalidations",
+        ]
         Resource = [
           aws_cloudfront_distribution.webapp.arn,
           aws_cloudfront_distribution.static.arn,


### PR DESCRIPTION
As requested on Zulip [^1], the additional permissions help the team debug failing cache invalidations.

[^1]: https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/docs.2Ers.20.2F.20more.20CloudFront.20caching/near/310830223