### PR TITLE
Increase size of bastion instance

### DIFF
--- a/terraform/bastion/.terraform.lock.hcl
+++ b/terraform/bastion/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "~> 3.59"
   hashes = [
     "h1:6JlihvRdEq02BzOZ7P7De2W5HH41ASVYg5I5Z2lAhIo=",
+    "h1:cN7sJwv3gwrkgbZS40vbV6IOnwHY0WWsUKPQf1gErv4=",
     "zh:0b33154c805071af15839184f3faafeb1549d26a2f1fe721393461790c5ddb46",
     "zh:1c5c6793cbec328394c6dda686298d9f6bb7b4c6a39e3dc48dc3035dea9aeda0",
     "zh:20b590b9d9f0a18fdc9f0fb18bb2d9d5349b14039899ecf66e4ae5513606405b",
@@ -25,6 +26,7 @@ provider "registry.terraform.io/hashicorp/dns" {
   constraints = "~> 3.2"
   hashes = [
     "h1:Qo7hi4WZHZsvtuJ27Owl1XiVlpanXvYFEG+ne6oDSaw=",
+    "h1:bGDbmpidD9CB9kWU1BGUVFPi/ZCvvlT5+iAvPw68Ho0=",
     "zh:0246c961c7c9f5ef506911b3a279caebd7892d7187797f0d4f16591c438604d5",
     "zh:545f7c18f916197d7f39d7de12f6022f943fddb46cf05c9b20fee9d910f04535",
     "zh:5c2c8ad5dc7133de4e203b595c32387b9345e4f4a5b6b819167dc0251039257f",

--- a/terraform/bastion/instance.tf
+++ b/terraform/bastion/instance.tf
@@ -52,7 +52,7 @@ data "aws_ami" "ubuntu_bionic" {
 
 resource "aws_instance" "bastion" {
   ami                     = data.aws_ami.ubuntu_bionic.id
-  instance_type           = "t3a.nano"
+  instance_type           = "t3a.micro"
   key_name                = data.terraform_remote_state.shared.outputs.master_ec2_key_pair
   ebs_optimized           = true
   disable_api_termination = true


### PR DESCRIPTION
The bastion instance was running very close to its memory limit, which caused issues when installing the Datadog agent on the machine. The instance has been resized to the next bigger size to avoid any more instabilities.