### PR TITLE
Enable metadata for Fastly function again

### DIFF
--- a/terragrunt/modules/crates-io/compute-static/bin/terraform-external-build.sh
+++ b/terragrunt/modules/crates-io/compute-static/bin/terraform-external-build.sh
@@ -19,7 +19,7 @@ script_path=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 project_path=$(cd "${script_path}" && cd ".." && pwd)
 project_name="${project_path##*/}"
 
-cd "${project_path}" && fastly compute build --metadata-disable &>/dev/null
+cd "${project_path}" && fastly compute build &>/dev/null
 
 # Return a valid JSON object that Terraform can consume
 echo "{\"path\": \"./${project_name}/pkg/compute-static.tar.gz\"}"


### PR DESCRIPTION
The collection of metadata was disabled in #387, because the metadata contained an unstable property that broke the change detection in Terraform. This issue has been resolved upstream by introducing buckets for the heap allocation size, which reduces the risk of changes in the metadata while preserving the usefulness of the property.

See https://github.com/fastly/cli/pull/1130 for details on the buckets.