### PR TITLE
Add `lld` and `lldb` to the preinstalled packages in the dev-desktops

### DIFF
--- a/ansible/roles/dev-desktop/tasks/dependencies.yml
+++ b/ansible/roles/dev-desktop/tasks/dependencies.yml
@@ -46,6 +46,8 @@
       - libatspi2.0-0
       - libelf-dev  # Allows building tools that link against libelf
       - emacs
+      - lld
+      - llvm
     state: present
 
 - name: Install tools for x86

--- a/ansible/roles/dev-desktop/tasks/dependencies.yml
+++ b/ansible/roles/dev-desktop/tasks/dependencies.yml
@@ -47,7 +47,7 @@
       - libelf-dev  # Allows building tools that link against libelf
       - emacs
       - lld
-      - llvm
+      - lldb
     state: present
 
 - name: Install tools for x86


### PR DESCRIPTION
This allows the usage of `lld` and `lldb` in the dev-desktops