### PR TITLE
increase cloudfront TTL for docs.rs and static.docs.rs

### DIFF
--- a/terraform/docs-rs/cloudfront.tf
+++ b/terraform/docs-rs/cloudfront.tf
@@ -41,7 +41,7 @@ resource "aws_cloudfront_distribution" "webapp" {
     compress               = true
     viewer_protocol_policy = "redirect-to-https"
 
-    default_ttl = 86400 // 1 day
+    default_ttl = 604800 // 1 week
     min_ttl     = 0
     max_ttl     = 31536000 // 1 year
 

--- a/terraform/docs-rs/static-cloudfront.tf
+++ b/terraform/docs-rs/static-cloudfront.tf
@@ -17,7 +17,7 @@ module "static_certificate" {
 
 resource "aws_cloudfront_cache_policy" "static_docs_rs" {
   name        = "static-docs-rs"
-  default_ttl = 86400 // 1 day
+  default_ttl = 604800 // 1 week
   min_ttl     = 0
   max_ttl     = 86400
   parameters_in_cache_key_and_forwarded_to_origin {


### PR DESCRIPTION
we got no reports of outdated content after #210 was merged & deployed, 

also we were keeping up with the invalidation queue, 

so IMO we can increase further. 

