### PR TITLE
Set variables to invalidate releases on Fastly

### DIFF
--- a/terraform/releases/environments.tf
+++ b/terraform/releases/environments.tf
@@ -60,7 +60,12 @@ module "dev" {
       name  = "PROMOTE_RELEASE_DISCOURSE_API_KEY"
       value = "/prod/promote-release/discourse-api-key"
       type  = "PARAMETER_STORE"
-    }
+    },
+    {
+      name  = "PROMOTE_RELEASE_INVALIDATE_FASTLY"
+      value = "true"
+      type  = "PLAINTEXT"
+    },
   ])
 
   promote_release_cron = {}

--- a/terraform/releases/impl/promote-release.tf
+++ b/terraform/releases/impl/promote-release.tf
@@ -115,6 +115,17 @@ resource "aws_codebuild_project" "promote_release" {
       value = "1"
     }
 
+    environment_variable {
+      name  = "PROMOTE_RELEASE_FASTLY_API_TOKEN"
+      value = data.aws_ssm_parameter.fastly_api_token.name
+      type  = "PARAMETER_STORE"
+    }
+
+    environment_variable {
+      name  = "PROMOTE_RELEASE_FASTLY_STATIC_DOMAIN"
+      value = var.static_domain_name
+    }
+
     dynamic "environment_variable" {
       for_each = var.extra_environment_variables
       content {
@@ -251,6 +262,11 @@ resource "aws_iam_role_policy" "promote_release" {
       }
     ]
   })
+}
+
+data "aws_ssm_parameter" "fastly_api_token" {
+  name            = "/${var.name}/promote-release/fastly-api-token"
+  with_decryption = false
 }
 
 data "aws_ssm_parameter" "github_app_key" {


### PR DESCRIPTION
The new environment variables that were added to promote-release in rust-lang/promote-release#66 have been added to the environments. For now, only the dev environment invalidates the cache on Fastly.