### PR TITLE
Fix terragrunt-locals for the legacy account

### DIFF
--- a/terragrunt/accounts/legacy/account.json
+++ b/terragrunt/accounts/legacy/account.json
@@ -1,6 +1,6 @@
 {
     "aws": {
-        "profile": "default",
+        "profile": null,
         "region": "us-west-1"
     }
 }

--- a/terragrunt/terragrunt-locals.py
+++ b/terragrunt/terragrunt-locals.py
@@ -35,8 +35,7 @@ def find_aws_account_id(account_json):
             "aws",
             "sts",
             "get-caller-identity",
-            "--profile",
-            account_json["aws"]["profile"],
+            *profile_args(account_json),
             "--output",
             "text",
             "--query",
@@ -57,12 +56,26 @@ def calculate_remote_state_key(account_json_file, terragrunt_dir):
 
 
 def calculate_providers_content(account_json):
-    return f"""
+    if account_json["aws"]["profile"] is not None:
+        return f"""
 provider "aws" {{
   profile = "{account_json["aws"]["profile"]}"
   region = "{account_json["aws"]["region"]}"
 }}
 """
+    else:
+        return f"""
+provider "aws" {{
+  region = "{account_json["aws"]["region"]}"
+}}
+"""
+
+
+def profile_args(account_json):
+    if account_json["aws"]["profile"] is not None:
+        return ["--profile", account_json["aws"]["profile"]]
+    else:
+        return []
 
 
 def error(message):

--- a/terragrunt/terragrunt.hcl
+++ b/terragrunt/terragrunt.hcl
@@ -12,16 +12,16 @@ remote_state {
     if_exists = "overwrite_terragrunt"
   }
   config = {
-    profile        = "${local.cmd.remote_state_profile}"
-    bucket         = "${local.cmd.remote_state_bucket}"
-    dynamodb_table = "${local.cmd.remote_state_dynamodb_table}"
-    region         = "${local.cmd.remote_state_region}"
-    key            = "${local.cmd.remote_state_key}"
+    profile        = local.cmd.remote_state_profile
+    bucket         = local.cmd.remote_state_bucket
+    dynamodb_table = local.cmd.remote_state_dynamodb_table
+    region         = local.cmd.remote_state_region
+    key            = local.cmd.remote_state_key
   }
 }
 
 generate "providers" {
-  path = "terragrunt-generated-provider.tf"
+  path      = "terragrunt-generated-provider.tf"
   if_exists = "overwrite_terragrunt"
-  contents = local.cmd.providers_content
+  contents  = local.cmd.providers_content
 }


### PR DESCRIPTION
Turns out the `default` profile doesn't load credentials from the environment. This PR updates the script to also support `null`, which will omit the profile.