### PR TITLE
also forward referer header to docs.rs servers

### DIFF
--- a/terraform/docs-rs/cloudfront.tf
+++ b/terraform/docs-rs/cloudfront.tf
@@ -54,7 +54,7 @@ resource "aws_cloudfront_origin_request_policy" "docs_rs" {
   headers_config {
     header_behavior = "whitelist"
     headers {
-      items = ["User-Agent"]
+      items = ["User-Agent", "Referer"]
     }
   }
 


### PR DESCRIPTION
as a follow-up to https://github.com/rust-lang/simpleinfra/pull/344 , related to https://github.com/rust-lang/docs.rs/pull/2198. 

