### PR TITLE
Increase traffic to Fastly

### DIFF
--- a/terragrunt/accounts/legacy/crates-io-prod/crates-io/terragrunt.hcl
+++ b/terragrunt/accounts/legacy/crates-io-prod/crates-io/terragrunt.hcl
@@ -24,6 +24,6 @@ inputs = {
 
   strict_security_headers = true
 
-  static_cloudfront_weight = 100
-  static_fastly_weight = 0
+  static_cloudfront_weight = 80
+  static_fastly_weight = 20
 }


### PR DESCRIPTION
We've fixed the issue with the database dumb in pull request #250, and are routing traffic through Fastly again.