### PR TITLE
Set AWS region for static crates certificate

### DIFF
--- a/terragrunt/modules/acm-certificate/_terraform.tf
+++ b/terragrunt/modules/acm-certificate/_terraform.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.20"
+    }
+  }
+}

--- a/terragrunt/modules/crates-io/certificate.tf
+++ b/terragrunt/modules/crates-io/certificate.tf
@@ -1,6 +1,10 @@
 module "certificate" {
   source = "../acm-certificate"
 
+  providers = {
+    aws = aws.us-east-1
+  }
+
   domains = [
     var.webapp_domain_name,
     var.static_domain_name,


### PR DESCRIPTION
The certificates for crates.io are managed in the us-east-1 region, while the infrastructure is deployed in us-west-2. This causes Terraform to not find the certificate, thinking that it has been removed. Setting the provider for the certificate manually resolves the issue.