### PR TITLE
Grant promote-release access to SSM parameter

### DIFF
--- a/terraform/releases/impl/promote-release.tf
+++ b/terraform/releases/impl/promote-release.tf
@@ -260,6 +260,7 @@ resource "aws_iam_role_policy" "promote_release" {
           data.aws_ssm_parameter.internals_discourse.arn,
           data.aws_ssm_parameter.users_discourse.arn,
           data.aws_ssm_parameter.fastly_api_token.arn,
+          data.aws_ssm_parameter.fastly_service_id.arn,
         ]
       }
     ]


### PR DESCRIPTION
When the SSM parameter for the service id was added, we forgot to give promote-release access to it. This caused builds to fail with an unauthorized error.