### PR TITLE
Bump memory size of Crater EC2 instance

### DIFF
--- a/terraform/crater/instance.tf
+++ b/terraform/crater/instance.tf
@@ -244,7 +244,7 @@ resource "aws_iam_instance_profile" "crater" {
 
 resource "aws_instance" "crater" {
   ami                     = data.aws_ami.ubuntu.id
-  instance_type           = "c5a.large"
+  instance_type           = "m6a.large"
   key_name                = data.terraform_remote_state.shared.outputs.master_ec2_key_pair
   iam_instance_profile    = aws_iam_instance_profile.crater.name
   ebs_optimized           = true


### PR DESCRIPTION
This should make it less prone to OOMs, at only a small ($4/month) increase in costs.

