### PR TITLE
Add an autoscaling group for the docs-rs-builder

### DIFF
--- a/terragrunt/accounts/docs-rs-staging/docs-rs/terragrunt.hcl
+++ b/terragrunt/accounts/docs-rs-staging/docs-rs/terragrunt.hcl
@@ -25,4 +25,6 @@ inputs = {
   private_subnet_ids        = dependency.vpc.outputs.private_subnets
   domain                    = "docs-rs-staging.rust-lang.net"
   bastion_security_group_id = dependency.vpc.outputs.bastion_security_group_id
+  min_num_builder_instances = 1
+  max_num_builder_instances = 1
 }

--- a/terragrunt/modules/docs-rs/builder.tf
+++ b/terragrunt/modules/docs-rs/builder.tf
@@ -37,6 +37,13 @@ resource "aws_launch_template" "builder" {
     }
   }
 
+  tag_specifications {
+    resource_type = "instance"
+
+    tags = {
+      Name = "docs-rs-builder"
+    }
+  }
 }
 
 data "aws_ami" "builder" {

--- a/terragrunt/modules/docs-rs/builder.tf
+++ b/terragrunt/modules/docs-rs/builder.tf
@@ -1,5 +1,50 @@
-// The instance profile the builder will assume when communicating with
-// other AWS services.
+// The autoscaling group for the builder
+
+resource "aws_autoscaling_group" "builder" {
+  name                = "docs-rs-builder"
+  vpc_zone_identifier = var.cluster_config.subnet_ids
+  max_size            = var.max_num_builder_instances
+  min_size            = var.min_num_builder_instances
+  # Let the instances get warm
+  default_instance_warmup = 60
+
+  launch_template {
+    id      = aws_launch_template.builder.id
+    version = "$Latest"
+  }
+}
+
+resource "aws_launch_template" "builder" {
+  name_prefix   = "builder"
+  image_id      = data.aws_ami.builder.id
+  instance_type = "t2.large"
+
+  network_interfaces {
+    associate_public_ip_address = true
+    security_groups             = [aws_security_group.builder.id]
+  }
+
+  iam_instance_profile {
+    arn = aws_iam_instance_profile.builder.arn
+  }
+
+  block_device_mappings {
+    device_name = "/dev/sda1"
+
+    ebs {
+      volume_size           = 64
+      delete_on_termination = true
+    }
+  }
+
+}
+
+data "aws_ami" "builder" {
+  most_recent = true
+  name_regex  = "^docs-rs-builder-*"
+}
+
+// The instance profile the builder will assume when communicating with s3
 
 resource "aws_iam_instance_profile" "builder" {
   name = "builder"
@@ -46,4 +91,42 @@ resource "aws_iam_role_policy" "builder_s3" {
       }
     ]
   })
+}
+
+// Security group allowing all egress and ssh ingress from the bastion instance
+resource "aws_security_group" "builder" {
+  vpc_id      = var.cluster_config.vpc_id
+  name        = "docs-rs-builder"
+  description = "Access rules for the docs-rs builder."
+
+  // SSH access from the bastion instance
+  ingress {
+    from_port       = 22
+    to_port         = 22
+    protocol        = "tcp"
+    description     = "SSH access from bastion"
+    security_groups = [aws_security_group.web.id]
+  }
+
+  // Allow outgoing connections
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = -1
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow all IPv4 egress traffic."
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = -1
+    ipv6_cidr_blocks = ["::/0"]
+    description      = "Allow all IPv6 egress traffic."
+  }
+
+  tags = {
+    Name = "docs-rs-builder"
+  }
 }

--- a/terragrunt/modules/docs-rs/variables.tf
+++ b/terragrunt/modules/docs-rs/variables.tf
@@ -29,3 +29,13 @@ variable "cluster_config" {
   })
   description = "The configuration for the cluster this is running in"
 }
+
+variable "min_num_builder_instances" {
+  type        = number
+  description = "The minimum number of builder instances there should be"
+}
+
+variable "max_num_builder_instances" {
+  type        = number
+  description = "The maximum number of builder instances there should be"
+}


### PR DESCRIPTION
This adds an autoscaling group for the docs-rs-builder.

Currently this works by grabbing the latest docs-rs-builder AMI, creating a launch template with that AMI, and then using that template to make an autoscaling group.

I'm not sure we want to actually deploy this way in the long term, but I think it's a good start for testing how the autoscaling group behaves in practice.
