### PR TITLE
Increase disk quota to 150GB

### DIFF
--- a/ansible/roles/dev-desktop/defaults/main.yml
+++ b/ansible/roles/dev-desktop/defaults/main.yml
@@ -4,7 +4,7 @@ vars_team_login_path: "/root/team_login"
 allow_ssh_extra_groups: "dev-desktop-allow-ssh"
 
 # Filesystem quota per user in GB
-vars_user_quota_gb: 100
+vars_user_quota_gb: 150
 
 # Prototype user whose file system quota will be copied to new user accounts
 vars_user_quota_prototype_user: "quota-prototype"


### PR DESCRIPTION
The quota for users of the dev desktops has been bumped to 150GB after issues were reported in Zulip[^1].

[^1]: https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/Cloud.20compute.20.2F.20Dev.20desktop.20feedback/near/326239155