### PR TITLE
install rustfilt

### DIFF
--- a/ansible/roles/dev-desktop/tasks/dependencies.yml
+++ b/ansible/roles/dev-desktop/tasks/dependencies.yml
@@ -29,6 +29,7 @@
       - python3-pip
       - quota
       - ripgrep
+      - rustfilt
       - valgrind
       - "linux-tools-{{ kernel.stdout }}"
       - "linux-tools-{{ kernel_flavor.stdout }}"


### PR DESCRIPTION
```
Description: Demangle Rust symbol names using rustc-demangle
 rustfilt works similarly to c++filt, in that it accepts mangled symbol names as
 command line arguments, and if none are provided it accepts mangled symbols
 from stdin. Demangled symbols are written to stdout.
```