### PR TITLE
Create more AWS accounts in new root organization

### DIFF
--- a/terragrunt/aws/root/aws-organization/.terraform.lock.hcl
+++ b/terragrunt/aws/root/aws-organization/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.40.0"
   constraints = "~> 4.32"
   hashes = [
+    "h1:YlsYrKClET1k7WDshRwEnB8slVJBuMHQum8K5owL+p4=",
     "h1:wZ0mPxigFhz6C+0YUzI5vecGwya1PqlCGTSr6giqjvg=",
     "zh:04ca7287b7f5a2a310b60308cc08df11e97714d32d1a10c34a94454d330af66e",
     "zh:13c28ba9b324c526580783a3807007a296ce58c607c7bdc94ae2bb72b35b6495",

--- a/terragrunt/modules/aws-organization/accounts.tf
+++ b/terragrunt/modules/aws-organization/accounts.tf
@@ -6,3 +6,13 @@ resource "aws_organizations_account" "admin" {
   name  = "rust-root"
   email = "admin+root@rust-lang.org"
 }
+
+resource "aws_organizations_account" "docs_rs_staging" {
+  name  = "docs-rs-staging"
+  email = "admin+docs-rs-staging@rust-lang.org"
+}
+
+resource "aws_organizations_account" "dev_desktops_prod" {
+  name  = "dev-desktops-prod"
+  email = "admin+dev-desktops-prod@rust-lang.org"
+}


### PR DESCRIPTION
Two more AWS accounts are created under the new root organization for the Rust project. One is for the staging environment for docs.rs, while the other is for the dev desktops.