### PR TITLE
Create AWS accounts for crates.io

### DIFF
--- a/terragrunt/modules/aws-organization/accounts.tf
+++ b/terragrunt/modules/aws-organization/accounts.tf
@@ -12,6 +12,16 @@ resource "aws_organizations_account" "legacy" {
   email = "admin@rust-lang.org"
 }
 
+resource "aws_organizations_account" "crates_io_staging" {
+  name  = "crates-io-staging"
+  email = "admin+crates-io-staging@rust-lang.org"
+}
+
+resource "aws_organizations_account" "crates_io_prod" {
+  name  = "crates-io-prod"
+  email = "admin+crates-io-prod@rust-lang.org"
+}
+
 resource "aws_organizations_account" "docs_rs_staging" {
   name  = "docs-rs-staging"
   email = "admin+docs-rs-staging@rust-lang.org"

--- a/terragrunt/modules/aws-organization/groups.tf
+++ b/terragrunt/modules/aws-organization/groups.tf
@@ -28,6 +28,13 @@ resource "aws_identitystore_group" "billing" {
   description  = "People with access to the billing portal"
 }
 
+resource "aws_identitystore_group" "crates_io" {
+  identity_store_id = local.identity_store_id
+
+  display_name = "crates-io"
+  description  = "The crates.io team"
+}
+
 # The different permission sets a group may have assigned to it
 
 resource "aws_ssoadmin_permission_set" "administrator_access" {
@@ -110,6 +117,30 @@ locals {
         permissions : [aws_ssoadmin_permission_set.billing_access] },
         { group : aws_identitystore_group.infra,
         permissions : [aws_ssoadmin_permission_set.view_only_access] }
+      ]
+    },
+    # crates-io Staging
+    {
+      account : aws_organizations_account.crates_io_staging,
+      groups : [
+        { group : aws_identitystore_group.infra-admins,
+        permissions : [aws_ssoadmin_permission_set.view_only_access, aws_ssoadmin_permission_set.administrator_access] },
+        { group : aws_identitystore_group.infra,
+        permissions : [aws_ssoadmin_permission_set.view_only_access, aws_ssoadmin_permission_set.administrator_access] },
+        { group : aws_identitystore_group.crates_io,
+        permissions : [aws_ssoadmin_permission_set.view_only_access] },
+      ]
+    },
+    # crates-io Production
+    {
+      account : aws_organizations_account.crates_io_prod,
+      groups : [
+        { group : aws_identitystore_group.infra-admins,
+        permissions : [aws_ssoadmin_permission_set.view_only_access, aws_ssoadmin_permission_set.administrator_access] },
+        { group : aws_identitystore_group.infra,
+        permissions : [aws_ssoadmin_permission_set.view_only_access] },
+        { group : aws_identitystore_group.crates_io,
+        permissions : [aws_ssoadmin_permission_set.view_only_access] },
       ]
     },
     # docs-rs Staging


### PR DESCRIPTION
We are planning[^1] to count crate downloads using CDN logs. This requires new infrastructure, namely a SQS queue into which S3 can publish events and that crates.io can monitor.

[^1]: https://github.com/rust-lang/simpleinfra/issues/372