### PR TITLE
Increase default TTL for crates index

### DIFF
--- a/terraform/crates-io/impl/cloudfront-index.tf
+++ b/terraform/crates-io/impl/cloudfront-index.tf
@@ -26,9 +26,9 @@ resource "aws_cloudfront_distribution" "index" {
     compress               = true
     viewer_protocol_policy = "redirect-to-https"
 
-    default_ttl = 300 // 5 minutes
+    default_ttl = 3600 // 1 hour
     min_ttl     = 1
-    max_ttl     = 300 // 5 minutes
+    max_ttl     = 3600 // 1 hour
 
     forwarded_values {
       headers = [


### PR DESCRIPTION
The default TTL for the crates index has been increased to one hour, as per the request on Zulip [^1].

[^1]: https://rust-lang.zulipchat.com/#narrow/stream/318791-t-crates-io/topic/cloudfront.20invalidation/near/314564225