### PR TITLE
Add the rest of the AWS org users

### DIFF
--- a/terragrunt/aws/root/aws-organization/.terraform.lock.hcl
+++ b/terragrunt/aws/root/aws-organization/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "~> 4.32"
   hashes = [
     "h1:YlsYrKClET1k7WDshRwEnB8slVJBuMHQum8K5owL+p4=",
+    "h1:ZNYcP0N4WfRiuCmkXJkPrTS/4BG7PfkbXBUhbA77WTg=",
     "h1:wZ0mPxigFhz6C+0YUzI5vecGwya1PqlCGTSr6giqjvg=",
     "zh:04ca7287b7f5a2a310b60308cc08df11e97714d32d1a10c34a94454d330af66e",
     "zh:13c28ba9b324c526580783a3807007a296ce58c607c7bdc94ae2bb72b35b6495",

--- a/terragrunt/aws/root/terragrunt.hcl
+++ b/terragrunt/aws/root/terragrunt.hcl
@@ -11,3 +11,32 @@ remote_state {
     key            = "${path_relative_to_include()}.tfstate"
   }
 }
+
+inputs = {
+  users = {
+    "jdno" = {
+      given_name  = "Jan David",
+      family_name = "Nose"
+      email       = "jandavidnose@rustfoundation.org"
+      groups      = ["infra", "infra-admins"]
+    }
+    "pietroalbini" = {
+      given_name  = "Pietro",
+      family_name = "Albini"
+      email       = "pietro@pietroalbini.org"
+      groups      = ["infra", "infra-admins"]
+    }
+    "simulacrum" = {
+      given_name  = "Mark",
+      family_name = "Rousskov"
+      email       = "mark.simulacrum@gmail.com"
+      groups      = ["infra", "infra-admins"]
+    }
+    "rylev" = {
+      given_name  = "Ryan",
+      family_name = "Levick"
+      email       = "me@ryanlevick.com"
+      groups      = ["infra"]
+    }
+  }
+}

--- a/terragrunt/modules/aws-organization/_terraform.tf
+++ b/terragrunt/modules/aws-organization/_terraform.tf
@@ -23,11 +23,4 @@ variable "users" {
     email       = string,
     groups      = list(string)
   }))
-
-  validation {
-    condition = alltrue([
-      for name, user in var.users : alltrue([for group in user.groups : contains(["infra", "infra-admins"], group)])
-    ])
-    error_message = "The only valid group names are \"infra\" or \"infra-admins\""
-  }
 }

--- a/terragrunt/modules/aws-organization/_terraform.tf
+++ b/terragrunt/modules/aws-organization/_terraform.tf
@@ -14,3 +14,20 @@ terraform {
 provider "aws" {
   region = "us-east-1"
 }
+
+variable "users" {
+  description = "The users inside the aws organization"
+  type = map(object({
+    given_name  = string,
+    family_name = string,
+    email       = string,
+    groups      = list(string)
+  }))
+
+  validation {
+    condition = alltrue([
+      for name, user in var.users : alltrue([for group in user.groups : contains(["infra", "infra-admins"], group)])
+    ])
+    error_message = "The only valid group names are \"infra\" or \"infra-admins\""
+  }
+}

--- a/terragrunt/modules/aws-organization/users.tf
+++ b/terragrunt/modules/aws-organization/users.tf
@@ -4,12 +4,10 @@ locals {
     infra-admins : aws_identitystore_group.infra-admins
   }
 
-  # Expand local.users into collection by group association
-  group_memberships = distinct(flatten([for user_name, user in var.users : [
-    for group in user.groups : {
-      name : user_name, group : local.groups[group]
-    }
-  ]]))
+  # Expand var.users into collection of group memberships associations
+  group_memberships = flatten([for user_name, user in var.users : [
+    for group in user.groups : { user : user_name, group : group }
+  ]])
 }
 
 resource "aws_identitystore_user" "users" {
@@ -31,9 +29,9 @@ resource "aws_identitystore_user" "users" {
 }
 
 resource "aws_identitystore_group_membership" "group_membership" {
-  for_each          = { for membership in local.group_memberships : "${membership.name}.${membership.group.id}" => membership }
+  for_each          = { for membership in local.group_memberships : "${membership.user}.${local.groups[membership.group].id}" => membership }
   identity_store_id = local.identity_store_id
 
-  member_id = aws_identitystore_user.users[each.value.name].user_id
-  group_id  = each.value.group.group_id
+  member_id = aws_identitystore_user.users[each.value.user].user_id
+  group_id  = local.groups[each.value.group].group_id
 }

--- a/terragrunt/modules/aws-organization/users.tf
+++ b/terragrunt/modules/aws-organization/users.tf
@@ -29,7 +29,7 @@ resource "aws_identitystore_user" "users" {
 }
 
 resource "aws_identitystore_group_membership" "group_membership" {
-  for_each          = { for membership in local.group_memberships : "${membership.user}.${local.groups[membership.group].id}" => membership }
+  for_each          = { for membership in local.group_memberships : "${local.groups[membership.group].display_name}[${membership.user}]" => membership }
   identity_store_id = local.identity_store_id
 
   member_id = aws_identitystore_user.users[each.value.user].user_id

--- a/terragrunt/modules/aws-organization/users.tf
+++ b/terragrunt/modules/aws-organization/users.tf
@@ -1,23 +1,17 @@
 locals {
-  users = {
-    "jdno" = {
-      given_name  = "Jan David",
-      family_name = "Nose"
-      email       = "jandavidnose@rustfoundation.org"
-      groups      = [aws_identitystore_group.infra, aws_identitystore_group.infra-admins]
-    }
-  }
+  infra_group        = aws_identitystore_group.infra
+  infra_admins_group = aws_identitystore_group.infra-admins
 
   # Expand local.users into collection by group association
-  group_memberships = distinct(flatten([for user_name, user in local.users : [
+  group_memberships = distinct(flatten([for user_name, user in var.users : [
     for group in user.groups : {
-      name : user_name, group : group
+      name : user_name, group : group == "infra-admins" ? local.infra_admins_group : local.infra_group
     }
   ]]))
 }
 
 resource "aws_identitystore_user" "users" {
-  for_each          = local.users
+  for_each          = var.users
   identity_store_id = local.identity_store_id
 
   display_name = "${each.value.given_name} ${each.value.family_name}"

--- a/terragrunt/modules/aws-organization/users.tf
+++ b/terragrunt/modules/aws-organization/users.tf
@@ -1,11 +1,13 @@
 locals {
-  infra_group        = aws_identitystore_group.infra
-  infra_admins_group = aws_identitystore_group.infra-admins
+  groups = {
+    infra : aws_identitystore_group.infra
+    infra-admins : aws_identitystore_group.infra-admins
+  }
 
   # Expand local.users into collection by group association
   group_memberships = distinct(flatten([for user_name, user in var.users : [
     for group in user.groups : {
-      name : user_name, group : group == "infra-admins" ? local.infra_admins_group : local.infra_group
+      name : user_name, group : local.groups[group]
     }
   ]]))
 }


### PR DESCRIPTION
This adds the remaining users to the aws organization. It also refactors so that the users are not a local but rather are passed to the module. 

Note: I've already added these users to the terraform state. 