### PR TITLE
Switch to AWS-managed policy for billing access

### DIFF
--- a/terraform/team-members-access/.terraform.lock.hcl
+++ b/terraform/team-members-access/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "~> 3.59"
   hashes = [
     "h1:6JlihvRdEq02BzOZ7P7De2W5HH41ASVYg5I5Z2lAhIo=",
+    "h1:cN7sJwv3gwrkgbZS40vbV6IOnwHY0WWsUKPQf1gErv4=",
     "zh:0b33154c805071af15839184f3faafeb1549d26a2f1fe721393461790c5ddb46",
     "zh:1c5c6793cbec328394c6dda686298d9f6bb7b4c6a39e3dc48dc3035dea9aeda0",
     "zh:20b590b9d9f0a18fdc9f0fb18bb2d9d5349b14039899ecf66e4ae5513606405b",

--- a/terraform/team-members-access/foundation.tf
+++ b/terraform/team-members-access/foundation.tf
@@ -50,16 +50,7 @@ resource "aws_iam_group_policy" "foundation" {
       {
         Effect = "Allow"
         Action = [
-          "aws-portal:*Usage",
-          "aws-portal:*Billing",
-          "aws-portal:*PaymentMethods",
-          "ce:*",
-          "purchase-orders:*",
-          "tax:*",
-          "cur:DescribeReportDefinitions",
-          "cur:PutReportDefinition",
-          "cur:DeleteReportDefinition",
-          "cur:ModifyReportDefinition"
+          "Billing"
         ]
         Resource = "*"
       },


### PR DESCRIPTION
AWS is deprecating[^1] the `aws-portal` prefix and two specific actions related to purchase orders. We have been getting reminders to migrate our policies to new, granular permissions. Comparing our custom policy with the AWS-managed Billing[^2] policy, it seems we can just adopt that and simplify our configuration.

Fixes #359

[^1]: https://aws.amazon.com/blogs/aws-cloud-financial-management/changes-to-aws-billing-cost-management-and-account-consoles-permissions/
[^2]: https://docs.aws.amazon.com/aws-managed-policy/latest/reference/Billing.html