### PR TITLE
add emacs in the dependencies list

### DIFF
--- a/ansible/roles/dev-desktop/tasks/dependencies.yml
+++ b/ansible/roles/dev-desktop/tasks/dependencies.yml
@@ -44,6 +44,7 @@
       - libcairo2
       - libasound2
       - libatspi2.0-0
+      - emacs
 
     state: present
 


### PR DESCRIPTION
This should add emacs, with home that it is a version >= 18

Fixes https://github.com/rust-lang/simpleinfra/issues/205

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>