### PR TITLE
Ensure package hash is stable

### DIFF
--- a/terragrunt/modules/crates-io/compute-static/bin/terraform-external-build.sh
+++ b/terragrunt/modules/crates-io/compute-static/bin/terraform-external-build.sh
@@ -19,7 +19,7 @@ script_path=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 project_path=$(cd "${script_path}" && cd ".." && pwd)
 project_name="${project_path##*/}"
 
-cd "${project_path}" && fastly compute build &>/dev/null
+cd "${project_path}" && fastly compute build --metadata-disable &>/dev/null
 
 # Return a valid JSON object that Terraform can consume
 echo "{\"path\": \"./${project_name}/pkg/compute-static.tar.gz\"}"


### PR DESCRIPTION
Fastly added metadata collection[^1] to the CLI in version 10.6.0. The metadata includes the heap size during the build, which is not stable over time. Because of that, Terraform always detected a change to the compute package, even though no code had changed.

Disabling the metadata collection ensures that the package hash is stable between builds, thus reducing the noise in Terraform.

[^1]: https://developer.fastly.com/learning/tools/cli/#metadata-collection