### PR TITLE
Remove billing access from legacy account

### DIFF
--- a/terraform/team-members-access/foundation.tf
+++ b/terraform/team-members-access/foundation.tf
@@ -46,31 +46,6 @@ resource "aws_iam_group_policy" "foundation" {
         Action   = ["support:*"]
         Resource = "*"
       },
-      // Billing-related resources
-      {
-        Effect = "Allow"
-        Action = [
-          "aws-portal:*Usage",
-          "aws-portal:*Billing",
-          "aws-portal:*PaymentMethods",
-          "ce:*",
-          "purchase-orders:*",
-          "tax:*",
-          "cur:DescribeReportDefinitions",
-          "cur:PutReportDefinition",
-          "cur:DeleteReportDefinition",
-          "cur:ModifyReportDefinition"
-        ]
-        Resource = "*"
-      },
-      // But not account settings
-      {
-        Effect = "Deny"
-        Action = [
-          "aws-portal:*Account",
-        ]
-        Resource = "*"
-      },
       // Access to the Route 53 console
       {
         Effect = "Allow"


### PR DESCRIPTION
The staff of the Rust Foundation has access to the billing portal on AWS, historically through the legacy account and now through the new root account that consolidates billing. Instead of updating the custom policy to remove deprecated policies, we are going to remove billing access from the legacy altogether since it is no longer required.

Fixes #359