### PR TITLE
Handle purge requests for crates.io

### DIFF
--- a/terragrunt/modules/crates-io/compute-static/src/main.rs
+++ b/terragrunt/modules/crates-io/compute-static/src/main.rs
@@ -14,8 +14,14 @@ mod log_line;
 #[fastly::main]
 fn main(request: Request) -> Result<Response, Error> {
     let config = Config::from_dictionary();
-    init_logging(&config);
 
+    // Forward purge requests immediately to a backend
+    // https://developer.fastly.com/learning/concepts/purging/#forwarding-purge-requests
+    if request.get_method() == "PURGE" {
+        return send_request_to_s3(&config, &request);
+    }
+
+    init_logging(&config);
     let mut log = collect_request(&request);
 
     let has_origin_header = request.get_header("Origin").is_some();


### PR DESCRIPTION
When content for `static.crates.io` is purged from Fastly's cache, a request with HTTP method `PURGE` is sent to the Compute@Edge function. Since we don't allow this request method and respond with an HTTP 401 response, purging the cache failed.