### PR TITLE
Fix issue with lldb 14

### DIFF
--- a/ansible/roles/dev-desktop/tasks/fix_llvm_55575.yml
+++ b/ansible/roles/dev-desktop/tasks/fix_llvm_55575.yml
@@ -1,0 +1,24 @@
+---
+
+# lldb 14 fails to load Python modules due to a wrong path. The workaround for
+# this issue is to symlink the modules to the path that lldb expects.
+# https://github.com/llvm/llvm-project/issues/55575
+
+- name: Find all lldb Python files
+  ansible.builtin.find:
+    paths: /usr/lib/llvm-14/lib/python3.10/dist-packages/lldb
+    file_type: file
+  register: lldb_python_files
+
+- name: Find all lldb Python modules
+  ansible.builtin.find:
+    paths: /usr/lib/llvm-14/lib/python3.10/dist-packages/lldb
+    file_type: directory
+  register: lldb_python_directories
+
+- name: Fix llvm/llvm-project#55575
+  ansible.builtin.file:
+    src: "{{ item.path }}"
+    dest: "/usr/lib/python3/dist-packages/lldb/{{ item.path | basename }}"
+    state: link
+  with_items: "{{ lldb_python_files.files + lldb_python_directories.files }}"

--- a/ansible/roles/dev-desktop/tasks/fix_llvm_55575.yml
+++ b/ansible/roles/dev-desktop/tasks/fix_llvm_55575.yml
@@ -22,3 +22,9 @@
     dest: "/usr/lib/python3/dist-packages/lldb/{{ item.path | basename }}"
     state: link
   with_items: "{{ lldb_python_files.files + lldb_python_directories.files }}"
+
+- name: Fix lldb-server-14.0.0
+  ansible.builtin.file:
+    src: /usr/lib/llvm-14/bin/lldb-server
+    dest: /usr/bin/lldb-server-14.0.0
+    state: link

--- a/ansible/roles/dev-desktop/tasks/main.yml
+++ b/ansible/roles/dev-desktop/tasks/main.yml
@@ -7,3 +7,4 @@
 - include: github.yml
 - include: motd.yml
 - include: scripts.yml
+- include: fix_llvm_55575.yml


### PR DESCRIPTION
lldb 14 fails to load Python modules due to a wrong path. The workaround for this issue is to symlink the modules to the path that lldb expects.

Fixes #254