### PR TITLE
Read GitHub tokens from context by default

### DIFF
--- a/github-actions/cancel-outdated-builds/action.yml
+++ b/github-actions/cancel-outdated-builds/action.yml
@@ -4,7 +4,8 @@ description: Start a daemon that will cancel the current build if a new commit i
 inputs:
   github_token:
     description: GitHub token used to interact with the GitHub API
-    required: true
+    default: ${{ github.token }}
+    required: false
   check_every_seconds:
     description: How many seconds to wait between checks
     required: true

--- a/github-actions/static-websites/action.yml
+++ b/github-actions/static-websites/action.yml
@@ -7,7 +7,8 @@ inputs:
     required: true
   github_token:
     description: 'GitHub token used to push the website'
-    required: true
+    default: ${{ github.token }}
+    required: false
   cloudfront_distribution:
     description: 'Cloudfront distribution to invalidate'
     required: false


### PR DESCRIPTION
This makes some actions read GitHub tokens from context for convenience.
We usually read it via `${{ secrets.GITHUB_TOKEN }}` and it can be replaced by `${{ github.token }}` on action.yml, see https://docs.github.com/en/actions/security-guides/automatic-token-authentication for more details.