### PR TITLE
Add libfuse3-dev to dev-desktops

### DIFF
--- a/ansible/roles/dev-desktop/tasks/dependencies.yml
+++ b/ansible/roles/dev-desktop/tasks/dependencies.yml
@@ -47,6 +47,7 @@
       - libatspi2.0-0
       - libelf-dev  # Allows building tools that link against libelf
       - libsecret-1-dev # used by cargo
+      - libfuse3-dev
       - emacs
       - lld
       - lldb


### PR DESCRIPTION
`libfuse3-dev` allows experimenting with FUSE file systems