### PR TITLE
doc.rust-lang.org: immutably cache static files

### DIFF
--- a/terraform/releases/impl/cloudfront-doc.tf
+++ b/terraform/releases/impl/cloudfront-doc.tf
@@ -71,7 +71,45 @@ resource "aws_cloudfront_distribution" "doc" {
   }
 
   ordered_cache_behavior {
-    path_pattern     = "*.woff2"
+    path_pattern     = "/nightly/static.files/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "main"
+
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.cache_immutable.id
+    cache_policy_id            = data.aws_cloudfront_cache_policy.caching.id
+
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+
+    lambda_function_association {
+      event_type   = "origin-request"
+      lambda_arn   = module.lambda_doc_router.version_arn
+      include_body = false
+    }
+  }
+
+  ordered_cache_behavior {
+    path_pattern     = "/beta/static.files/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "main"
+
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.cache_immutable.id
+    cache_policy_id            = data.aws_cloudfront_cache_policy.caching.id
+
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+
+    lambda_function_association {
+      event_type   = "origin-request"
+      lambda_arn   = module.lambda_doc_router.version_arn
+      include_body = false
+    }
+  }
+
+  ordered_cache_behavior {
+    path_pattern     = "/static.files/*"
     allowed_methods  = ["GET", "HEAD", "OPTIONS"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = "main"


### PR DESCRIPTION
In https://github.com/rust-lang/simpleinfra/pull/108, @Mark-Simulacrum rightly pointed out that it would be better for rustdoc's static files to have hashes in the name, so we can confidently cache them immutably, knowing that if the contents ever change, the filename will also change.

That work is done in https://github.com/rust-lang/rust/issues/98413, and all of stable, beta, and nightly docs have been built with that change. Also as part of the change, all static files are served from a separate directory, `static.files/`, so we know that any files in that directory may be cached immutably.