### PR TITLE
Create AWS accounts for LawnGnome

### DIFF
--- a/terraform/team-members-access/_users.tf
+++ b/terraform/team-members-access/_users.tf
@@ -18,6 +18,7 @@ locals {
     "paullenz"      = [aws_iam_group.foundation.name],
     "shepmaster"    = [aws_iam_group.infra_deploy_playground.name, aws_iam_group.infra_team.name],
     "oli-obk"       = [aws_iam_group.infra_deploy_staging_dev_desktop.name],
+    "LawnGnome"     = [aws_iam_group.crates_io.name],
   }
 }
 

--- a/terragrunt/accounts/root/aws-organization/terragrunt.hcl
+++ b/terragrunt/accounts/root/aws-organization/terragrunt.hcl
@@ -63,5 +63,11 @@ inputs = {
       email = "tobias@bieniek.cloud"
       groups = ["crates-io"]
     }
+    "adam" = {
+      given_name = "Adam"
+      family_name = "Harvey"
+      email = "adam@adamharvey.name"
+      groups = ["crates-io"]
+    }
   }
 }


### PR DESCRIPTION
@LawnGnome is part of the crates-io team and needs access to the CDN logs as well as the SQS queue to debug and fix an issue with broken download counts on crates.io.