### PR TITLE
Enable cache invalidations on Fastly in production

### DIFF
--- a/terraform/releases/environments.tf
+++ b/terraform/releases/environments.tf
@@ -107,7 +107,12 @@ module "prod" {
       name  = "PROMOTE_RELEASE_DISCOURSE_API_KEY"
       value = "/prod/promote-release/users-discourse-api-key"
       type  = "PARAMETER_STORE"
-    }
+    },
+    {
+      name  = "PROMOTE_RELEASE_INVALIDATE_FASTLY"
+      value = "true"
+      type  = "PLAINTEXT"
+    },
   ])
 
   promote_release_cron = {


### PR DESCRIPTION
Cache invalidations on Fastly are gated behind a feature flag, which this change enables. Invalidations require the static domain name as well as an API key, both of which have been added to the service in a previous commit.