### PR TITLE
Create CNAME for fedi.crates.io

### DIFF
--- a/terraform/dns/.terraform.lock.hcl
+++ b/terraform/dns/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.28.0"
   constraints = "~> 4.28"
   hashes = [
+    "h1:OsPtt0JGl70xbY2+V/ai0d+Jk2p7pvkW8h9IKhIr288=",
     "h1:TXCUuuaf2q54C43bxSNiF9g+cxTr8zqEZem0pW15cjE=",
     "zh:1d4806e50971d2cd565273cedf3206e38931677a6f546cf2b9fb140b52b80604",
     "zh:3f076791002b8afa5ba2d2038f1e1db5956022327eb5242152723ed410ae4571",

--- a/terraform/dns/crates.io.tf
+++ b/terraform/dns/crates.io.tf
@@ -11,6 +11,7 @@ module "crates_io" {
   ttl     = 300
 
   CNAME = {
+    "fedi"   = ["vip.masto.host"]
     "status" = ["pvbm341xnpgm.stspg-customer.com"],
     "doc"    = ["rust-lang.github.io"], # https://github.com/rust-lang/cargo/tree/gh-pages
   }


### PR DESCRIPTION
The crates.io team plans to use Mastodon for status updates in the feature and has rented its own Mastodon server for this. A new CNAME has been created under the `crates.io` domain that points to this host.

See https://github.com/rust-lang/crates.io/issues/6877 for more details.