### PR TITLE
Deploy SQS queue for crates.io to staging

### DIFF
--- a/terragrunt/accounts/crates-io-staging/account.json
+++ b/terragrunt/accounts/crates-io-staging/account.json
@@ -1,0 +1,6 @@
+{
+    "aws": {
+        "profile": "crates-io-staging",
+        "region": "us-east-2"
+    }
+}

--- a/terragrunt/accounts/crates-io-staging/crates-io-logs/.terraform.lock.hcl
+++ b/terragrunt/accounts/crates-io-staging/crates-io-logs/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.67.0"
+  constraints = "~> 4.32"
+  hashes = [
+    "h1:5Zfo3GfRSWBaXs4TGQNOflr1XaYj6pRnVJLX5VAjFX4=",
+    "zh:0843017ecc24385f2b45f2c5fce79dc25b258e50d516877b3affee3bef34f060",
+    "zh:19876066cfa60de91834ec569a6448dab8c2518b8a71b5ca870b2444febddac6",
+    "zh:24995686b2ad88c1ffaa242e36eee791fc6070e6144f418048c4ce24d0ba5183",
+    "zh:4a002990b9f4d6d225d82cb2fb8805789ffef791999ee5d9cb1fef579aeff8f1",
+    "zh:559a2b5ace06b878c6de3ecf19b94fbae3512562f7a51e930674b16c2f606e29",
+    "zh:6a07da13b86b9753b95d4d8218f6dae874cf34699bca1470d6effbb4dee7f4b7",
+    "zh:768b3bfd126c3b77dc975c7c0e5db3207e4f9997cf41aa3385c63206242ba043",
+    "zh:7be5177e698d4b547083cc738b977742d70ed68487ce6f49ecd0c94dbf9d1362",
+    "zh:8b562a818915fb0d85959257095251a05c76f3467caa3ba95c583ba5fe043f9b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9c385d03a958b54e2afd5279cd8c7cbdd2d6ca5c7d6a333e61092331f38af7cf",
+    "zh:b3ca45f2821a89af417787df8289cb4314b273d29555ad3b2a5ab98bb4816b3b",
+    "zh:da3c317f1db2469615ab40aa6baba63b5643bae7110ff855277a1fb9d8eb4f2c",
+    "zh:dc6430622a8dc5cdab359a8704aec81d3825ea1d305bbb3bbd032b1c6adfae0c",
+    "zh:fac0d2ddeadf9ec53da87922f666e1e73a603a611c57bcbc4b86ac2821619b1d",
+  ]
+}

--- a/terragrunt/accounts/crates-io-staging/crates-io-logs/terragrunt.hcl
+++ b/terragrunt/accounts/crates-io-staging/crates-io-logs/terragrunt.hcl
@@ -1,0 +1,13 @@
+terraform {
+  source = "../../../..//terragrunt/modules/crates-io-logs"
+}
+
+include {
+  path           = find_in_parent_folders()
+  merge_strategy = "deep"
+}
+
+inputs = {
+  bucket_account = 890664054962
+  bucket_arn = "arn:aws:s3:::rust-staging-crates-io-logs"
+}

--- a/terragrunt/modules/crates-io-logs/README.md
+++ b/terragrunt/modules/crates-io-logs/README.md
@@ -1,0 +1,36 @@
+# Infrastructure to Count Crate Downloads
+
+This module creates the infrastructure that enables [crates.io] to count crate
+downloads asynchronously using request logs from our Content Delivery Networks.
+
+Whenever a new archive with request logs is uploaded to S3, S3 pushes an event
+into a SQS queue. [crates.io] monitors the queue and processes incoming events.
+From the event, it can determine what files to fetch from S3, download and then
+parse them, and update the download counts in the database.
+
+```mermaid
+sequenceDiagram
+	static.crates.io ->> S3: Uploads logs
+	S3 ->> SQS: Queues event
+	crates.io ->> SQS: Pulls event from queue
+	crates.io ->> S3: Fetches new log file
+	crates.io ->> crates.io: Parses log file
+	crates.io ->> crates.io: Updates download counts
+```
+
+See [rust-lang/simpleinfra#372] for a detailed discussion of the design.
+
+## AWS Accounts
+
+The infrastructure for [crates.io] has historically been deployed to the
+`legacy` AWS account. For this infrastructure, new accounts have been created
+that follow the new convention of specialized and isolated accounts for
+services.
+
+This requires the S3 bucket with the request logs in the `legacy` account to
+push events into the SQS queue in a different account. And the [crates.io]
+application needs a second set of AWS credentials to pull events from the
+queue.
+
+[crates.io]: https://crates.io
+[rust-lang/simpleinfra#372]: https://github.com/rust-lang/simpleinfra/issues/372

--- a/terragrunt/modules/crates-io-logs/_terraform.tf
+++ b/terragrunt/modules/crates-io-logs/_terraform.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = "~> 1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.32"
+    }
+  }
+}
+
+variable "bucket_account" {
+  type        = number
+  description = "Account ID of the S3 bucket which will send events to the SQS queue"
+}
+
+variable "bucket_arn" {
+  type        = string
+  description = "ARN of the S3 bucket which will send events to the SQS queue"
+}


### PR DESCRIPTION
The SQS queue that was configured in #377 has been deployed to the new staging account for crates.io that was created in #374. Slight modifications were necessary to the configuration:

  - The resource and human-readable names of the SQS are now identical.
  - The `sid` for policies matches the naming rules of AWS.
  - The input variable has been changed, since the account number is not part of a bucket's ARN and can thus not be extracted from it.

The infrastructure has been deployed with the same version of the Terraform provider for AWS as the other modules in simpleinfra to ensure future compatibility.