### PR TITLE
Set the right bucket for the docs-rs app

### DIFF
--- a/terragrunt/modules/docs-rs/web-server.tf
+++ b/terragrunt/modules/docs-rs/web-server.tf
@@ -22,6 +22,8 @@ module "web" {
     DOCSRS_STORAGE_BACKEND      = "s3"
     DOCSRS_LOG                  = "docs_rs=debug,rustwide=info"
     RUST_BACKTRACE              = "1"
+    S3_REGION                   = "us-east-1"
+    DOCSRS_S3_BUCKET            = "${aws_s3_bucket.storage.id}"
     DOCSRS_STATIC_CLOUDFRONT_ID = "${aws_cloudfront_distribution.static.id}"
   }
 


### PR DESCRIPTION
Without these environment variables the web app attempts to access the wrong bucket. 