### PR TITLE
Add alternate name to Fastly service

### DIFF
--- a/terragrunt/modules/crates-io/fastly-static.tf
+++ b/terragrunt/modules/crates-io/fastly-static.tf
@@ -26,6 +26,10 @@ resource "fastly_service_compute" "static" {
     name = local.fastly_domain_name
   }
 
+  domain {
+    name = var.static_domain_name
+  }
+
   backend {
     # Must be identical to s3-primary-host item in dictionary
     name = local.primary_host_name
@@ -77,7 +81,10 @@ resource "fastly_service_dictionary_items" "compute_static" {
 
 resource "fastly_tls_subscription" "static" {
   certificate_authority = "lets-encrypt"
-  domains               = [local.fastly_domain_name]
+  domains = [
+    local.fastly_domain_name,
+    var.static_domain_name
+  ]
 }
 
 ### Stage 2


### PR DESCRIPTION
The Fastly service for `static.crates.io` has its own domain and certificate. This makes it easier to deploy and test the service, and it allows us to split traffic using weighted DNS records in the future. For this to work, though, the service needs to have a `static.crates.io` as an alternate name in its certificate and it needs to respond to requests for this domain.