### PR TITLE
add second docs.rs build process to metrics collection

### DIFF
--- a/ansible/playbooks/monitoring.yml
+++ b/ansible/playbooks/monitoring.yml
@@ -82,6 +82,13 @@
             - targets:
               - docs.rs:443
 
+        - job_name: docsrs-builder
+          metrics_path: /about/metrics/instance.builder
+          scheme: https
+          static_configs:
+            - targets:
+              - docs.rs:443
+
         - job_name: perfrlo
           metrics_path: /perf/metrics
           scheme: https


### PR DESCRIPTION
after we got a bigger EC2 machine for docs.rs, we are setting up a second build-process to parallize builds. 

This gives us a bigger advantage than just having faster non-parallel builds. 

I don't know anything about the network topoligy between prometheus & the docs.rs server, so the change here is an untested guess. 

The second build-server exposes a small HTTP server at the port where it returns the prometheus metrics. 

If this doesn't work we could also configure a special path in the nginx config that proxies the request to the second build process. 