### PR TITLE
Pin node version used for GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - name: Ensure the bundled action is the same as the source code
         run: |
           for action in $(ls github-actions/); do


### PR DESCRIPTION
GitHub Actions recently [updated the default version of node](https://github.com/actions/runner-images/issues/7002) available in GitHub Actions. It seems this causes our builds to [fail](https://github.com/rust-lang/simpleinfra/actions/runs/4223059318/jobs/7333674500#step:3:24). We should consider updating the version that the the actions in the `github-actions` dir target, but until then, we pin to node v16.