### PR TITLE
Explicitly set TTL for static assets

### DIFF
--- a/terragrunt/accounts/legacy/releases-dev/release-distribution/terragrunt.hcl
+++ b/terragrunt/accounts/legacy/releases-dev/release-distribution/terragrunt.hcl
@@ -15,4 +15,6 @@ inputs = {
 
   static_bucket = "dev-static-rust-lang-org"
   log_bucket = "rust-release-logs"
+
+  static_ttl = 86400 // 1 day
 }

--- a/terragrunt/accounts/legacy/releases-prod/release-distribution/terragrunt.hcl
+++ b/terragrunt/accounts/legacy/releases-prod/release-distribution/terragrunt.hcl
@@ -15,4 +15,6 @@ inputs = {
 
   static_bucket = "static-rust-lang-org"
   log_bucket = "rust-release-logs"
+
+  static_ttl = 86400 // 1 day
 }

--- a/terragrunt/modules/release-distribution/cloudfront-static.tf
+++ b/terragrunt/modules/release-distribution/cloudfront-static.tf
@@ -41,6 +41,8 @@ resource "aws_cloudfront_distribution" "static" {
     compress               = true
     viewer_protocol_policy = "redirect-to-https"
 
+    default_ttl = var.static_ttl
+
     forwarded_values {
       headers = [
         // Following the spec, AWS S3 only replies with the CORS headers when

--- a/terragrunt/modules/release-distribution/fastly-static.tf
+++ b/terragrunt/modules/release-distribution/fastly-static.tf
@@ -24,6 +24,8 @@ resource "fastly_service_vcl" "static" {
     ssl_cert_hostname = data.aws_s3_bucket.static.bucket_regional_domain_name
   }
 
+  default_ttl = var.static_ttl
+
   # The VCL snippets can be tested here: https://fiddle.fastly.dev/fiddle/eb4b0dfb
   snippet {
     name    = "list files in S3"

--- a/terragrunt/modules/release-distribution/variables.tf
+++ b/terragrunt/modules/release-distribution/variables.tf
@@ -23,6 +23,11 @@ variable "static_bucket" {
   type        = string
 }
 
+variable "static_ttl" {
+  description = "TTL for static assets"
+  type        = number
+}
+
 variable "log_bucket" {
   description = "Name of the bucket that stores the CloudFront logs"
   type        = string


### PR DESCRIPTION
CloudFront caches content by default for a day. To ensure consistency between CloudFrotn and Fastly, the default TTL is now set explicitly for both providers.