### PR TITLE
Scope down promote_release IAM role S3 permissions

### DIFF
--- a/terraform/releases/impl/promote-release.tf
+++ b/terraform/releases/impl/promote-release.tf
@@ -197,7 +197,17 @@ resource "aws_iam_role_policy" "promote_release" {
           "${aws_s3_bucket.static.arn}/doc/*",
           "${aws_s3_bucket.static.arn}/dist",
           "${aws_s3_bucket.static.arn}/dist/*",
-
+        ]
+      },
+      {
+        Sid    = "BucketsReadDelete"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObjectAcl",
+          "s3:GetObject",
+          "s3:DeleteObject",
+        ]
+        Resource = [
           // Artifacts bucket
           "${data.aws_s3_bucket.artifacts.arn}/rustc-builds",
           "${data.aws_s3_bucket.artifacts.arn}/rustc-builds/*",


### PR DESCRIPTION
Based on my limited understanding of the promote_release role, it only needs to read and delete objects from the artifacts bucket and doesn't need to write anything there. This change removes s3:PutObject and s3:PutObjectAcl permissions on the artifacts bucket from the promote_release role. I have tested with `terraform validate` (with some local mods to, e.g. bucket names) but I am not able to validate this any further. Any feedback would be welcome.