### PR TITLE
Grant the crates.io team access to new AWS accounts

### DIFF
--- a/terragrunt/accounts/root/aws-organization/terragrunt.hcl
+++ b/terragrunt/accounts/root/aws-organization/terragrunt.hcl
@@ -57,5 +57,11 @@ inputs = {
       email = "berykubik@gmail.com"
       groups = ["infra"]
     }
+    "tobias" = {
+      given_name = "Tobias"
+      family_name = "Bieniek"
+      email = "tobias@bieniek.cloud"
+      groups = ["crates-io"]
+    }
   }
 }

--- a/terragrunt/modules/aws-organization/groups.tf
+++ b/terragrunt/modules/aws-organization/groups.tf
@@ -81,13 +81,7 @@ resource "aws_ssoadmin_permission_set" "read_only_access" {
 
 resource "aws_ssoadmin_managed_policy_attachment" "read_only_access" {
   instance_arn       = local.instance_arn
-  managed_policy_arn = "arn:aws:iam::aws:policy/job-function/ViewOnlyAccess"
-  permission_set_arn = aws_ssoadmin_permission_set.read_only_access.arn
-}
-
-resource "aws_ssoadmin_managed_policy_attachment" "cloudwatch_readonly" {
-  instance_arn       = local.instance_arn
-  managed_policy_arn = "arn:aws:iam::aws:policy/CloudWatchLogsReadOnlyAccess"
+  managed_policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
   permission_set_arn = aws_ssoadmin_permission_set.read_only_access.arn
 }
 
@@ -124,11 +118,15 @@ locals {
       account : aws_organizations_account.crates_io_staging,
       groups : [
         { group : aws_identitystore_group.infra-admins,
-        permissions : [aws_ssoadmin_permission_set.view_only_access, aws_ssoadmin_permission_set.administrator_access] },
+        permissions : [
+          aws_ssoadmin_permission_set.view_only_access,
+          aws_ssoadmin_permission_set.read_only_access,
+          aws_ssoadmin_permission_set.administrator_access
+        ] },
         { group : aws_identitystore_group.infra,
-        permissions : [aws_ssoadmin_permission_set.view_only_access, aws_ssoadmin_permission_set.administrator_access] },
+        permissions : [aws_ssoadmin_permission_set.read_only_access, aws_ssoadmin_permission_set.administrator_access] },
         { group : aws_identitystore_group.crates_io,
-        permissions : [aws_ssoadmin_permission_set.view_only_access] },
+        permissions : [aws_ssoadmin_permission_set.read_only_access] },
       ]
     },
     # crates-io Production
@@ -136,11 +134,15 @@ locals {
       account : aws_organizations_account.crates_io_prod,
       groups : [
         { group : aws_identitystore_group.infra-admins,
-        permissions : [aws_ssoadmin_permission_set.view_only_access, aws_ssoadmin_permission_set.administrator_access] },
+        permissions : [
+          aws_ssoadmin_permission_set.view_only_access,
+          aws_ssoadmin_permission_set.read_only_access,
+          aws_ssoadmin_permission_set.administrator_access
+        ] },
         { group : aws_identitystore_group.infra,
-        permissions : [aws_ssoadmin_permission_set.view_only_access] },
+        permissions : [aws_ssoadmin_permission_set.read_only_access, aws_ssoadmin_permission_set.administrator_access] },
         { group : aws_identitystore_group.crates_io,
-        permissions : [aws_ssoadmin_permission_set.view_only_access] },
+        permissions : [aws_ssoadmin_permission_set.read_only_access] },
       ]
     },
     # docs-rs Staging

--- a/terragrunt/modules/aws-organization/users.tf
+++ b/terragrunt/modules/aws-organization/users.tf
@@ -3,6 +3,7 @@ locals {
     billing : aws_identitystore_group.billing
     infra : aws_identitystore_group.infra
     infra-admins : aws_identitystore_group.infra-admins
+    crates-io : aws_identitystore_group.crates_io
   }
 
   # Expand var.users into collection of group memberships associations


### PR DESCRIPTION
In https://github.com/rust-lang/simpleinfra/pull/374, two new AWS accounts for crates.io were created. The team has
been given read-only access to these accounts so that they can monitor and debug the SQS queue.