### PR TITLE
adapt docs.rs CPU monitoring so it triggers earlier

### DIFF
--- a/ansible/playbooks/monitoring.yml
+++ b/ansible/playbooks/monitoring.yml
@@ -202,13 +202,13 @@
                 description: "There are more than 1000 deprioritized crates in the docs.rs queue, and the situation didn't resolve itself in the 24 hours. The build queue is available at https://docs.rs/releases/queue"
 
             - alert: HighCpuUsage
-              expr: avg(rate(node_cpu_seconds_total{job="node",instance="docsrs.infra.rust-lang.org:9100",mode="idle"}[1m])) < 0.1
+              expr: avg(rate(node_cpu_seconds_total{job="node",instance="docsrs.infra.rust-lang.org:9100",mode="idle"}[10m])) < 0.15
               for: 30m
               labels:
                 dispatch: docsrs
               annotations:
                 summary: "High CPU usage on the docs.rs server"
-                description: "user-mode CPU usage is > 90% for longer than 30 minutes, something is wrong. Please check `htop` for which threads consume the CPU. Restarting the server helps then."
+                description: "user-mode CPU usage is > 85% for longer than 30 minutes, something is wrong. Please check `htop` for which threads consume the CPU. Restarting the server helps then."
 
             - alert: FailingBuilds
               expr: increase(docsrs_failed_builds{job="docsrs"}[3h]) / increase(docsrs_total_builds{job="docsrs"}[3h]) > 0.75

--- a/ansible/playbooks/monitoring.yml
+++ b/ansible/playbooks/monitoring.yml
@@ -208,7 +208,7 @@
                 dispatch: docsrs
               annotations:
                 summary: "High CPU usage on the docs.rs server"
-                description: "user-mode CPU usage is > 85% for longer than 30 minutes, something is wrong. Please check `htop` for which threads consume the CPU. Restarting the server helps then."
+                description: "the 10-minute rolling average idle time over a 30-minute period was < 15%, something is wrong. Please check `htop` for which threads consume the CPU. Restarting the server can help then."
 
             - alert: FailingBuilds
               expr: increase(docsrs_failed_builds{job="docsrs"}[3h]) / increase(docsrs_total_builds{job="docsrs"}[3h]) > 0.75


### PR DESCRIPTION
last night we had the CPU-usage problem again: 
![grafik](https://user-images.githubusercontent.com/540890/205552420-e801b07a-e634-404a-bf94-1585bbade5a9.png)

two web-server threads were each on 100% CPU, but this alert didn't trigger. 

Idle-time before this change: 
![grafik](https://user-images.githubusercontent.com/540890/205552476-3c1d3780-15ba-4ba9-a7b4-3c5637e6811f.png)

idle-time flattened out after this change: 
![grafik](https://user-images.githubusercontent.com/540890/205552494-7fa6c64e-adca-49dc-bd96-6d346dbc500a.png)

