### PR TITLE
Remove unused cache behavior

### DIFF
--- a/terragrunt/modules/crates-io/cloudfront-webapp.tf
+++ b/terragrunt/modules/crates-io/cloudfront-webapp.tf
@@ -54,24 +54,6 @@ resource "aws_cloudfront_distribution" "webapp" {
     }
   }
 
-  // Cache assets ignoring headers, query strings and cookies.
-  ordered_cache_behavior {
-    path_pattern           = "/assets"
-    target_origin_id       = "heroku"
-    allowed_methods        = ["GET", "HEAD"]
-    cached_methods         = ["GET", "HEAD"]
-    compress               = true
-    viewer_protocol_policy = "redirect-to-https"
-
-    forwarded_values {
-      headers      = []
-      query_string = false
-      cookies {
-        forward = "none"
-      }
-    }
-  }
-
   origin {
     origin_id   = "heroku"
     domain_name = var.webapp_origin_domain


### PR DESCRIPTION
The custom cache behavior for `/assets` was never used, since the pattern matches only the specific `/assets` URL and not any resources served under it (e.g. `/assets/foo`). This was discovered while investigating the inconsistencies in #356.

Since the configuration was never used in the first place, we are removing it to remove some complexity.

cc @Turbo87