### PR TITLE
Fix port for monitoring dev-desktop-staging

### DIFF
--- a/ansible/playbooks/monitoring.yml
+++ b/ansible/playbooks/monitoring.yml
@@ -51,7 +51,7 @@
               - docsrs.infra.rust-lang.org:9100
               - bastion.infra.rust-lang.org:9100
               - play-1.infra.rust-lang.org:9100
-              - dev-desktop-staging.infra.rust-lang.org
+              - dev-desktop-staging.infra.rust-lang.org:9100
               - dev-desktop-eu-1.infra.rust-lang.org:9100
               - dev-desktop-eu-2.infra.rust-lang.org:9100
               - dev-desktop-us-1.infra.rust-lang.org:9100


### PR DESCRIPTION
The address for the dev-desktop-staging instance was missing its port due to a copy & paste error.