### PR TITLE
Grant access to global SSM parameters

### DIFF
--- a/terraform/team-members-access/infra-deploy-playground.tf
+++ b/terraform/team-members-access/infra-deploy-playground.tf
@@ -22,9 +22,13 @@ resource "aws_iam_group_policy" "infra_deploy_playground" {
     Statement = [
       // Parameters read by Ansible during deployment.
       {
-        Effect   = "Allow"
-        Action   = ["ssm:GetParameters", "ssm:GetParametersByPath"]
-        Resource = "arn:aws:ssm:us-west-1:890664054962:parameter/prod/ansible/playground/*"
+        Effect = "Allow"
+        Action = ["ssm:GetParameters", "ssm:GetParametersByPath"]
+        Resource = [
+          "arn:aws:ssm:us-west-1:890664054962:parameter/prod/ansible/all/*",
+          "arn:aws:ssm:us-west-1:890664054962:parameter/prod/ansible/playground/*",
+          "arn:aws:ssm:us-west-1:890664054962:parameter/staging/ansible/all/*",
+        ]
       },
     ]
   })


### PR DESCRIPTION
When deploying the playground, access to the global SSM parameters in the `/{staging,prod}/ansible/all/*` namespace is required.