### PR TITLE
Initial SQS queue + user policy

### DIFF
--- a/terragrunt/modules/crates-io-logs/main.tf
+++ b/terragrunt/modules/crates-io-logs/main.tf
@@ -28,7 +28,7 @@ data "aws_iam_policy_document" "s3_push_to_queue" {
     condition {
       test     = "StringEquals"
       variable = "aws:SourceAccount"
-      values   = [data.aws_arn.account]
+      values   = [data.aws_arn.src_bucket.account]
     }
   }
 }

--- a/terragrunt/modules/crates-io-logs/main.tf
+++ b/terragrunt/modules/crates-io-logs/main.tf
@@ -1,0 +1,72 @@
+resource "aws_sqs_queue" "log_event_queue" {
+  name                      = "cdn-log-queue"
+  receive_wait_time_seconds = 20
+}
+
+resource "aws_sqs_queue_policy" "s3_push" {
+  queue_url = aws_sqs_queue.log_event_queue.id
+  policy    = data.aws_iam_policy_document.s3_push_to_queue.json
+}
+
+data "aws_iam_policy_document" "s3_push_to_queue" {
+  statement {
+    sid    = "allow-s3-to-push-events"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["s3.amazonaws.com"]
+    }
+
+    actions = ["sqs:SendMessage"]
+
+    resources = [aws_sqs_queue.log_event_queue.arn]
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = [data.aws_arn.src_bucket.arn]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_arn.account]
+    }
+  }
+}
+
+data "aws_arn" "src_bucket" {
+  arn = var.src_log_bucket_arn
+}
+
+variable "src_log_bucket_arn" {
+  type        = string
+  description = "Bucket ARN which will send events to the SQS queue"
+}
+
+resource "aws_iam_user" "heroku_access" {
+  name = "crates-io-heroku-access"
+}
+
+resource "aws_iam_access_key" "crates_io" {
+  user = aws_iam_user.heroku_access
+}
+
+resouce "aws_iam_user_policy" "sqs_read" {
+  name = "heroku-access"
+  user = aws_iam_user.heroku_access.name
+}
+
+data "aws_iam_policy_document" "heroku_access" {
+  statement {
+    sid    = "allow-sqs"
+    effect = "Allow"
+
+    actions = [
+      "sqs:GetQueueAttributes",
+      "sqs:DeleteMessage",
+      "sqs:DeleteMessageBatch",
+      "sqs:ReceiveMessage",
+    ]
+
+    resources = [aws_sqs_queue.log_event_queue.arn]
+  }
+}


### PR DESCRIPTION
This adds a new terragrunt module for the new crates.io account(s) and puts the SQS queue and related IAM policies into the module. However, it does not yet wire up the account or try to deploy this -- I haven't connected those bits yet and getting terragrunt to cooperate with me is usually pretty finicky. Hopefully this helps as a starting point though.

Remaining steps:

* Confirm whether the IAM user + hardcoded, non-rotating access key is the best way for Heroku crates.io to access this account (at least in the short term)
* Confirm this all actually works
* Create the resources

Possibly:

* Figure out if we want a dead letter queue. This would prevent a message crates.io doesn't know how to read from blocking all other messages in the queue (since it'll constantly fail and crates.io shouldn't call DeleteMessage on it). But, it's more complexity and it's not obvious that any particular message should be any different than others. I think it's not unreasonable to punt on setting this additional infrastructure up for now.
* Figure out alarming/metrics -- maybe crates.io should self-drive this with the queue metadata API, maybe we want to wire up datadog/grafana to read from this account.

IMO if we can, let's deploy this before we actually finish wiring up s3 -- crates.io can start reading from the queue and such early that way and kick the tires.

cc https://github.com/rust-lang/simpleinfra/issues/372

r? @jdno cc @Turbo87 