### PR TITLE
reduce alert threshold for docs.rs server CPU load

### DIFF
--- a/ansible/playbooks/monitoring.yml
+++ b/ansible/playbooks/monitoring.yml
@@ -217,13 +217,13 @@
                 description: "There are more than 1000 deprioritized crates in the docs.rs queue, and the situation didn't resolve itself in the 24 hours. The build queue is available at https://docs.rs/releases/queue"
 
             - alert: HighCpuUsage
-              expr: avg(rate(node_cpu_seconds_total{job="node",instance="docsrs.infra.rust-lang.org:9100",mode="idle"}[10m])) < 0.15
+              expr: avg(rate(node_cpu_seconds_total{job="node",instance="docsrs.infra.rust-lang.org:9100",mode="idle"}[10m])) < 0.10
               for: 30m
               labels:
                 dispatch: docsrs
               annotations:
                 summary: "High CPU usage on the docs.rs server"
-                description: "the 10-minute rolling average idle time over a 30-minute period was < 15%, something is wrong. Please check `htop` for which threads consume the CPU. Restarting the server can help then."
+                description: "the 10-minute rolling average idle time over a 30-minute period was < 10%, something is wrong. Please check `htop` for which threads consume the CPU. Restarting the server can help then."
 
             - alert: FailingBuilds
               expr: increase(docsrs_failed_builds{job="docsrs"}[3h]) / increase(docsrs_total_builds{job="docsrs"}[3h]) > 0.75


### PR DESCRIPTION
In the last week, mostly due to a big increase in RPM on rustdoc pages, the CPU load went higher too. 

While we are debugging this too, this alert was too sensitive. 

Looking [at the data from the last 7 days](https://grafana.rust-lang.org/explore?left=%7B%22datasource%22:%22P1809F7CD0C75ACF3%22,%22queries%22:%5B%7B%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22P1809F7CD0C75ACF3%22%7D,%22expr%22:%22avg%20by%20%28mode%29%20%28rate%28node_cpu_seconds_total%7Bjob%3D%5C%22node%5C%22,instance%3D%5C%22docsrs.infra.rust-lang.org:9100%5C%22,mode%3D%5C%22idle%5C%22%7D%5B10m%5D%29%29%20%2A%20100%22,%22refId%22:%22A%22,%22interval%22:%22%22,%22editorMode%22:%22code%22,%22range%22:true,%22instant%22:true%7D%5D,%22range%22:%7B%22from%22:%22now-7d%22,%22to%22:%22now%22%7D%7D&orgId=1), I think this new setting would have triggered when it should have. 
