### PR TITLE
Disable the fwupd-refresh service

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -8,3 +8,4 @@
 - include: metrics.yml
 - include: papertrail.yml
 - include: cleanup.yml
+- include: services.yml

--- a/ansible/roles/common/tasks/services.yml
+++ b/ansible/roles/common/tasks/services.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Disable the fwupd-refresh timer
+  ansible.builtin.systemd:
+    enabled: false
+    state: stopped
+    name: fwupd-refresh.timer
+
+- name: Disable the fwupd-refresh service
+  ansible.builtin.systemd:
+    enabled: false
+    state: stopped
+    name: fwupd-refresh.service


### PR DESCRIPTION
The fwupd-refresh service doesn't execute properly on all systems, so we are disabling it globally.