### PR TITLE
Remove packages missing in apt

### DIFF
--- a/ansible/roles/dev-desktop/tasks/main.yml
+++ b/ansible/roles/dev-desktop/tasks/main.yml
@@ -210,10 +210,7 @@
       - ninja-build
       - fish
       - ripgrep
-      - hyperfine
       - jq
-      - mdbook
-      - git-absorb
       # Allows running `x check --target x86_64-pc-windows-gnu`
       - gcc-mingw-w64-x86-64
     state: present


### PR DESCRIPTION
A few of the new packages for the dev-desktops are not distributed through apt. They have been removed for now, and will be added back in a later commit after some refactoring.