### PR TITLE
Add a `project.metadata.docs.rs` redirect in addition to `package.metadata`

### DIFF
--- a/terraform/domain-redirects/redirects.tf
+++ b/terraform/domain-redirects/redirects.tf
@@ -102,6 +102,7 @@ module "docs_rs_metadata" {
   to_path = "about/metadata"
   from = [
     "package.metadata.docs.rs",
+    "project.metadata.docs.rs",
   ]
   permanent = true
 }


### PR DESCRIPTION
Eric Huss says that the two are equivalent in Cargo.toml, so support both in the domain names as well: https://rust-lang.zulipchat.com/#narrow/stream/318791-t-crates-io/topic/crate.20files.20with.20unusual.20.60Cargo.2Etoml.60.20files/near/362487043

https://github.com/rust-lang/cargo/blob/58b22f00ef76667ec4f93f4f7936831eaf63f5b7/src/cargo/util/toml/mod.rs#L2030

cc @rust-lang/docs-rs