### PR TITLE
Decommission the original dev-desktop

### DIFF
--- a/ansible/envs/prod/hosts
+++ b/ansible/envs/prod/hosts
@@ -16,7 +16,10 @@ ci-arm-2.infra.rust-lang.org
 play-1.infra.rust-lang.org
 
 [dev-desktop]
-dev-desktop.infra.rust-lang.org
+dev-desktop-eu-1.infra.rust-lang.org
+dev-desktop-eu-2.infra.rust-lang.org
+dev-desktop-us-1.infra.rust-lang.org
+dev-desktop-us-2.infra.rust-lang.org
 
 [crater-server]
 crater.infra.rust-lang.org

--- a/ansible/playbooks/monitoring.yml
+++ b/ansible/playbooks/monitoring.yml
@@ -51,7 +51,11 @@
               - docsrs.infra.rust-lang.org:9100
               - bastion.infra.rust-lang.org:9100
               - play-1.infra.rust-lang.org:9100
-              - dev-desktop.infra.rust-lang.org:9100
+              - dev-desktop-staging.infra.rust-lang.org
+              - dev-desktop-eu-1.infra.rust-lang.org:9100
+              - dev-desktop-eu-2.infra.rust-lang.org:9100
+              - dev-desktop-us-1.infra.rust-lang.org:9100
+              - dev-desktop-us-2.infra.rust-lang.org:9100
 
         # Metrics scraped from apps hosted in our ECS clusters
         - job_name: ecs-sd  # Will be overridden by each job


### PR DESCRIPTION
The original dev-desktop that was used to develop the system configuration has been deprecated. While we leave the machine itself around for now to give users time to backup their data, we are already removing it from Ansible and the monitoring. Instead, the four new machines are now officially "live".