### PR TITLE
Rewrite URLs with plus character for crates.io

### DIFF
--- a/terragrunt/modules/crates-io/cloudfront-functions/static-router.js
+++ b/terragrunt/modules/crates-io/cloudfront-functions/static-router.js
@@ -1,7 +1,5 @@
-'use strict';
-
-exports.handler = (event, context, callback) => {
-    const request = event.Records[0].cf.request;
+function handler(event) {
+    var request = event.request;
 
     // URL-encode the `+` character in the request URI
     // See more: https://github.com/rust-lang/crates.io/issues/4891
@@ -9,5 +7,5 @@ exports.handler = (event, context, callback) => {
         request.uri = request.uri.replace("+", "%2B");
     }
 
-    callback(null, request);
-};
+    return request;
+}

--- a/terragrunt/modules/crates-io/lambdas/static-router/index.js
+++ b/terragrunt/modules/crates-io/lambdas/static-router/index.js
@@ -1,0 +1,13 @@
+'use strict';
+
+exports.handler = (event, context, callback) => {
+    const request = event.Records[0].cf.request;
+
+    // URL-encode the `+` character in the request URI
+    // See more: https://github.com/rust-lang/crates.io/issues/4891
+    if (request.uri.includes("+")) {
+        request.uri = request.uri.replace("+", "%2B");
+    }
+
+    callback(null, request);
+};


### PR DESCRIPTION
The CDNs for `static.crates.io` now rewrites URLs that contain a plus character to a properly URL-encoded version. This ensures that clients access objects in S3 in a consistent way, and avoids any issues with Amazon S3's special handling of the plus character.

See https://github.com/rust-lang/crates.io/issues/4891 for more details.