### PR TITLE
Get metrics from Fastly

### DIFF
--- a/ansible/playbooks/monitoring.yml
+++ b/ansible/playbooks/monitoring.yml
@@ -128,7 +128,7 @@
           metrics_path: /metrics
           static_configs:
             - targets:
-              - fastly-exporter.infra.rust-lang.org:8080
+              - fastly-exporter.infra.rust-lang.org
 
 
       prometheus_rule_groups:

--- a/ansible/playbooks/monitoring.yml
+++ b/ansible/playbooks/monitoring.yml
@@ -123,6 +123,13 @@
             - targets:
               - crates-io-heroku-metrics.infra.rust-lang.org:443
 
+        - job_name: fastly_exporter
+          scheme: https
+          metrics_path: /metrics
+          static_configs:
+            - targets:
+              - fastly-exporter.infra.rust-lang.org:8080
+
 
       prometheus_rule_groups:
         - name: node

--- a/terraform/fastly-exporter/.terraform.lock.hcl
+++ b/terraform/fastly-exporter/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.57.1"
+  constraints = "~> 4.20, ~> 4.32"
+  hashes = [
+    "h1:Qfq7Q9aCQqdl7w439mCMm89126n8DsDAmg6H8gXhnLI=",
+    "zh:44200c213ddb138df80d2a5ad86c2ebadbb5fd1d08cd7e4fc56ec6dca927659b",
+    "zh:469e6fe6a9e99e60cb168d32f05e2e9a83cf161f39160d075ff96f7674c510e1",
+    "zh:6110ba2c15a2268652ec9ea3797dd0216de84ece428055c49eaf9caa2be1ed62",
+    "zh:62ed7348acca44f64fc087e879e01cfa4e084c7600cc91e8bb7683f8065a9c79",
+    "zh:7a80e6fa9b35be178bb566093f7984dd6ffb7ad9d40b9dd5d5907f054f0c3e60",
+    "zh:8793043c8575a598c1a7cbefcb65ee1776b0061eba719098e552a3adc88f3090",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a777a0082114e273b7b3eb14095a3f6f6e703c1aff61ffb1f0846bb869e6dfc7",
+    "zh:b060c3b2973097f2087a98ac6aad7c9c89fe80f7cf3027019049feafc3f8305b",
+    "zh:e7035e74563f4486848ea1feb60852175353790bc374e0e97e241a88dc0908f7",
+    "zh:eaaa8e9eba09ada41e13116d53d4baece04fead8fcf3eab68cca3a67ed738e18",
+    "zh:ec52d8f95a84fad8fe1aae169c89d0c54d5401f75caae0869ad8182c6b6db65b",
+    "zh:f0e33174025b1b57ecfbdd09f2a59c2559ee94d7681e5ae09079e2822ec54ecf",
+    "zh:f69790a21380e5aab9303a252564737333e1e95b5d25567681630e49b17e3ec7",
+    "zh:ff6053942c40a99904bd407f3c082c1fa8f927ecce0374566eb7e8ee8145e582",
+  ]
+}

--- a/terraform/fastly-exporter/README.md
+++ b/terraform/fastly-exporter/README.md
@@ -1,0 +1,9 @@
+# Prometheus Exporter for Fastly
+
+This module deploys a Prometheus exporter for Fastly using the official
+[fastly/fastly-exporter] Docker image. The implementation uses the [`ecs-task`]
+and [`ecs-service`] modules to deploy the exporter to ECS.
+
+[`ecs-service`]: ../../terragrunt/modules/ecs-service
+[`ecs-task`]: ../../terragrunt/modules/ecs-task
+[fastly/fastly-exporter]: https://github.com/fastly/fastly-exporter

--- a/terraform/fastly-exporter/_terraform.tf
+++ b/terraform/fastly-exporter/_terraform.tf
@@ -1,0 +1,34 @@
+// Configuration for Terraform itself.
+
+terraform {
+  required_version = "~> 1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.32"
+    }
+  }
+
+  backend "s3" {
+    bucket         = "rust-terraform"
+    key            = "simpleinfra/fastly-exporter.tfstate"
+    region         = "us-west-1"
+    dynamodb_table = "terraform-state-lock"
+    encrypt        = true
+  }
+}
+
+data "terraform_remote_state" "shared" {
+  backend = "s3"
+  config = {
+    bucket = "rust-terraform"
+    key    = "simpleinfra/shared.tfstate"
+    region = "us-west-1"
+  }
+}
+
+provider "aws" {
+  profile = "legacy"
+  region  = "us-west-1"
+}

--- a/terraform/fastly-exporter/main.tf
+++ b/terraform/fastly-exporter/main.tf
@@ -83,6 +83,8 @@ resource "aws_security_group" "fastly_exporter" {
     protocol  = "tcp"
     # Elastic IP of the monitoring server
     cidr_blocks = ["52.9.166.219/32"]
+    # Load balancer security group, required for health checks
+    security_groups = ["sg-0ddcb954525a46b70"]
   }
 }
 

--- a/terraform/fastly-exporter/main.tf
+++ b/terraform/fastly-exporter/main.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 data "aws_ssm_parameter" "fastly_api_token" {
-  name = "/prod/crates-io/fastly/api-token"
+  name = "/prod/fastly-exporter/fastly/api-token"
 }
 
 resource "aws_iam_policy" "read_fastly_api_token" {

--- a/terraform/fastly-exporter/main.tf
+++ b/terraform/fastly-exporter/main.tf
@@ -1,0 +1,107 @@
+locals {
+  name = "fastly-exporter"
+}
+
+data "aws_ssm_parameter" "fastly_api_token" {
+  name = "/prod/crates-io/fastly/api-token"
+}
+
+resource "aws_iam_policy" "read_fastly_api_token" {
+  name = "ecs--${local.name}"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "AllowReadingFastlyApiToken"
+        Effect   = "Allow"
+        Action   = "ssm:GetParameters"
+        Resource = data.aws_ssm_parameter.fastly_api_token.arn
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "read_fastly_api_token" {
+  role       = module.ecs_task.execution_role_name
+  policy_arn = aws_iam_policy.read_fastly_api_token.arn
+}
+
+module "ecs_task" {
+  source = "../shared/modules/ecs-task"
+
+  name   = local.name
+  cpu    = 256
+  memory = 512
+
+  log_retention_days = 7
+  ecr_repositories_arns = [
+    # This repository does not exist, since we're pulling the imge directly from GitHub.
+    # But the task module cannot be applied without providing at least one ARN here.
+    "arn:aws:ecr:us-west-1:890664054962:repository/fastly-exporter"
+  ]
+
+  containers = <<EOF
+[
+  {
+    "name": "${local.name}",
+    "image": "ghcr.io/fastly/fastly-exporter:v7.4.0",
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 8080,
+        "hostPort": 8080
+      }
+    ],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "/ecs/${local.name}",
+        "awslogs-region": "us-west-1",
+        "awslogs-stream-prefix": "${local.name}"
+      }
+    },
+    "environment": [],
+    "secrets": [
+      {
+        "name": "FASTLY_API_TOKEN",
+        "valueFrom": "${data.aws_ssm_parameter.fastly_api_token.arn}"
+      }
+    ]
+  }
+]
+EOF
+}
+
+resource "aws_security_group" "fastly_exporter" {
+  name        = "fastly-exporter"
+  description = "Allow Prometheus to scrape the fastly-exporter"
+  vpc_id      = data.terraform_remote_state.shared.outputs.ecs_cluster_config.vpc_id
+
+  ingress {
+    from_port        = 8080
+    to_port          = 8080
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+}
+
+module "ecs_service" {
+  source = "../shared/modules/ecs-service"
+
+  cluster_config   = data.terraform_remote_state.shared.outputs.ecs_cluster_config
+  platform_version = "1.4.0"
+
+  name        = local.name
+  task_arn    = module.ecs_task.arn
+  tasks_count = 1
+
+  http_container = local.name
+  http_port      = 8080
+
+  domains = ["fastly-exporter.infra.rust-lang.org"]
+
+  additional_security_group_ids = [
+    aws_security_group.fastly_exporter.id,
+  ]
+}

--- a/terraform/fastly-exporter/main.tf
+++ b/terraform/fastly-exporter/main.tf
@@ -78,11 +78,11 @@ resource "aws_security_group" "fastly_exporter" {
   vpc_id      = data.terraform_remote_state.shared.outputs.ecs_cluster_config.vpc_id
 
   ingress {
-    from_port        = 8080
-    to_port          = 8080
-    protocol         = "tcp"
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
+    from_port = 8080
+    to_port   = 8080
+    protocol  = "tcp"
+    # Elastic IP of the monitoring server
+    cidr_blocks = ["52.9.166.219/32"]
   }
 }
 

--- a/terraform/rust-log-analyzer/_terraform.tf
+++ b/terraform/rust-log-analyzer/_terraform.tf
@@ -33,10 +33,10 @@ data "terraform_remote_state" "shared" {
 }
 
 provider "aws" {
-  region  = "us-west-1"
+  region = "us-west-1"
 }
 
 provider "aws" {
-  region  = "us-east-1"
-  alias   = "east1"
+  region = "us-east-1"
+  alias  = "east1"
 }


### PR DESCRIPTION
The [fastly-exporter](https://github.com/fastly/fastly-exporter) provides an easy way to export metrics from Fastly into Prometheus. It is deployed as a stateless container on ECS and scraped by the monitoring server.