### PR TITLE
Invite legacy account

### DIFF
--- a/terragrunt/README.md
+++ b/terragrunt/README.md
@@ -115,8 +115,37 @@ instance of the service will create its own certificate.
 
 ## Running Terragrunt
 
+When running [Terragrunt], it fetches and stores the state of the infrastructure
+in AWS. This requires that an AWS profile is configured for each account. After
+that has been done, running [Terragrunt] is as simple as replacing `terraform`
+with `terragrunt` in the command.
+
+### Configure AWS Profiles
+
 Running [Terragrunt] requires permissions to the AWS account you are
-configuring. Assuming you have permission, you can `cd` into the corresponding
+configuring. For each of the accounts, copy the following snippet into the
+configuration file at `~/.aws/config`:
+
+```text
+[profile rust-root]
+sso_start_url = https://rust-lang.awsapps.com/start
+sso_account_id = <rust-root-account-id>
+sso_role_name = AdministratorAccess
+sso_region = us-east-1
+region = us-east-1
+```
+
+Each account in `./accounts` has a `account.json` file that contains the name of
+the respective profile. In the above example, `./account/root/account.json` sets
+the profile name to `rust-root`.
+
+The `sso_account_id` can be found in the web interface of AWS SSO. Open the
+`sso_start_url` in a browser, log in, and you'll see a list of accounts with
+their respective account ids.
+
+### Run Terragrunt
+
+Assuming you have permission, you can `cd` into the corresponding
 service within the `accounts` directory and run `terragrunt plan` to see the
 plan terraform will apply and `terragrunt apply` to actually apply the plan.
 

--- a/terragrunt/README.md
+++ b/terragrunt/README.md
@@ -145,9 +145,17 @@ their respective account ids.
 
 ### Run Terragrunt
 
-Assuming you have permission, you can `cd` into the corresponding
-service within the `accounts` directory and run `terragrunt plan` to see the
-plan terraform will apply and `terragrunt apply` to actually apply the plan.
+Before running Terragrunt, make sure you are signed into the correct AWS
+profile. For example, run the following command to sign into the `rust-root`
+account:
+
+```shell
+aws sso login --profile rust-root
+```
+
+You can then `cd` into the corresponding service within the `accounts` directory
+and run `terragrunt plan` to see the plan terraform will apply and
+`terragrunt apply` to actually apply the plan.
 
 [terraform]: https://www.terraform.io/
 [terragrunt]: https://terragrunt.gruntwork.io/

--- a/terragrunt/modules/aws-organization/accounts.tf
+++ b/terragrunt/modules/aws-organization/accounts.tf
@@ -7,6 +7,11 @@ resource "aws_organizations_account" "admin" {
   email = "admin+root@rust-lang.org"
 }
 
+resource "aws_organizations_account" "legacy" {
+  name  = "Rust Admin - 8450"
+  email = "admin@rust-lang.org"
+}
+
 resource "aws_organizations_account" "docs_rs_staging" {
   name  = "docs-rs-staging"
   email = "admin+docs-rs-staging@rust-lang.org"

--- a/terragrunt/modules/aws-organization/groups.tf
+++ b/terragrunt/modules/aws-organization/groups.tf
@@ -79,6 +79,18 @@ locals {
         permissions : [aws_ssoadmin_permission_set.view_only_access] }
       ]
     },
+    # Legacy
+    {
+      account : aws_organizations_account.legacy,
+      groups : [
+        { group : aws_identitystore_group.infra-admins,
+        permissions : [aws_ssoadmin_permission_set.view_only_access, aws_ssoadmin_permission_set.administrator_access] },
+        { group : aws_identitystore_group.billing,
+        permissions : [aws_ssoadmin_permission_set.billing_access] },
+        { group : aws_identitystore_group.infra,
+        permissions : [aws_ssoadmin_permission_set.view_only_access] }
+      ]
+    },
     # docs-rs Staging
     {
       account : aws_organizations_account.docs_rs_staging,
@@ -103,7 +115,7 @@ locals {
 }
 
 module "sso_account_assignment" {
-  for_each   = { for assignment in local.assignments : "${assignment.account.name}" => assignment }
+  for_each   = { for assignment in local.assignments : assignment.account.name => assignment }
   source     = "./sso-account-assignment"
   account_id = each.value.account.id
   groups     = each.value.groups


### PR DESCRIPTION
The legacy AWS account has been invited into the new AWS organization. This enables us to access the account using SSO, and consolidates billing for all AWS accounts.