### PR TITLE
Send S3 notifications in staging environment

### DIFF
--- a/terragrunt/accounts/crates-io-staging/account.json
+++ b/terragrunt/accounts/crates-io-staging/account.json
@@ -1,6 +1,6 @@
 {
     "aws": {
         "profile": "crates-io-staging",
-        "region": "us-east-2"
+        "region": "us-west-1"
     }
 }

--- a/terragrunt/accounts/legacy/crates-io-staging/crates-io/terragrunt.hcl
+++ b/terragrunt/accounts/legacy/crates-io-staging/crates-io/terragrunt.hcl
@@ -27,4 +27,6 @@ inputs = {
   static_fastly_weight = 100
 
   fastly_customer_id_ssm_parameter = "/staging/crates-io/fastly/customer-id"
+
+  cdn_log_event_queue_arn = "arn:aws:sqs:us-west-1:359172468976:cdn-log-event-queue"
 }

--- a/terragrunt/modules/crates-io-logs/_terraform.tf
+++ b/terragrunt/modules/crates-io-logs/_terraform.tf
@@ -8,13 +8,3 @@ terraform {
     }
   }
 }
-
-variable "bucket_account" {
-  type        = number
-  description = "Account ID of the S3 bucket which will send events to the SQS queue"
-}
-
-variable "bucket_arn" {
-  type        = string
-  description = "ARN of the S3 bucket which will send events to the SQS queue"
-}

--- a/terragrunt/modules/crates-io-logs/outputs.tf
+++ b/terragrunt/modules/crates-io-logs/outputs.tf
@@ -1,0 +1,4 @@
+# ARN of the SQS queue that receives S3 bucket notifications
+output "sqs_queue_arn" {
+  value = aws_sqs_queue.cdn_log_event_queue.arn
+}

--- a/terragrunt/modules/crates-io-logs/variables.tf
+++ b/terragrunt/modules/crates-io-logs/variables.tf
@@ -1,0 +1,9 @@
+variable "bucket_account" {
+  type        = number
+  description = "Account ID of the S3 bucket which will send events to the SQS queue"
+}
+
+variable "bucket_arn" {
+  type        = string
+  description = "ARN of the S3 bucket which will send events to the SQS queue"
+}

--- a/terragrunt/modules/crates-io/_terraform.tf
+++ b/terragrunt/modules/crates-io/_terraform.tf
@@ -102,3 +102,9 @@ variable "fastly_aws_account_id" {
   description = "The AWS account ID that Fastly uses to write logs"
   default     = "717331877981"
 }
+
+variable "cdn_log_event_queue_arn" {
+  # See the `crates-io-logs` module
+  description = "ARN of the SQS queue that receives S3 notifications for CDN logs"
+  type        = string
+}

--- a/terragrunt/modules/crates-io/s3-logs.tf
+++ b/terragrunt/modules/crates-io/s3-logs.tf
@@ -25,3 +25,21 @@ resource "aws_s3_bucket_public_access_block" "logs" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+
+resource "aws_s3_bucket_notification" "cdn_log_event_queue" {
+  bucket = aws_s3_bucket.logs.id
+
+  queue {
+    id            = "cloudfront"
+    events        = ["s3:ObjectCreated:*"]
+    queue_arn     = var.cdn_log_event_queue_arn
+    filter_prefix = "cloudfront/"
+  }
+
+  queue {
+    id            = "fastly"
+    events        = ["s3:ObjectCreated:*"]
+    queue_arn     = var.cdn_log_event_queue_arn
+    filter_prefix = "fastly-requests/"
+  }
+}


### PR DESCRIPTION
The S3 bucket with the CDN logs for crates.io now sends S3 notifications to an SQS queue. This enables crates.io to start counting downloads in the background and not as part of the request-response cycle.