### PR TITLE
Link to documentation from MOTD

### DIFF
--- a/ansible/roles/dev-desktop/templates/motd_rules
+++ b/ansible/roles/dev-desktop/templates/motd_rules
@@ -1,1 +1,3 @@
 By accessing and making use of this Cloud Compute Program resource, you are agreeing that you have both read and will abide by its official Access Agreement. The Access Agreement can be found at https://foundation.rust-lang.org/policies/cloud-compute-program/.
+
+Documentation on how to set up and use this machine can be found at: https://forge.rust-lang.org/infra/docs/dev-desktop.html


### PR DESCRIPTION
The "message of the day" is displayed whenever a user connects to the machine, and is a good place to link to the user documentation in Forge.