### PR TITLE
Redirect database dump to CloudFront

### DIFF
--- a/terragrunt/modules/crates-io/compute-static/src/config.rs
+++ b/terragrunt/modules/crates-io/compute-static/src/config.rs
@@ -3,6 +3,9 @@ use fastly::ConfigStore;
 // Name of the dictionary. Must match the dictionary in `fastly-static.tf`.
 const DICTIONARY_NAME: &str = "compute_static";
 
+// Name of the dictionary item with the CloudFront URL
+const CLOUDFRONT_URL: &str = "cloudfront-url";
+
 // Name of the dictionary item with the name of the primary host.
 const PRIMARY_HOST: &str = "s3-primary-host";
 
@@ -17,6 +20,7 @@ pub struct Config {
     pub primary_host: String,
     pub fallback_host: String,
     pub static_ttl: u32,
+    pub cloudfront_url: String,
 }
 
 impl Config {
@@ -35,11 +39,15 @@ impl Config {
             .expect("failed to get TTL for the static bucket from dictionary")
             .parse()
             .expect("failed to parse TTL for the static bucket");
+        let cloudfront_url = dictionary
+            .get(CLOUDFRONT_URL)
+            .expect("failed to get CloudFront URL from dictionary");
 
         Self {
             primary_host,
             fallback_host,
             static_ttl,
+            cloudfront_url,
         }
     }
 }

--- a/terragrunt/modules/crates-io/fastly-static.tf
+++ b/terragrunt/modules/crates-io/fastly-static.tf
@@ -74,6 +74,7 @@ resource "fastly_service_dictionary_items" "compute_static" {
   manage_items  = true
 
   items = {
+    "cloudfront-url": local.cloudfront_domain_name
     "s3-primary-host" : local.primary_host_name
     "s3-fallback-host" : local.fallback_host_name
     "static-ttl" : var.static_ttl

--- a/terragrunt/modules/crates-io/fastly-static.tf
+++ b/terragrunt/modules/crates-io/fastly-static.tf
@@ -74,7 +74,7 @@ resource "fastly_service_dictionary_items" "compute_static" {
   manage_items  = true
 
   items = {
-    "cloudfront-url": local.cloudfront_domain_name
+    "cloudfront-url" : local.cloudfront_domain_name
     "s3-primary-host" : local.primary_host_name
     "s3-fallback-host" : local.fallback_host_name
     "static-ttl" : var.static_ttl


### PR DESCRIPTION
An issue with the database dump for crates was reported on Zulip[^1], and determined to be caused by the file size limit of Fastly. We can currently cache files up to 50MB on Fastly, but the database dump is close to 250MB in size. To avoid this issue, we are redirecting download requests for the dump to CloudFront.

[^1]: https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/403s.20from.20.2Fdb-dump.2Etar.2Egz