### PR TITLE
Update environment variable to support surrogate keys

### DIFF
--- a/terraform/releases/impl/promote-release.tf
+++ b/terraform/releases/impl/promote-release.tf
@@ -122,8 +122,9 @@ resource "aws_codebuild_project" "promote_release" {
     }
 
     environment_variable {
-      name  = "PROMOTE_RELEASE_FASTLY_STATIC_DOMAIN"
-      value = var.static_domain_name
+      name  = "PROMOTE_RELEASE_FASTLY_SERVICE_ID"
+      value = data.aws_ssm_parameter.fastly_service_id.name
+      type  = "PARAMETER_STORE"
     }
 
     dynamic "environment_variable" {
@@ -267,6 +268,11 @@ resource "aws_iam_role_policy" "promote_release" {
 
 data "aws_ssm_parameter" "fastly_api_token" {
   name            = "/${var.name}/promote-release/fastly-api-token"
+  with_decryption = false
+}
+
+data "aws_ssm_parameter" "fastly_service_id" {
+  name            = "/${var.name}/promote-release/fastly-service-id"
   with_decryption = false
 }
 


### PR DESCRIPTION
The cache invalidation on Fastly for releases has been refactored to use surrogate keys instead of paths[^1]. This removes the need to set the static domain for Fastly, but requires passing in the respective service id. The service ids for dev-static and static have already been configured as SSM parameters.

[^1]: https://github.com/rust-lang/promote-release/pull/72