### PR TITLE
Enable request logging for crates.io

### DIFF
--- a/terragrunt/accounts/legacy/crates-io-staging/crates-io/terragrunt.hcl
+++ b/terragrunt/accounts/legacy/crates-io-staging/crates-io/terragrunt.hcl
@@ -25,4 +25,6 @@ inputs = {
 
   static_cloudfront_weight = 50
   static_fastly_weight = 50
+
+  fastly_customer_id_ssm_parameter = "/staging/crates-io/fastly/customer-id"
 }

--- a/terragrunt/modules/crates-io/_terraform.tf
+++ b/terragrunt/modules/crates-io/_terraform.tf
@@ -91,3 +91,14 @@ variable "static_fastly_weight" {
   description = "Weight of the traffic for static.crates.io that is routed through Fastly"
   type        = number
 }
+
+variable "fastly_customer_id_ssm_parameter" {
+  description = "Name of the SSM parameter with our Fastly customer id"
+  type        = string
+}
+
+variable "fastly_aws_account_id" {
+  # See https://docs.fastly.com/en/guides/creating-an-aws-iam-role-for-fastly-logging
+  description = "The AWS account ID that Fastly uses to write logs"
+  default     = "717331877981"
+}

--- a/terragrunt/modules/crates-io/cloudfront-static.tf
+++ b/terragrunt/modules/crates-io/cloudfront-static.tf
@@ -79,6 +79,12 @@ resource "aws_cloudfront_distribution" "static" {
     }
   }
 
+  logging_config {
+    include_cookies = false
+    bucket          = aws_s3_bucket.logs.bucket_regional_domain_name
+    prefix          = "cloudfront/${var.static_domain_name}"
+  }
+
   tags = {
     TeamAccess = "crates-io"
   }

--- a/terragrunt/modules/crates-io/compute-static/Cargo.lock
+++ b/terragrunt/modules/crates-io/compute-static/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,8 +54,13 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 name = "compute-static"
 version = "0.1.0"
 dependencies = [
+ "derive_builder",
  "fastly",
  "log",
+ "log-fastly",
+ "serde",
+ "serde_json",
+ "time",
 ]
 
 [[package]]
@@ -56,6 +70,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "darling"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0808e1bd8671fb44a113a14e13497557533369847788fa2ae912b6ebfce9fa8"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "001d80444f28e193f30c2f293455da62dcf9a6b29918a4253152ae2b1de592cb"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b36230598a2d5de7ec1c6f51f72d8a99a9208daff41de2084d06e3fd3ea56685"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+dependencies = [
+ "derive_builder_core",
+ "syn",
 ]
 
 [[package]]
@@ -69,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "fastly"
-version = "0.8.9"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d14ee2f12a3191582449a2e080287eff8898fc52da61c437869d91c41b3ae2a"
+checksum = "645e7a0c3782166bcab2c7f0704d51db0fed2d27093d5beea94cef878ba11bb9"
 dependencies = [
  "anyhow",
  "bytes 0.5.6",
@@ -93,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "fastly-macros"
-version = "0.8.9"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1b2980c09148cb84bfd18591943ee449a350dc1ff1ead69edbf012f7e2eef"
+checksum = "6b5163881fe9bab8e865258351e931635d2d17ed88113e546db7c7e57f7249e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -104,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "fastly-shared"
-version = "0.8.9"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f79939bdbbab8b1de759d584f386319454f8623681400675a07f9ad35f2b158"
+checksum = "40d95b3a3816d17b02f3972d16fefddd164c0ec7c1b4e090b380177131a4a22d"
 dependencies = [
  "bitflags",
  "http",
@@ -115,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "fastly-sys"
-version = "0.8.9"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d01e98274a6b12c85c0eef22924871cc12c54b5322268947322463e59d09336"
+checksum = "286a15f3231704bfadc3e2a739b04fdd6fadfa4706157d482f05c0539c681594"
 dependencies = [
  "bitflags",
  "fastly-shared",
@@ -160,6 +240,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +281,23 @@ checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "log-fastly"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6033f42b6c8ca6e46966073065312ac3d371fc8cac323dd76cf479093730f71f"
+dependencies = [
+ "fastly",
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "mime"
@@ -233,6 +336,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+
+[[package]]
 name = "ryu"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,18 +360,18 @@ checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "serde"
-version = "1.0.151"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fed41fc1a24994d044e6db6935e69511a1153b52c15eb42493b26fa87feba0"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.151"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "255abe9a125a985c05190d687b320c12f9b1f0b99445e608c21ba0782c719ad8"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -260,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "7434af0dc1cbd59268aa98b4c22c131c0584d2232f6fb166efb993e2832e896a"
 dependencies = [
  "itoa",
  "ryu",
@@ -293,6 +413,12 @@ dependencies = [
  "digest",
  "opaque-debug",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -331,6 +457,7 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
+ "itoa",
  "serde",
  "time-core",
  "time-macros",

--- a/terragrunt/modules/crates-io/compute-static/Cargo.toml
+++ b/terragrunt/modules/crates-io/compute-static/Cargo.toml
@@ -15,5 +15,10 @@ publish = false
 debug = 1
 
 [dependencies]
-fastly = "0.8.9"
+derive_builder = "0.12.0"
+fastly = "0.9.1"
 log = "0.4.17"
+log-fastly = "0.9.1"
+serde = { version = "1.0.152", features = ["derive"] }
+serde_json = "1.0.92"
+time = { version = "0.3.17", features = ["serde-human-readable"] }

--- a/terragrunt/modules/crates-io/compute-static/src/config.rs
+++ b/terragrunt/modules/crates-io/compute-static/src/config.rs
@@ -15,25 +15,35 @@ const FALLBACK_HOST: &str = "s3-fallback-host";
 // Name of the dictionary item with the TTL for the static bucket
 const STATIC_TTL: &str = "static-ttl";
 
+// Name of the directory item with the logging endpoint for requests
+const REQUEST_LOGS_ENDPOINT: &str = "request-logs-endpoint";
+
+// Name of the directory item with the logging endpoint for the worker
+const SERVICE_LOGS_ENDPOINT: &str = "service-logs-endpoint";
+
 #[derive(Debug)]
 pub struct Config {
     pub primary_host: String,
     pub fallback_host: String,
     pub static_ttl: u32,
     pub cloudfront_url: String,
+    pub request_logs_endpoint: String,
+    pub service_logs_endpoint: String,
 }
 
 impl Config {
     pub fn from_dictionary() -> Self {
         let dictionary = ConfigStore::open(DICTIONARY_NAME);
 
-        // Lookup S3 hosts for current environment
+        // Look up S3 hosts for current environment
         let primary_host = dictionary
             .get(PRIMARY_HOST)
             .expect("failed to get S3 primary host from dictionary");
         let fallback_host = dictionary
             .get(FALLBACK_HOST)
             .expect("failed to get S3 fallback host from dictionary");
+
+        // Look up time to cache crates
         let static_ttl = dictionary
             .get(STATIC_TTL)
             .expect("failed to get TTL for the static bucket from dictionary")
@@ -43,11 +53,21 @@ impl Config {
             .get(CLOUDFRONT_URL)
             .expect("failed to get CloudFront URL from dictionary");
 
+        // Look up the endpoints for logging
+        let request_logs_endpoint = dictionary
+            .get(REQUEST_LOGS_ENDPOINT)
+            .expect("failed to get endpoint for request logs from dictionary");
+        let service_logs_endpoint = dictionary
+            .get(SERVICE_LOGS_ENDPOINT)
+            .expect("failed to get endpoint for service logs from dictionary");
+
         Self {
             primary_host,
             fallback_host,
             static_ttl,
             cloudfront_url,
+            request_logs_endpoint,
+            service_logs_endpoint,
         }
     }
 }

--- a/terragrunt/modules/crates-io/compute-static/src/log_line.rs
+++ b/terragrunt/modules/crates-io/compute-static/src/log_line.rs
@@ -2,7 +2,7 @@ use std::net::IpAddr;
 
 use derive_builder::Builder;
 use serde::Serialize;
-use time::{Date, Time};
+use time::OffsetDateTime;
 
 #[derive(Debug, Serialize)]
 #[serde(tag = "version")]
@@ -13,8 +13,8 @@ pub enum LogLine {
 
 #[derive(Debug, Builder, Serialize)]
 pub struct LogLineV1 {
-    date: Date,
-    time: Time,
+    #[serde(with = "time::serde::rfc3339")]
+    date_time: OffsetDateTime,
     url: String,
     bytes: Option<usize>,
     ip: Option<IpAddr>,

--- a/terragrunt/modules/crates-io/compute-static/src/log_line.rs
+++ b/terragrunt/modules/crates-io/compute-static/src/log_line.rs
@@ -1,0 +1,23 @@
+use std::net::IpAddr;
+
+use derive_builder::Builder;
+use serde::Serialize;
+use time::{Date, Time};
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "version")]
+pub enum LogLine {
+    #[serde(rename = "1")]
+    V1(LogLineV1),
+}
+
+#[derive(Debug, Builder, Serialize)]
+pub struct LogLineV1 {
+    date: Date,
+    time: Time,
+    url: String,
+    bytes: Option<usize>,
+    ip: Option<IpAddr>,
+    method: Option<String>,
+    status: Option<u16>,
+}

--- a/terragrunt/modules/crates-io/compute-static/src/main.rs
+++ b/terragrunt/modules/crates-io/compute-static/src/main.rs
@@ -43,11 +43,8 @@ fn init_logging(config: &Config) {
 
 /// Collect data for the logs from the request
 fn collect_request(request: &Request) -> LogLineV1Builder {
-    let datetime = OffsetDateTime::now_utc();
-
     LogLineV1Builder::default()
-        .date(datetime.date())
-        .time(datetime.time())
+        .date_time(OffsetDateTime::now_utc())
         .url(request.get_url_str().into())
         .ip(request.get_client_ip_addr())
         .method(Some(request.get_method().to_string()))

--- a/terragrunt/modules/crates-io/compute-static/src/main.rs
+++ b/terragrunt/modules/crates-io/compute-static/src/main.rs
@@ -1,26 +1,76 @@
 use fastly::http::{Method, StatusCode};
 use fastly::{Error, Request, Response};
-use log::warn;
+use log::{info, warn, LevelFilter};
+use log_fastly::Logger;
+use serde_json::json;
+use time::OffsetDateTime;
 
 use crate::config::Config;
+use crate::log_line::{LogLine, LogLineV1Builder};
 
 mod config;
+mod log_line;
 
 #[fastly::main]
-fn main(mut request: Request) -> Result<Response, Error> {
+fn main(request: Request) -> Result<Response, Error> {
     let config = Config::from_dictionary();
+    init_logging(&config);
 
+    let mut log = collect_request(&request);
+
+    let response = handle_request(&config, request);
+
+    let log = collect_response(&mut log, &response);
+    build_and_send_log(log, &config);
+
+    response
+}
+
+/// Initialize the logger
+///
+/// Fastly provides its own logger implementation that streams logs to pre-configured endpoints. We
+/// have created one endpoint for request logs and one for service logs.
+///
+/// Logs are echoed to stdout as well to enable tailing the logs with the Fastly CLI.
+fn init_logging(config: &Config) {
+    Logger::builder()
+        .max_level(LevelFilter::Debug)
+        .endpoint(config.request_logs_endpoint.clone())
+        .default_endpoint(config.service_logs_endpoint.clone())
+        .echo_stdout(true)
+        .init();
+}
+
+/// Collect data for the logs from the request
+fn collect_request(request: &Request) -> LogLineV1Builder {
+    let datetime = OffsetDateTime::now_utc();
+
+    LogLineV1Builder::default()
+        .date(datetime.date())
+        .time(datetime.time())
+        .url(request.get_url_str().into())
+        .ip(request.get_client_ip_addr())
+        .method(Some(request.get_method().to_string()))
+        .to_owned()
+}
+
+/// Handle the request
+///
+/// This method handles the incoming request and returns a response for the client. It first ensures
+/// that the request uses whitelisted request methods, then sets a TTL to cache the response, before
+/// finally forwarding the request to S3.
+fn handle_request(config: &Config, mut request: Request) -> Result<Response, Error> {
     if let Some(response) = limit_http_methods(&request) {
         return Ok(response);
     }
 
-    set_ttl(&config, &mut request);
+    set_ttl(config, &mut request);
 
     // Database dump is too big to cache on Fastly
     if request.get_url_str().ends_with("db-dump.tar.gz") {
-        redirect_db_dump_to_cloudfront(&config)
+        redirect_db_dump_to_cloudfront(config)
     } else {
-        send_request_to_s3(&config, &request)
+        send_request_to_s3(config, &request)
     }
 }
 
@@ -81,4 +131,32 @@ fn send_request_to_s3(config: &Config, request: &Request) -> Result<Response, Er
     }
 
     Ok(response)
+}
+
+/// Collect data for the logs from the response
+fn collect_response(
+    log_line: &mut LogLineV1Builder,
+    response: &Result<Response, Error>,
+) -> LogLineV1Builder {
+    if let Ok(response) = response {
+        log_line
+            .bytes(response.get_content_length())
+            .status(Some(response.get_status().as_u16()))
+            .to_owned()
+    } else {
+        log_line.status(Some(500)).to_owned()
+    }
+}
+
+/// Finalize the builder and log the line
+fn build_and_send_log(log_line: LogLineV1Builder, config: &Config) {
+    match log_line.build() {
+        Ok(log) => {
+            let versioned_log = LogLine::V1(log);
+            info!(target: &config.request_logs_endpoint, "{}", json!(versioned_log).to_string())
+        }
+        Err(error) => {
+            warn!("failed to serialize request log: {error}");
+        }
+    };
 }

--- a/terragrunt/modules/crates-io/fastly-iam-role.tf
+++ b/terragrunt/modules/crates-io/fastly-iam-role.tf
@@ -1,0 +1,51 @@
+data "aws_ssm_parameter" "fastly_customer_id" {
+  name = var.fastly_customer_id_ssm_parameter
+}
+
+resource "aws_iam_role" "fastly_assume_role" {
+  name        = "${var.iam_prefix}--fastly"
+  description = "Allow Fastly to assume a role with write access to the logs for ${var.webapp_domain_name}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Condition = {
+          StringEquals = {
+            "sts:ExternalId" = [
+              data.aws_ssm_parameter.fastly_customer_id.value
+            ]
+          }
+        }
+        Action = "sts:AssumeRole"
+        Principal = {
+          AWS = var.fastly_aws_account_id
+        }
+        Effect = "Allow"
+        Sid    = "S3LoggingTrustPolicy"
+      },
+    ]
+  })
+}
+
+resource "aws_iam_policy" "fastly_put_logs" {
+  name        = "${var.iam_prefix}--fastly-put-logs"
+  description = "Allow Fastly to put the logs for ${var.webapp_domain_name} into S3"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action   = "s3:PutObject"
+        Effect   = "Allow"
+        Resource = "${aws_s3_bucket.logs.arn}/*"
+    }]
+  })
+}
+
+resource "aws_iam_policy_attachment" "fastly_s3_logging" {
+  name = "${var.iam_prefix}--fastly-s3-logging"
+
+  roles      = [aws_iam_role.fastly_assume_role.name]
+  policy_arn = aws_iam_policy.fastly_put_logs.arn
+}

--- a/terragrunt/modules/crates-io/fastly-static.tf
+++ b/terragrunt/modules/crates-io/fastly-static.tf
@@ -10,6 +10,9 @@ locals {
   fallback_host_name = aws_s3_bucket.fallback.region
 
   dictionary_name = "compute_static"
+
+  request_logs_endpoint = "s3-request-logs"
+  service_logs_endpoint = "s3-service-logs"
 }
 
 data "external" "package" {
@@ -62,6 +65,22 @@ resource "fastly_service_compute" "static" {
     filename         = data.external.package.result.path
     source_code_hash = filesha512(data.external.package.result.path)
   }
+
+  logging_s3 {
+    name        = local.request_logs_endpoint
+    bucket_name = aws_s3_bucket.logs.bucket
+
+    s3_iam_role = aws_iam_role.fastly_assume_role.arn
+    path        = "/fastly-requests/${var.static_domain_name}/"
+  }
+
+  logging_s3 {
+    name        = local.service_logs_endpoint
+    bucket_name = aws_s3_bucket.logs.bucket
+
+    s3_iam_role = aws_iam_role.fastly_assume_role.arn
+    path        = "/fastly-logs/${var.static_domain_name}/"
+  }
 }
 
 resource "fastly_service_dictionary_items" "compute_static" {
@@ -78,6 +97,8 @@ resource "fastly_service_dictionary_items" "compute_static" {
     "s3-primary-host" : local.primary_host_name
     "s3-fallback-host" : local.fallback_host_name
     "static-ttl" : var.static_ttl
+    "request-logs-endpoint" : local.request_logs_endpoint
+    "service-logs-endpoint" : local.service_logs_endpoint
   }
 }
 

--- a/terragrunt/modules/crates-io/fastly-static.tf
+++ b/terragrunt/modules/crates-io/fastly-static.tf
@@ -71,6 +71,7 @@ resource "fastly_service_compute" "static" {
     bucket_name = aws_s3_bucket.logs.bucket
 
     s3_iam_role = aws_iam_role.fastly_assume_role.arn
+    domain      = "s3.us-west-1.amazonaws.com"
     path        = "/fastly-requests/${var.static_domain_name}/"
   }
 
@@ -79,6 +80,7 @@ resource "fastly_service_compute" "static" {
     bucket_name = aws_s3_bucket.logs.bucket
 
     s3_iam_role = aws_iam_role.fastly_assume_role.arn
+    domain      = "s3.us-west-1.amazonaws.com"
     path        = "/fastly-logs/${var.static_domain_name}/"
   }
 }

--- a/terragrunt/modules/crates-io/s3-logs.tf
+++ b/terragrunt/modules/crates-io/s3-logs.tf
@@ -1,0 +1,27 @@
+resource "aws_s3_bucket" "logs" {
+  bucket = "rust-${replace(var.webapp_domain_name, ".", "-")}-logs"
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "logs" {
+  bucket = aws_s3_bucket.logs.id
+
+  rule {
+    id     = "yearly-delete"
+    status = "Enabled"
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+    expiration {
+      days = 330
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "logs" {
+  bucket = aws_s3_bucket.logs.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}


### PR DESCRIPTION
As with the Rust releases (see https://github.com/rust-lang/simpleinfra/commit/8c6cf1fa9aaea8dc596103e9614c341ef942c25e), we are now collecting request logs for crates.io.