### PR TITLE
Deploy custom role for Wiz integration

### DIFF
--- a/terragrunt/modules/wiz/_terraform.tf
+++ b/terragrunt/modules/wiz/_terraform.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = "~> 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.20"
+    }
+  }
+}
+

--- a/terragrunt/modules/wiz/main.tf
+++ b/terragrunt/modules/wiz/main.tf
@@ -121,8 +121,6 @@ resource "aws_iam_role_policy" "tf-policy" {
         "Action" : [
           "ec2:CopySnapshot",
           "ec2:CreateSnapshot",
-          "kms:CreateKey",
-          "kms:DescribeKey",
           "ec2:GetEbsEncryptionByDefault",
           "ec2:DescribeSnapshots"
         ],
@@ -143,19 +141,6 @@ resource "aws_iam_role_policy" "tf-policy" {
           "arn:aws:kms:*:*:alias/wizKey",
           "arn:aws:kms:*:*:key/*"
         ]
-      },
-      {
-        "Action" : [
-          "kms:CreateGrant",
-          "kms:ReEncryptFrom"
-        ],
-        "Condition" : {
-          "StringLike" : {
-            "kms:ViaService" : "ec2.*.amazonaws.com"
-          }
-        },
-        "Effect" : "Allow",
-        "Resource" : "*"
       },
       {
         "Action" : [

--- a/terragrunt/modules/wiz/main.tf
+++ b/terragrunt/modules/wiz/main.tf
@@ -170,16 +170,11 @@ resource "aws_iam_role_policy" "tf-policy" {
       },
       {
         "Action" : [
-          "s3:*",
+          "s3:GetObject"
         ],
         "Effect" : "Deny",
         "Resource" : [
-          "arn:aws:s3:::*terraform*",
-          "arn:aws:s3:::*tfstate*",
-          "arn:aws:s3:::*tf?state*",
-          "arn:aws:s3:::*cloudtrail*",
-          "arn:aws:s3:::elasticbeanstalk-*",
-          "arn:aws:s3:::rust-release-keys",
+          "*"
         ],
         "Sid" : "WizAccessS3"
       }

--- a/terragrunt/modules/wiz/main.tf
+++ b/terragrunt/modules/wiz/main.tf
@@ -1,6 +1,205 @@
-module "wiz" {
-  source        = "https://s3-us-east-2.amazonaws.com/wizio-public/deployment-v2/aws/wiz-aws-native-terraform-terraform-module.zip"
-  remote-arn    = "arn:aws:iam::830522659852:role/prod-us43-AssumeRoleDelegator"
-  external-id   = "fc959d31-537c-4108-8b87-9af9e0c9b8d2"
-  data-scanning = false
+resource "aws_iam_role_policy" "tf-policy" {
+  name = "WizCustomPolicy"
+  role = aws_iam_role.user-role-tf.id
+
+  policy = jsonencode({
+    "Statement" : [
+      {
+        "Action" : [
+          "acm:GetCertificate",
+          "apigateway:GET",
+          "backup:DescribeGlobalSettings",
+          "backup:GetBackupVaultAccessPolicy",
+          "backup:GetBackupVaultNotifications",
+          "backup:ListBackupVaults",
+          "backup:ListTags",
+          "cloudtrail:GetInsightSelectors",
+          "cloudtrail:ListTrails",
+          "codebuild:BatchGetProjects",
+          "codebuild:GetResourcePolicy",
+          "codebuild:ListProjects",
+          "cognito-identity:DescribeIdentityPool",
+          "connect:ListInstances",
+          "connect:ListInstanceAttributes",
+          "connect:ListInstanceStorageConfigs",
+          "connect:ListSecurityKeys",
+          "connect:ListLexBots",
+          "connect:ListLambdaFunctions",
+          "connect:ListApprovedOrigins",
+          "connect:ListIntegrationAssociations",
+          "dynamodb:DescribeExport",
+          "dynamodb:DescribeKinesisStreamingDestination",
+          "dynamodb:ListExports",
+          "ec2:GetEbsEncryptionByDefault",
+          "ec2:SearchTransitGatewayRoutes",
+          "ecr:BatchGetImage",
+          "ecr:DescribeImages",
+          "ecr:GetAuthorizationToken",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:ListTagsForResource",
+          "ecr:GetRegistryPolicy",
+          "ecr:DescribeRegistry",
+          "ecr-public:BatchGetImage",
+          "ecr-public:DescribeImages",
+          "ecr-public:GetAuthorizationToken",
+          "ecr-public:GetDownloadUrlForLayer",
+          "ecr-public:ListTagsForResource",
+          "ecr-public:GetRegistryPolicy",
+          "eks:ListTagsForResource",
+          "elasticfilesystem:DescribeAccessPoints",
+          "elasticfilesystem:DescribeFileSystemPolicy",
+          "elasticmapreduce:GetAutoTerminationPolicy",
+          "elasticmapreduce:GetManagedScalingPolicy",
+          "emr-serverless:ListApplications",
+          "emr-serverless:ListJobRuns",
+          "ssm:GetDocument",
+          "ssm:GetServiceSetting",
+          "glacier:GetDataRetrievalPolicy",
+          "glacier:GetVaultLock",
+          "glue:GetConnection",
+          "glue:GetSecurityConfiguration",
+          "glue:GetTags",
+          "health:DescribeAffectedAccountsForOrganization",
+          "health:DescribeAffectedEntities",
+          "health:DescribeAffectedEntitiesForOrganization",
+          "health:DescribeEntityAggregates",
+          "health:DescribeEventAggregates",
+          "health:DescribeEventDetails",
+          "health:DescribeEventDetailsForOrganization",
+          "health:DescribeEventTypes",
+          "health:DescribeEvents",
+          "health:DescribeEventsForOrganization",
+          "health:DescribeHealthServiceStatusForOrganization",
+          "kafka:ListClusters",
+          "kendra:DescribeDataSource",
+          "kendra:DescribeIndex",
+          "kendra:ListDataSources",
+          "kendra:ListIndices",
+          "kendra:ListTagsForResource",
+          "kinesisanalytics:ListApplications",
+          "kinesisanalytics:DescribeApplication",
+          "kinesisanalytics:ListTagsForResource",
+          "kinesisvideo:ListStreams",
+          "kinesisvideo:ListTagsForStream",
+          "kinesisvideo:GetDataEndpoint",
+          "kms:GetKeyRotationStatus",
+          "kms:ListResourceTags",
+          "lambda:GetFunction",
+          "lambda:GetLayerVersion",
+          "logs:ListTagsForResource",
+          "profile:GetDomain",
+          "profile:ListDomains",
+          "profile:ListIntegrations",
+          "s3:GetBucketNotification",
+          "s3:GetMultiRegionAccessPointPolicy",
+          "s3:ListMultiRegionAccessPoints",
+          "ses:DescribeActiveReceiptRuleSet",
+          "ses:GetAccount",
+          "ses:GetConfigurationSet",
+          "ses:GetConfigurationSetEventDestinations",
+          "ses:GetDedicatedIps",
+          "ses:GetEmailIdentity",
+          "ses:ListConfigurationSets",
+          "ses:ListDedicatedIpPools",
+          "ses:ListReceiptFilters",
+          "voiceid:DescribeDomain",
+          "wafv2:GetLoggingConfiguration",
+          "wafv2:GetWebACLForResource",
+          "wisdom:GetAssistant",
+          "macie2:ListFindings",
+          "macie2:GetFindings",
+          "identitystore:List*",
+          "identitystore:Describe*",
+          "sso-directory:Describe*",
+          "sso-directory:ListMembersInGroup",
+          "cloudwatch:GetMetricStatistics"
+        ],
+        "Effect" : "Allow",
+        "Resource" : "*"
+      },
+      {
+        "Action" : [
+          "ec2:CopySnapshot",
+          "ec2:CreateSnapshot",
+          "kms:CreateKey",
+          "kms:DescribeKey",
+          "ec2:GetEbsEncryptionByDefault",
+          "ec2:DescribeSnapshots"
+        ],
+        "Effect" : "Allow",
+        "Resource" : "*"
+      },
+      {
+        "Action" : [
+          "ec2:CreateTags"
+        ],
+        "Effect" : "Allow",
+        "Resource" : "arn:aws:ec2:*::snapshot/*"
+      },
+      {
+        "Action" : "kms:CreateAlias",
+        "Effect" : "Allow",
+        "Resource" : [
+          "arn:aws:kms:*:*:alias/wizKey",
+          "arn:aws:kms:*:*:key/*"
+        ]
+      },
+      {
+        "Action" : [
+          "kms:CreateGrant",
+          "kms:ReEncryptFrom"
+        ],
+        "Condition" : {
+          "StringLike" : {
+            "kms:ViaService" : "ec2.*.amazonaws.com"
+          }
+        },
+        "Effect" : "Allow",
+        "Resource" : "*"
+      },
+      {
+        "Action" : [
+          "kms:GetKeyPolicy",
+          "kms:PutKeyPolicy"
+        ],
+        "Condition" : {
+          "StringEquals" : {
+            "aws:ResourceTag/wiz" : "auto-gen-cmk"
+          }
+        },
+        "Effect" : "Allow",
+        "Resource" : "*"
+      },
+      {
+        "Action" : [
+          "ec2:DeleteSnapshot",
+          "ec2:ModifySnapshotAttribute"
+        ],
+        "Condition" : {
+          "StringEquals" : {
+            "ec2:ResourceTag/wiz" : "auto-gen-snapshot"
+          }
+        },
+        "Effect" : "Allow",
+        "Resource" : "*"
+      },
+      {
+        "Action" : [
+          "s3:*",
+        ],
+        "Effect" : "Deny",
+        "Resource" : [
+          "arn:aws:s3:::*terraform*",
+          "arn:aws:s3:::*tfstate*",
+          "arn:aws:s3:::*tf?state*",
+          "arn:aws:s3:::*cloudtrail*",
+          "arn:aws:s3:::elasticbeanstalk-*",
+          "arn:aws:s3:::rust-release-keys",
+        ],
+        "Sid" : "WizAccessS3"
+      }
+    ]
+    "Version" : "2012-10-17"
+    }
+  )
 }

--- a/terragrunt/modules/wiz/outputs.tf
+++ b/terragrunt/modules/wiz/outputs.tf
@@ -1,3 +1,3 @@
-output "wiz_connector_arn" {
-  value = module.wiz.role_arn
+output "role_arn" {
+  value = aws_iam_role.user-role-tf.arn
 }

--- a/terragrunt/modules/wiz/role.tf
+++ b/terragrunt/modules/wiz/role.tf
@@ -1,0 +1,39 @@
+resource "aws_iam_role" "user-role-tf" {
+  name = var.rolename
+  assume_role_policy = jsonencode(
+    {
+      "Version" : "2012-10-17",
+      "Statement" : [
+        {
+          "Effect" : "Allow",
+          "Principal" : {
+            "AWS" : var.remote-arn
+          },
+          "Action" : "sts:AssumeRole",
+          "Condition" : {
+            "StringEquals" : {
+              "sts:ExternalId" : var.external-id
+            }
+          }
+        }
+      ]
+    }
+  )
+}
+
+data "aws_iam_policy" "view_only_access" {
+  arn = "arn:aws:iam::aws:policy/job-function/ViewOnlyAccess"
+}
+
+data "aws_iam_policy" "security_audit" {
+  arn = "arn:aws:iam::aws:policy/SecurityAudit"
+}
+
+resource "aws_iam_role_policy_attachment" "view_only_access_role_policy_attach" {
+  role       = aws_iam_role.user-role-tf.name
+  policy_arn = data.aws_iam_policy.view_only_access.arn
+}
+resource "aws_iam_role_policy_attachment" "security_audit_role_policy_attach" {
+  role       = aws_iam_role.user-role-tf.name
+  policy_arn = data.aws_iam_policy.security_audit.arn
+}

--- a/terragrunt/modules/wiz/variables.tf
+++ b/terragrunt/modules/wiz/variables.tf
@@ -1,0 +1,14 @@
+variable "external-id" {
+  type    = string
+  default = "fc959d31-537c-4108-8b87-9af9e0c9b8d2"
+}
+
+variable "rolename" {
+  type    = string
+  default = "WizAccess-Role"
+}
+
+variable "remote-arn" {
+  type    = string
+  default = "arn:aws:iam::830522659852:role/prod-us43-AssumeRoleDelegator"
+}


### PR DESCRIPTION
Wiz provides a managed AWS role for its integration. The role grants Wiz access to certain S3 buckets that we want to exclude from its analysis. Namely, buckets contain Terraform state files and the Rust release keys. The provided AWS role has been copied into the project and modified to deny access to those buckets.