### PR TITLE
Add GNU parallel to dev-desktops

### DIFF
--- a/ansible/roles/dev-desktop/tasks/dependencies.yml
+++ b/ansible/roles/dev-desktop/tasks/dependencies.yml
@@ -54,6 +54,7 @@
       - lldb
       - mold
       - neovim
+      - parallel
       # Necessary for building rr
       - capnproto
       - libcapnp-dev


### PR DESCRIPTION
GNU parallel is just a concurrent xargs, useful to use the beasts that are the dev desktops