### PR TITLE
Add `libsecret-1-dev` to dev desktop packages

### DIFF
--- a/ansible/roles/dev-desktop/tasks/dependencies.yml
+++ b/ansible/roles/dev-desktop/tasks/dependencies.yml
@@ -46,6 +46,7 @@
       - libasound2
       - libatspi2.0-0
       - libelf-dev  # Allows building tools that link against libelf
+      - libsecret-1-dev # used by cargo
       - emacs
       - lld
       - lldb

--- a/terraform/rust-log-analyzer/app.tf
+++ b/terraform/rust-log-analyzer/app.tf
@@ -39,7 +39,7 @@ module "rla" {
 }
 
 resource "aws_s3_bucket" "storage" {
-   bucket = "rust-log-analyzer-storage"
+  bucket = "rust-log-analyzer-storage"
 }
 
 resource "aws_s3_bucket_public_access_block" "storage" {


### PR DESCRIPTION
It is used by cargo: https://github.com/rust-lang/cargo/blob/master/credential/cargo-credential-gnome-secret/build.rs

Also fixed terraform formatting