### PR TITLE
Updates to AWS MFA policies due to changes in AWS implementation and best practices

### DIFF
--- a/terraform/team-members-access/_shared.tf
+++ b/terraform/team-members-access/_shared.tf
@@ -80,7 +80,7 @@ resource "aws_iam_policy" "manage_own_credentials" {
         "iam:CreateVirtualMFADevice",
         "iam:DeleteVirtualMFADevice"
       ],
-      "Resource": "arn:aws:iam::*:mfa/$${aws:username}"
+      "Resource": "arn:aws:iam::*:mfa/*"
     },
     {
       "Sid": "AllowManageOwnUserMFA",

--- a/terraform/team-members-access/_shared.tf
+++ b/terraform/team-members-access/_shared.tf
@@ -77,8 +77,7 @@ resource "aws_iam_policy" "manage_own_credentials" {
       "Sid": "AllowManageOwnVirtualMFADevice",
       "Effect": "Allow",
       "Action": [
-        "iam:CreateVirtualMFADevice",
-        "iam:DeleteVirtualMFADevice"
+        "iam:CreateVirtualMFADevice"
       ],
       "Resource": "arn:aws:iam::*:mfa/*"
     },


### PR DESCRIPTION
## What happened

I tried to change my MFA in my AWS account. When I tried, I got this error:

```
User: arn:aws:iam::890664054962:user/carols10cents is not authorized to perform: iam:CreateVirtualMFADevice on resource: arn:aws:iam::890664054962:mfa/aaa because no identity-based policy allows the iam:CreateVirtualMFADevice action
```

despite [appearing to have that permission](https://github.com/rust-lang/simpleinfra/blob/f55b3b921d09123d00aaa7dfb4356f5efe75dfc6/terraform/team-members-access/_shared.tf#L80). 

I also tried logging out and logging in to no avail.

After searching, I found [this AWS question and answer from 2 months ago](https://repost.aws/questions/QUBD8nxw68S92EaaPiCydisg/how-to-allow-mfa-self-management-with-custom-mfa-device-names-multiple-mfa), which indicates AWS only recently began allowing users to have more than one MFA device and thus give them custom names.

To test that theory, I added an MFA device named `carols10cents` and it worked.

So the first commit in this branch removes the restriction that the MFA device be named with your username 🤦🏻‍♀️ 

The second commit is a change I noticed when reading [the updated documentation for MFA IAM permissions](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws_my-sec-creds-self-manage-mfa-only.html) in a big "warning" box. I can't claim to understand this completely, but AWS is recommending this, so... 🤷🏻‍♀️ 

Please review this carefully because I only barely know what I'm doing here!!! I'm happy to make whatever changes.