### PR TITLE
Increase robustness of SSL renewing

### DIFF
--- a/ansible/roles/letsencrypt/templates/renew-ssl-certs.service
+++ b/ansible/roles/letsencrypt/templates/renew-ssl-certs.service
@@ -11,3 +11,8 @@ Group=ssl-read-keys
 # afterwards. It will be owned by the user and group defined above.
 RuntimeDirectory=acme-challenges
 RuntimeDirectoryMode=0755
+
+# Sometimes the renew can fail, such as when the Let's Encrypt servers
+# are overloaded. Give it a little break and try again.
+Restart=on-failure
+RestartSec=1m

--- a/ansible/roles/letsencrypt/templates/renew-ssl-certs.timer
+++ b/ansible/roles/letsencrypt/templates/renew-ssl-certs.timer
@@ -5,5 +5,9 @@ Description=Renew SSL certificates each week
 OnCalendar=weekly
 Persistent=true
 
+# Add a bit of randomness to avoid hitting the Let's Encrypt servers
+# at the exact same time the entire world is doing this.
+RandomizedDelaySec=5m
+
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
The playground had an error renewing:

```
Error -> One or more domains had a problem:
error: 0 :: POST :: https://acme-v02.api.letsencrypt.org/acme/finalize/514094497/249375107307 :: urn:ietf:params:acme:error:rateLimited :: Service busy; retry later., url:
```

Our renew timer runs once a week at midnight UTC, and my guess is that lots of other servers across the world are doing the same thing causing temporary overloads. These changes are intended to help spread out the load a bit and retry when an error happens anyway.