### PR TITLE
crates.io: Add support for download URLs without placeholders

### DIFF
--- a/terragrunt/modules/crates-io/cloudfront-functions/static-router.js
+++ b/terragrunt/modules/crates-io/cloudfront-functions/static-router.js
@@ -7,5 +7,15 @@ function handler(event) {
         request.uri = request.uri.replace("+", "%2B");
     }
 
+    // cargo versions before 1.24 don't support placeholders in the `dl` field
+    // of the index, so we need to rewrite the download URL to point to the
+    // crate file instead.
+    var match = request.uri.match(/^\/crates\/([^\/]+)\/([^\/]+)\/download$/);
+    if (match) {
+        var crate = match[1];
+        var version = match[2];
+        request.uri = `/crates/${crate}/${crate}-${version}.crate`;
+    }
+
     return request;
 }

--- a/terragrunt/modules/crates-io/compute-static/Cargo.lock
+++ b/terragrunt/modules/crates-io/compute-static/Cargo.lock
@@ -58,6 +58,8 @@ dependencies = [
  "fastly",
  "log",
  "log-fastly",
+ "once_cell",
+ "regex",
  "serde",
  "serde_json",
  "time",
@@ -304,6 +306,12 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "once_cell"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "opaque-debug"

--- a/terragrunt/modules/crates-io/compute-static/Cargo.toml
+++ b/terragrunt/modules/crates-io/compute-static/Cargo.toml
@@ -19,6 +19,8 @@ derive_builder = "0.12.0"
 fastly = "0.9.1"
 log = "0.4.17"
 log-fastly = "0.9.1"
+once_cell = "1.18.0"
+regex = "1.7.1"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.92"
 time = { version = "0.3.17", features = ["serde-human-readable"] }


### PR DESCRIPTION
In https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/placeholders.20in.20index.20config.2Ejson I asked what cargo version added support for placeholders in the `dl` config field of the package index and apparently the answer is Rust 1.24.

In the future the crates.io team would like to move crate file downloads directly to the CDN, instead of them having to go through our own backend, since that has proven to be a somewhat problematic bottleneck. To be able to support earlier cargo versions, this PR introduces URL rewriting for `/crates/:crate/:version/download` requests for the CloudFront and Fastly CDNs.

This should allow us to change https://github.com/rust-lang/crates.io-index/blob/27423df2d3aecc0642d64eee2b321ffa1e6860ba/config.json#L2 to `"dl": "https://static.crates.io/crates"` in the future.