### PR TITLE
Create weighted records for static.crates.io

### DIFF
--- a/terragrunt/accounts/legacy/crates-io-staging/crates-io/terragrunt.hcl
+++ b/terragrunt/accounts/legacy/crates-io-staging/crates-io/terragrunt.hcl
@@ -22,4 +22,7 @@ inputs = {
   iam_prefix = "staging-crates-io"
 
   strict_security_headers = true
+
+  static_cloudfront_weight = 50
+  static_fastly_weight = 50
 }

--- a/terragrunt/modules/crates-io/_terraform.tf
+++ b/terragrunt/modules/crates-io/_terraform.tf
@@ -81,3 +81,13 @@ variable "static_ttl" {
   description = "TTL for static crates"
   type        = number
 }
+
+variable "static_cloudfront_weight" {
+  description = "Weight of the traffic for static.crates.io that is routed through CloudFront"
+  type        = number
+}
+
+variable "static_fastly_weight" {
+  description = "Weight of the traffic for static.crates.io that is routed through Fastly"
+  type        = number
+}

--- a/terragrunt/modules/crates-io/certificate.tf
+++ b/terragrunt/modules/crates-io/certificate.tf
@@ -5,6 +5,7 @@ module "certificate" {
     var.webapp_domain_name,
     var.static_domain_name,
     var.index_domain_name,
+    local.cloudfront_domain_name,
   ]
 
   legacy = true

--- a/terragrunt/modules/crates-io/fastly-static.tf
+++ b/terragrunt/modules/crates-io/fastly-static.tf
@@ -132,3 +132,17 @@ resource "aws_route53_record" "fastly_static_domain" {
   records         = local.fastly_static_destinations
   ttl             = 60
 }
+
+resource "aws_route53_record" "weighted_static_fastly" {
+  zone_id = data.aws_route53_zone.static.id
+  name    = var.static_domain_name
+  type    = "CNAME"
+  ttl     = 300
+  records = [aws_route53_record.fastly_static_domain.fqdn]
+
+  weighted_routing_policy {
+    weight = var.static_fastly_weight
+  }
+
+  set_identifier = "fastly"
+}


### PR DESCRIPTION
Weighted records[^1] allow us to manage traffic between different targets. We use them for static.crates.io to split traffic between CloudFront and Fastly. The exact distribution can be set via variables for each environment.

[^1]: https://docs.aws.amazon.com/Route53/latest/APIReference/api-policies-traffic-policy-document-format.html#traffic-policy-document-format-rules-weighted