### PR TITLE
Set up billing access for the Rust Foundation

### DIFF
--- a/terragrunt/accounts/root/aws-organization/terragrunt.hcl
+++ b/terragrunt/accounts/root/aws-organization/terragrunt.hcl
@@ -45,5 +45,11 @@ inputs = {
       email       = "jake.goulding@integer32.com"
       groups      = ["infra"]
     }
+    "abibroom" = {
+      given_name = "Abi"
+      family_name = "Broom"
+      email = "abibroom@rustfoundation.org"
+      groups = ["billing"]
+    }
   }
 }

--- a/terragrunt/modules/aws-organization/groups.tf
+++ b/terragrunt/modules/aws-organization/groups.tf
@@ -21,6 +21,13 @@ resource "aws_identitystore_group" "infra" {
   description  = "The infrastructure team"
 }
 
+resource "aws_identitystore_group" "billing" {
+  identity_store_id = local.identity_store_id
+
+  display_name = "billing"
+  description  = "People with access to the billing portal"
+}
+
 # The different permission sets a group may have assigned to it
 
 resource "aws_ssoadmin_permission_set" "administrator_access" {
@@ -32,6 +39,17 @@ resource "aws_ssoadmin_managed_policy_attachment" "administrator_access" {
   instance_arn       = local.instance_arn
   managed_policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
   permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn
+}
+
+resource "aws_ssoadmin_permission_set" "billing_access" {
+  instance_arn = local.instance_arn
+  name         = "BillingAccess"
+}
+
+resource "aws_ssoadmin_managed_policy_attachment" "billing_access" {
+  instance_arn       = local.instance_arn
+  managed_policy_arn = "arn:aws:iam::aws:policy/job-function/Billing"
+  permission_set_arn = aws_ssoadmin_permission_set.billing_access.arn
 }
 
 resource "aws_ssoadmin_permission_set" "view_only_access" {
@@ -55,6 +73,8 @@ locals {
       groups : [
         { group : aws_identitystore_group.infra-admins,
         permissions : [aws_ssoadmin_permission_set.view_only_access, aws_ssoadmin_permission_set.administrator_access] },
+        { group : aws_identitystore_group.billing,
+        permissions : [aws_ssoadmin_permission_set.billing_access] },
         { group : aws_identitystore_group.infra,
         permissions : [aws_ssoadmin_permission_set.view_only_access] }
       ]

--- a/terragrunt/modules/aws-organization/users.tf
+++ b/terragrunt/modules/aws-organization/users.tf
@@ -1,5 +1,6 @@
 locals {
   groups = {
+    billing : aws_identitystore_group.billing
     infra : aws_identitystore_group.infra
     infra-admins : aws_identitystore_group.infra-admins
   }


### PR DESCRIPTION
Some members of the Rust Foundation need access to the billing portal on the new account. This access has been granted using an AWS-managed policy.