### PR TITLE
Create weighted DNS records for Rust releases

### DIFF
--- a/terragrunt/accounts/legacy/releases-dev/release-distribution/terragrunt.hcl
+++ b/terragrunt/accounts/legacy/releases-dev/release-distribution/terragrunt.hcl
@@ -18,6 +18,6 @@ inputs = {
 
   static_ttl = 86400 // 1 day
 
-  static_cloudfront_weight = 100
-  static_fastly_weight = 0
+  static_cloudfront_weight = 50
+  static_fastly_weight = 50
 }

--- a/terragrunt/accounts/legacy/releases-dev/release-distribution/terragrunt.hcl
+++ b/terragrunt/accounts/legacy/releases-dev/release-distribution/terragrunt.hcl
@@ -17,4 +17,7 @@ inputs = {
   log_bucket = "rust-release-logs"
 
   static_ttl = 86400 // 1 day
+
+  static_cloudfront_weight = 100
+  static_fastly_weight = 0
 }

--- a/terragrunt/modules/release-distribution/cloudfront-static.tf
+++ b/terragrunt/modules/release-distribution/cloudfront-static.tf
@@ -106,5 +106,11 @@ resource "aws_route53_record" "static" {
   name    = var.static_domain_name
   type    = "CNAME"
   ttl     = 300
-  records = [aws_cloudfront_distribution.static.domain_name]
+  records = [aws_route53_record.cloudfront_static_domain.fqdn]
+
+  weighted_routing_policy {
+    weight = var.static_cloudfront_weight
+  }
+
+  set_identifier = "cloudfront"
 }

--- a/terragrunt/modules/release-distribution/cloudfront-static.tf
+++ b/terragrunt/modules/release-distribution/cloudfront-static.tf
@@ -101,7 +101,7 @@ resource "aws_route53_record" "cloudfront_static_domain" {
   records = [aws_cloudfront_distribution.static.domain_name]
 }
 
-resource "aws_route53_record" "static" {
+resource "aws_route53_record" "weighted_static_cloudfront" {
   zone_id = data.aws_route53_zone.static.id
   name    = var.static_domain_name
   type    = "CNAME"

--- a/terragrunt/modules/release-distribution/fastly-static.tf
+++ b/terragrunt/modules/release-distribution/fastly-static.tf
@@ -88,10 +88,24 @@ module "fastly_tls_subscription" {
 }
 
 resource "aws_route53_record" "fastly_static_domain" {
+  zone_id         = data.aws_route53_zone.static.id
   name            = local.fastly_domain_name
   type            = "CNAME"
-  zone_id         = data.aws_route53_zone.static.id
+  ttl             = 300
   allow_overwrite = true
   records         = module.fastly_tls_subscription.destinations
-  ttl             = 60
+}
+
+resource "aws_route53_record" "weighted_static_fastly" {
+  zone_id = data.aws_route53_zone.static.id
+  name    = var.static_domain_name
+  type    = "CNAME"
+  ttl     = 300
+  records = [aws_route53_record.fastly_static_domain.fqdn]
+
+  weighted_routing_policy {
+    weight = var.static_fastly_weight
+  }
+
+  set_identifier = "fastly"
 }

--- a/terragrunt/modules/release-distribution/variables.tf
+++ b/terragrunt/modules/release-distribution/variables.tf
@@ -28,6 +28,16 @@ variable "static_ttl" {
   type        = number
 }
 
+variable "static_cloudfront_weight" {
+  description = "Weight of the traffic for static.rust-lang.org that is routed through CloudFront"
+  type        = number
+}
+
+variable "static_fastly_weight" {
+  description = "Weight of the traffic for static.rust-lang.org that is routed through Fastly"
+  type        = number
+}
+
 variable "log_bucket" {
   description = "Name of the bucket that stores the CloudFront logs"
   type        = string

--- a/terragrunt/modules/sync-team/confirmation.tf
+++ b/terragrunt/modules/sync-team/confirmation.tf
@@ -58,7 +58,7 @@ resource "aws_iam_role_policy_attachment" "lambda_confirmation" {
 }
 
 module "confirmation_certificate" {
-  source  = "../acm-certificate"
+  source = "../acm-certificate"
   providers = {
     aws = aws.us-east-1
   }


### PR DESCRIPTION
Weighted DNS records allow us to route traffic dynamically between CloudFront and Fastly. The existing DNS record is being modified, preventing any issues from removing and then recreating it so that the migration can be performed without downtime.