### PR TITLE
Increase traffic to Fastly

### DIFF
--- a/terragrunt/accounts/legacy/crates-io-prod/crates-io/terragrunt.hcl
+++ b/terragrunt/accounts/legacy/crates-io-prod/crates-io/terragrunt.hcl
@@ -24,6 +24,6 @@ inputs = {
 
   strict_security_headers = true
 
-  static_cloudfront_weight = 95
-  static_fastly_weight = 5
+  static_cloudfront_weight = 80
+  static_fastly_weight = 20
 }


### PR DESCRIPTION
We have been running 5% of traffic to static.crates.io through Fastly for the past week without major issues, so we're increasing the ratio of traffic again.