### PR TITLE
Send request logs for releases to S3

### DIFF
--- a/terragrunt/modules/release-distribution/data.tf
+++ b/terragrunt/modules/release-distribution/data.tf
@@ -14,3 +14,7 @@ data "aws_s3_bucket" "static" {
 data "aws_s3_bucket" "logs" {
   bucket = var.log_bucket
 }
+
+data "aws_ssm_parameter" "fastly_customer_id" {
+  name = var.fastly_customer_id_ssm_parameter
+}

--- a/terragrunt/modules/release-distribution/data.tf
+++ b/terragrunt/modules/release-distribution/data.tf
@@ -16,5 +16,6 @@ data "aws_s3_bucket" "logs" {
 }
 
 data "aws_ssm_parameter" "fastly_customer_id" {
-  name = var.fastly_customer_id_ssm_parameter
+  name            = "/${var.environment}/promote-release/fastly-customer-id"
+  with_decryption = false
 }

--- a/terragrunt/modules/release-distribution/fastly-iam-role.tf
+++ b/terragrunt/modules/release-distribution/fastly-iam-role.tf
@@ -1,0 +1,47 @@
+resource "aws_iam_role" "fastly_assume_role" {
+  name        = "fastly--promote-release--${var.environment}"
+  description = "Allow Fastly to assume a role with write access to the logs for ${var.static_domain_name}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Condition = {
+          StringEquals = {
+            "sts:ExternalId" = [
+              data.aws_ssm_parameter.fastly_customer_id.value
+            ]
+          }
+        }
+        Action = "sts:AssumeRole"
+        Principal = {
+          AWS = var.fastly_aws_account_id
+        }
+        Effect = "Allow"
+        Sid    = "S3LoggingTrustPolicy"
+      },
+    ]
+  })
+}
+
+resource "aws_iam_policy" "fastly_put_logs" {
+  name        = "fastly-put-logs--promote-release--${var.environment}"
+  description = "Allow Fastly to put the logs for ${var.static_domain_name} into S3"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action   = "s3:PutObject"
+        Effect   = "Allow"
+        Resource = "${data.aws_s3_bucket.logs.arn}/*"
+    }]
+  })
+}
+
+resource "aws_iam_policy_attachment" "fastly_s3_logging" {
+  name = "fastly-s3-logging--promote-release--${var.environment}"
+
+  roles      = [aws_iam_role.fastly_assume_role.name]
+  policy_arn = aws_iam_policy.fastly_put_logs.arn
+}

--- a/terragrunt/modules/release-distribution/fastly-static.tf
+++ b/terragrunt/modules/release-distribution/fastly-static.tf
@@ -83,6 +83,17 @@ resource "fastly_service_vcl" "static" {
       }
     VCL
   }
+
+  logging_s3 {
+    name        = "s3-request-logs"
+    bucket_name = data.aws_s3_bucket.logs.bucket
+
+    s3_iam_role = aws_iam_role.fastly_assume_role.arn
+    domain      = "s3.us-west-1.amazonaws.com"
+    path        = "/fastly-requests/${var.static_domain_name}/"
+
+    compression_codec = "gzip"
+  }
 }
 
 module "fastly_tls_subscription" {

--- a/terragrunt/modules/release-distribution/variables.tf
+++ b/terragrunt/modules/release-distribution/variables.tf
@@ -42,3 +42,14 @@ variable "log_bucket" {
   description = "Name of the bucket that stores the CloudFront logs"
   type        = string
 }
+
+variable "fastly_customer_id_ssm_parameter" {
+  description = "Name of the SSM parameter with our Fastly customer id"
+  type        = string
+}
+
+variable "fastly_aws_account_id" {
+  # See https://docs.fastly.com/en/guides/creating-an-aws-iam-role-for-fastly-logging
+  description = "The AWS account ID that Fastly uses to write logs"
+  default     = "717331877981"
+}

--- a/terragrunt/modules/release-distribution/variables.tf
+++ b/terragrunt/modules/release-distribution/variables.tf
@@ -43,11 +43,6 @@ variable "log_bucket" {
   type        = string
 }
 
-variable "fastly_customer_id_ssm_parameter" {
-  description = "Name of the SSM parameter with our Fastly customer id"
-  type        = string
-}
-
 variable "fastly_aws_account_id" {
   # See https://docs.fastly.com/en/guides/creating-an-aws-iam-role-for-fastly-logging
   description = "The AWS account ID that Fastly uses to write logs"


### PR DESCRIPTION
We are now archiving request logs from Fastly to S3, similar to our existing setups for CloudFront and static.crates.io.