### PR TITLE
Route production traffic for releases to Fastly

### DIFF
--- a/terragrunt/accounts/legacy/releases-prod/release-distribution/terragrunt.hcl
+++ b/terragrunt/accounts/legacy/releases-prod/release-distribution/terragrunt.hcl
@@ -18,6 +18,6 @@ inputs = {
 
   static_ttl = 86400 // 1 day
 
-  static_cloudfront_weight = 100
-  static_fastly_weight = 0
+  static_cloudfront_weight = 99
+  static_fastly_weight = 1
 }


### PR DESCRIPTION
After testing the new Fastly service for release in the dev environment, we feel confident to start using it in production as well. For the beginning, only a small percentage of traffic is routed through Fastly so that we can monitor the configuration and fix it as necessary.