### PR TITLE
Run Podman in rootless mode on dev-desktops

### DIFF
--- a/ansible/roles/dev-desktop/files/podman/storage.conf
+++ b/ansible/roles/dev-desktop/files/podman/storage.conf
@@ -1,0 +1,5 @@
+[storage]
+  driver = "overlay"
+
+[storage.options.overlay]
+  mount_program = "/usr/bin/fuse-overlayfs"

--- a/ansible/roles/dev-desktop/tasks/main.yml
+++ b/ansible/roles/dev-desktop/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 
 - include_tasks: dependencies.yml
+- include_tasks: podman.yml
 - include_tasks: quota.yml
 - include_tasks: user_configuration.yml
 - include_tasks: team_login.yml

--- a/ansible/roles/dev-desktop/tasks/podman.yml
+++ b/ansible/roles/dev-desktop/tasks/podman.yml
@@ -1,0 +1,34 @@
+---
+
+# These tasks follow the instructions for running Podman without root privileges
+# https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md
+
+- name: Install podman
+  package:
+    name: podman
+    state: present
+
+- name: Install podman-docker
+  package:
+    name: podman-docker
+    state: present
+
+# Required for user-space networking
+- name: Install slirp4netns
+  package:
+    name: slirp4netns
+    state: present
+
+# Recommended instead of the default VFS file system
+- name: Install fuse-overlayfs
+  package:
+    name: fuse-overlayfs
+    state: present
+
+- name: Copy global configuration file for storage driver
+  copy:
+    src: podman/storage.conf
+    dest: /etc/containers/storage.conf
+    owner: root
+    group: root
+    mode: 0644


### PR DESCRIPTION
Podman is a container runtime that supports running containers without root access. This allows us to run it on a shared host like the dev-desktops without compromising the security of the system.

The package for Podman and an alias for `docker` get installed through the system's package manager, as are packages for user-space networking and an alternative storage driver. The storage driver is enabled in a global configuration file so that it applies to all users.