### PR TITLE
Disable Fastly while investigating issue

### DIFF
--- a/terragrunt/accounts/legacy/crates-io-prod/crates-io/terragrunt.hcl
+++ b/terragrunt/accounts/legacy/crates-io-prod/crates-io/terragrunt.hcl
@@ -24,6 +24,6 @@ inputs = {
 
   strict_security_headers = true
 
-  static_cloudfront_weight = 95
-  static_fastly_weight = 5
+  static_cloudfront_weight = 100
+  static_fastly_weight = 0
 }


### PR DESCRIPTION
An issue with large crates on Fastly was reported for crates.io[^1]. While investigating the issue and implementing a solution, we've disabled traffic to Fastly.

[^1]: https://github.com/rust-lang/crates.io/issues/6028