### PR TITLE
Limit the s3 permissions of the docs-rs builder

### DIFF
--- a/terragrunt/modules/docs-rs/builder.tf
+++ b/terragrunt/modules/docs-rs/builder.tf
@@ -34,8 +34,6 @@ resource "aws_iam_role_policy" "builder_s3" {
         Effect = "Allow"
         Action = [
           "s3:PutObject",
-          "s3:GetObject",
-          "s3:CreateBucket",
           "s3:ListBucket",
           "s3:PutObjectTagging",
           "s3:DeleteObject"

--- a/terragrunt/modules/docs-rs/builder.tf
+++ b/terragrunt/modules/docs-rs/builder.tf
@@ -32,7 +32,14 @@ resource "aws_iam_role_policy" "builder_s3" {
       // Access to s3
       {
         Effect = "Allow"
-        Action = "s3:*"
+        Action = [
+          "s3:PutObject",
+          "s3:GetObject",
+          "s3:CreateBucket",
+          "s3:ListBucket",
+          "s3:PutObjectTagging",
+          "s3:DeleteObject"
+        ]
 
         Resource = [
           aws_s3_bucket.storage.arn,


### PR DESCRIPTION
Fixes #238 

This still gives the builder considerable permissions, but less than it had before. I believe this is the minimum that the builder needs today to run. 