### PR TITLE
Install capnproto on dev desktops

### DIFF
--- a/ansible/roles/dev-desktop/tasks/dependencies.yml
+++ b/ansible/roles/dev-desktop/tasks/dependencies.yml
@@ -54,6 +54,9 @@
       - lldb
       - mold
       - neovim
+      # Necessary for building rr
+      - capnproto
+      - libcapnp-dev
     state: present
 
 - name: Install tools for x86


### PR DESCRIPTION
Rr needs capnproto installed to build. There are no prebuilt versions of rr for AArch64 yet. Likely because AArch64 support is still experimental.