### PR TITLE
set a custom auth header when requesting docs.rs origin servers

### DIFF
--- a/terraform/docs-rs/cloudfront.tf
+++ b/terraform/docs-rs/cloudfront.tf
@@ -67,6 +67,11 @@ resource "aws_cloudfront_origin_request_policy" "docs_rs" {
   }
 }
 
+resource "random_password" "origin_auth" {
+  length  = 32
+  special = false
+}
+
 resource "aws_cloudfront_distribution" "webapp" {
   comment = local.domain_name
 
@@ -107,7 +112,7 @@ resource "aws_cloudfront_distribution" "webapp" {
 
     custom_header {
       name  = "X-Origin-Auth"
-      value = "some_secret_value"
+      value = random_password.origin_auth.result
     }
   }
 

--- a/terraform/docs-rs/cloudfront.tf
+++ b/terraform/docs-rs/cloudfront.tf
@@ -104,6 +104,11 @@ resource "aws_cloudfront_distribution" "webapp" {
       origin_protocol_policy = "http-only"
       origin_ssl_protocols   = ["TLSv1.2"]
     }
+
+    custom_header {
+      name  = "X-Origin-Auth"
+      value = "some_secret_value"
+    }
   }
 
   restrictions {


### PR DESCRIPTION
This is coming from [this discussion on zulip](https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/forbid.20docs.2Ers.20direct.20server.20access.20.28web.29) 

`custom_header` is not documented, but it exists:  https://github.com/terraform-aws-modules/terraform-aws-cloudfront/issues/69, linting seems to accept it too. 

The value for the secret has to come from another source. 

On other thing that is also missing: adding the secret value to the new docs.rs setup which is managed by simpleinfra here.

