### PR TITLE
Increase traffic to Fastly

### DIFF
--- a/terragrunt/accounts/legacy/crates-io-prod/crates-io/terragrunt.hcl
+++ b/terragrunt/accounts/legacy/crates-io-prod/crates-io/terragrunt.hcl
@@ -24,6 +24,6 @@ inputs = {
 
   strict_security_headers = true
 
-  static_cloudfront_weight = 99
-  static_fastly_weight = 1
+  static_cloudfront_weight = 95
+  static_fastly_weight = 5
 }


### PR DESCRIPTION
Fastly has successfully served 1% of traffic to static.crates.io for a few days now, so we are increasing the ratio by a few points.