### PR TITLE
Increase disk of dev-desktop-staging instance

### DIFF
--- a/terraform/dev-desktops/regions.tf
+++ b/terraform/dev-desktops/regions.tf
@@ -8,7 +8,7 @@ module "aws_eu_central_1" {
     "dev-desktop-staging" = {
       instance_type = "t3a.micro"
       instance_arch = "amd64"
-      storage       = 25
+      storage       = 250
     }
     "dev-desktop-eu-1" = {
       instance_type = "c6g.8xlarge"


### PR DESCRIPTION
The disk of the dev-desktop-staging instance ran full when testing Podman on the machine.