### PR TITLE
Pass Accept-Encoding header to origin

### DIFF
--- a/terragrunt/modules/crates-io/cloudfront-webapp.tf
+++ b/terragrunt/modules/crates-io/cloudfront-webapp.tf
@@ -32,6 +32,9 @@ resource "aws_cloudfront_distribution" "webapp" {
         // The crates.io website and API respond with different content based
         // on what the client is accepting (i.e. HTML, JSON...)
         "Accept",
+        // Pass the encoding header along so the origin can respond with
+        // compressed content if the client supports it.
+        "Accept-Encoding",
         // The header needs to be forwarded so it can be stored in the logs and
         // analyzed for abuse prevention and rate limiting purposes.
         "Referer",


### PR DESCRIPTION
The Accept-Encoding header is now passed to the origin so that it can respond with compressed responses.

This fixes an inconsistency with the backend, which prefers Brotli compression while CloudFront prefers gzip. Because the header is now passed to the origin, the Brotli-compressed response from the origin is passed through to the client. Previously, CloudFront would fetch uncompressed resources and compress them on the fly using gzip.

cc @Turbo87