### PR TITLE
Set up crates-io-prod account

### DIFF
--- a/terragrunt/accounts/crates-io-prod/account.json
+++ b/terragrunt/accounts/crates-io-prod/account.json
@@ -1,0 +1,6 @@
+{
+    "aws": {
+        "profile": "crates-io-prod",
+        "region": "us-west-1"
+    }
+}

--- a/terragrunt/accounts/crates-io-prod/datadog-aws/.terraform.lock.hcl
+++ b/terragrunt/accounts/crates-io-prod/datadog-aws/.terraform.lock.hcl
@@ -1,0 +1,47 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/datadog/datadog" {
+  version     = "3.28.0"
+  constraints = "3.28.0"
+  hashes = [
+    "h1:U2XC52fG1dIau+BFD3fNK84AzDrB7quUFVTsa1aSl28=",
+    "zh:0246fe3dac4a271015db05a9a642a79f089f2c618811e2f62cf43d883d14226e",
+    "zh:2ed049e51ac35ff2ee49f34873239f2dd31f69fac9462b6f995c48740951a0f9",
+    "zh:30871283e594f1288ba91fa637ea40c9a63846b83a8dd0d4b332d5f2fa43b63f",
+    "zh:46e81c2aa9e3c0586eaace027cd3612ba0b010a924af6d0db33d715f0e074c28",
+    "zh:68547e2994c81fc91712a36d70b76e850e98d5b7a71e0cd21cf1e9b47b783eed",
+    "zh:6a3930340e3b2c732fe112aa312b6854c0dbd37cabf3b4873672be56bdc8e9c3",
+    "zh:7660d83d137600b7a01113ba8ed8fdeaf2ca4236a093173e75cef6efaea1b934",
+    "zh:8752e3e02003dd7ec49f47eb3f60b287e9bbfd5034bb06384901a4c69f1f9287",
+    "zh:9be1fb6a1d012cdda0c8a7954c8caf73b4b10ec2a926e502a323e1e77f31027a",
+    "zh:b4c066acae2a13b0d1e3a875921fc88caebeca76c9d4b9d0f88b88f4ec8d6c71",
+    "zh:bfd7dca405407c561258a636e7abdda5cf8a6a324353aae64aff6ee624ae59a3",
+    "zh:d8c980a3c7732284a5c0c0b9a22c9432ca344f9b4f94af5df84dfe8ce12036bc",
+    "zh:e4045b7d34f62f676cadcc237c72a12bb1e82d5ce7748c730dd1b82064f12474",
+    "zh:eb9e52d91cb069a30b310b7bfd305862e4a8f86d09d1b9d44ea8cd199a7571ae",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.67.0"
+  constraints = "~> 4.32"
+  hashes = [
+    "h1:5Zfo3GfRSWBaXs4TGQNOflr1XaYj6pRnVJLX5VAjFX4=",
+    "zh:0843017ecc24385f2b45f2c5fce79dc25b258e50d516877b3affee3bef34f060",
+    "zh:19876066cfa60de91834ec569a6448dab8c2518b8a71b5ca870b2444febddac6",
+    "zh:24995686b2ad88c1ffaa242e36eee791fc6070e6144f418048c4ce24d0ba5183",
+    "zh:4a002990b9f4d6d225d82cb2fb8805789ffef791999ee5d9cb1fef579aeff8f1",
+    "zh:559a2b5ace06b878c6de3ecf19b94fbae3512562f7a51e930674b16c2f606e29",
+    "zh:6a07da13b86b9753b95d4d8218f6dae874cf34699bca1470d6effbb4dee7f4b7",
+    "zh:768b3bfd126c3b77dc975c7c0e5db3207e4f9997cf41aa3385c63206242ba043",
+    "zh:7be5177e698d4b547083cc738b977742d70ed68487ce6f49ecd0c94dbf9d1362",
+    "zh:8b562a818915fb0d85959257095251a05c76f3467caa3ba95c583ba5fe043f9b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9c385d03a958b54e2afd5279cd8c7cbdd2d6ca5c7d6a333e61092331f38af7cf",
+    "zh:b3ca45f2821a89af417787df8289cb4314b273d29555ad3b2a5ab98bb4816b3b",
+    "zh:da3c317f1db2469615ab40aa6baba63b5643bae7110ff855277a1fb9d8eb4f2c",
+    "zh:dc6430622a8dc5cdab359a8704aec81d3825ea1d305bbb3bbd032b1c6adfae0c",
+    "zh:fac0d2ddeadf9ec53da87922f666e1e73a603a611c57bcbc4b86ac2821619b1d",
+  ]
+}

--- a/terragrunt/accounts/crates-io-prod/datadog-aws/terragrunt.hcl
+++ b/terragrunt/accounts/crates-io-prod/datadog-aws/terragrunt.hcl
@@ -1,0 +1,12 @@
+terraform {
+  source = "../../../modules//datadog-aws"
+}
+
+include {
+  path           = find_in_parent_folders()
+  merge_strategy = "deep"
+}
+
+inputs = {
+  env = "prod"
+}

--- a/terragrunt/accounts/crates-io-prod/wiz/.terraform.lock.hcl
+++ b/terragrunt/accounts/crates-io-prod/wiz/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.67.0"
+  constraints = "~> 4.20"
+  hashes = [
+    "h1:5Zfo3GfRSWBaXs4TGQNOflr1XaYj6pRnVJLX5VAjFX4=",
+    "zh:0843017ecc24385f2b45f2c5fce79dc25b258e50d516877b3affee3bef34f060",
+    "zh:19876066cfa60de91834ec569a6448dab8c2518b8a71b5ca870b2444febddac6",
+    "zh:24995686b2ad88c1ffaa242e36eee791fc6070e6144f418048c4ce24d0ba5183",
+    "zh:4a002990b9f4d6d225d82cb2fb8805789ffef791999ee5d9cb1fef579aeff8f1",
+    "zh:559a2b5ace06b878c6de3ecf19b94fbae3512562f7a51e930674b16c2f606e29",
+    "zh:6a07da13b86b9753b95d4d8218f6dae874cf34699bca1470d6effbb4dee7f4b7",
+    "zh:768b3bfd126c3b77dc975c7c0e5db3207e4f9997cf41aa3385c63206242ba043",
+    "zh:7be5177e698d4b547083cc738b977742d70ed68487ce6f49ecd0c94dbf9d1362",
+    "zh:8b562a818915fb0d85959257095251a05c76f3467caa3ba95c583ba5fe043f9b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9c385d03a958b54e2afd5279cd8c7cbdd2d6ca5c7d6a333e61092331f38af7cf",
+    "zh:b3ca45f2821a89af417787df8289cb4314b273d29555ad3b2a5ab98bb4816b3b",
+    "zh:da3c317f1db2469615ab40aa6baba63b5643bae7110ff855277a1fb9d8eb4f2c",
+    "zh:dc6430622a8dc5cdab359a8704aec81d3825ea1d305bbb3bbd032b1c6adfae0c",
+    "zh:fac0d2ddeadf9ec53da87922f666e1e73a603a611c57bcbc4b86ac2821619b1d",
+  ]
+}

--- a/terragrunt/accounts/crates-io-prod/wiz/terragrunt.hcl
+++ b/terragrunt/accounts/crates-io-prod/wiz/terragrunt.hcl
@@ -1,0 +1,8 @@
+terraform {
+  source = "../../../..//terragrunt/modules/wiz"
+}
+
+include {
+  path           = find_in_parent_folders()
+  merge_strategy = "deep"
+}


### PR DESCRIPTION
The crates-io-prod account was recently created as part of the project to count crate downloads using CDN logs (see #372). Similar to all our other AWS accounts, Datadog and Wiz have been installed in the account.