### PR TITLE
Set surrogate keys for releases on Fastly

### DIFF
--- a/terragrunt/modules/release-distribution/fastly-static.tf
+++ b/terragrunt/modules/release-distribution/fastly-static.tf
@@ -54,6 +54,16 @@ resource "fastly_service_vcl" "static" {
   }
 
   snippet {
+    name = "set cache key for dist"
+    type = "fetch"
+    content = <<-VCL
+      if (req.url ~ "^\/dist/") {
+        set beresp.http.Surrogate-Key = "/dist/*";
+      }
+    VCL
+  }
+
+  snippet {
     name    = "redirect rustup.sh to rustup.rs"
     type    = "error"
     content = <<-VCL


### PR DESCRIPTION
Invalidations on Fastly work either with a specific URL or surrogate keys. To support wildcard invalidations, we are now tagging every cached resource under `/dist/` with a surrogate key. This key will then be invalidated by promote-release[^1].

[^1]: https://github.com/rust-lang/promote-release