### PR TITLE
Add chromium dependencies in dev-dektops

### DIFF
--- a/ansible/roles/dev-desktop/tasks/dependencies.yml
+++ b/ansible/roles/dev-desktop/tasks/dependencies.yml
@@ -31,6 +31,20 @@
       - valgrind
       - "linux-tools-{{ kernel.stdout }}"
       - "linux-tools-{{ kernel_flavor.stdout }}"
+      - libatk1.0-0 # Allows running `x test rustdoc-gui`
+      - libatk-bridge2.0-0
+      - libcups2
+      - libxkbcommon0
+      - libxcomposite1
+      - libxdamage1
+      - libxfixes3
+      - libxrandr2
+      - libgbm1
+      - libpango-1.0-0
+      - libcairo2
+      - libasound2
+      - libatspi2.0-0
+
     state: present
 
 - name: Install tools for x86


### PR DESCRIPTION
This allow running `x test rustdoc-gui` in the dev-desktops without manual work.

Here is a list of what is added:

- libatk1.0-0
- libatk-bridge2.0-0
- libcups2
- libxkbcommon0
- libxcomposite1
- libxdamage1
- libxfixes3
- libxrandr2
- libgbm1
- libpango-1.0-0
- libcairo2
- libasound2
- libatspi2.0-0