### PR TITLE
Install mold linker on dev-desktops

### DIFF
--- a/ansible/roles/dev-desktop/tasks/dependencies.yml
+++ b/ansible/roles/dev-desktop/tasks/dependencies.yml
@@ -49,6 +49,7 @@
       - emacs
       - lld
       - lldb
+      - mold
     state: present
 
 - name: Install tools for x86


### PR DESCRIPTION
The mold linker[^1] has been installed on the dev desktops as requested in Zulip[^2].

[^1]: https://github.com/rui314/mold
[^2]: https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/Cloud.20compute.20.2F.20Dev.20desktop.20feedback/near/348734066