### PR TITLE
Increase traffic to Fastly for static.crates.io

### DIFF
--- a/terragrunt/accounts/legacy/crates-io-prod/crates-io/terragrunt.hcl
+++ b/terragrunt/accounts/legacy/crates-io-prod/crates-io/terragrunt.hcl
@@ -24,8 +24,8 @@ inputs = {
 
   strict_security_headers = true
 
-  static_cloudfront_weight = 50
-  static_fastly_weight = 50
+  static_cloudfront_weight = 5
+  static_fastly_weight = 95
 
   fastly_customer_id_ssm_parameter = "/prod/crates-io/fastly/customer-id"
 }


### PR DESCRIPTION
The traffic split between Fastly and CloudFront has been increased to a 95/5 ratio. This is the highest that we intend to go so that we can monitor the health of both configurations.