### PR TITLE
Lock production environment to Git commit

### DIFF
--- a/terragrunt/accounts/legacy/releases-dev/release-distribution/terragrunt.hcl
+++ b/terragrunt/accounts/legacy/releases-dev/release-distribution/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "../../../../modules//release-distribution"
+  source = "../../../../..//terragrunt/modules/release-distribution"
 }
 
 include {

--- a/terragrunt/accounts/legacy/releases-prod/deployed-ref
+++ b/terragrunt/accounts/legacy/releases-prod/deployed-ref
@@ -1,0 +1,1 @@
+e40baaba26675b2f79bc0ddd0d98d9505e8dc465

--- a/terragrunt/accounts/legacy/releases-prod/release-distribution/terragrunt.hcl
+++ b/terragrunt/accounts/legacy/releases-prod/release-distribution/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "../../../../modules//release-distribution"
+  source = "git::../../../../..//terragrunt/modules/release-distribution?ref=${trimspace(file("../deployed-ref"))}"
 }
 
 include {

--- a/terragrunt/modules/aws-lambda/pack.py
+++ b/terragrunt/modules/aws-lambda/pack.py
@@ -44,6 +44,10 @@ def pack(query):
         os.makedirs(parent, exist_ok=True)
     zip = zipfile.ZipFile(query["destination"], mode="w")
     for path in paths:
+        # Ignore Terragrunt's metadata files.
+        if os.path.basename(path) == ".terragrunt-source-manifest":
+            continue
+
         # Override the permissions to set 0644 if the file is not executable,
         # or 0755 if the file is executable.
         permission = 0o100644


### PR DESCRIPTION
The production environment for releases has been locked to a specific Git commit. This makes it possible to test changes to the Terragrunt modules in isolation on staging, and then promote them to production once they have stabilized.

For consistency, the path for both the development and production environment has been changed. This ensures that running `terragrunt` in both environments produces the same directory structure in the cache. This is extremely useful for debugging.