### PR TITLE
Increase traffic ratio for crates on Fastly

### DIFF
--- a/terragrunt/accounts/legacy/crates-io-prod/crates-io/terragrunt.hcl
+++ b/terragrunt/accounts/legacy/crates-io-prod/crates-io/terragrunt.hcl
@@ -24,8 +24,8 @@ inputs = {
 
   strict_security_headers = true
 
-  static_cloudfront_weight = 80
-  static_fastly_weight = 20
+  static_cloudfront_weight = 50
+  static_fastly_weight = 50
 
   fastly_customer_id_ssm_parameter = "/prod/crates-io/fastly/customer-id"
 }


### PR DESCRIPTION
After running stable on an 80/20 split for a few weeks, we are increasing the traffic to Fastly again.