### PR TITLE
Update cargo resolver version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,7 @@
 [workspace]
+# Opt-in to the new feature resolver introduced in Rust 1.51 and Edition 2021.
+# https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
+resolver = "2"
 members = [
     "setup-deploy-keys",
     "ansible/roles/dev-desktop/files/team_login",

--- a/ansible/roles/dev-desktop/files/team_login/Cargo.toml
+++ b/ansible/roles/dev-desktop/files/team_login/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["Oli Scherer <github35764891676564198441@oli-obk.de>"]
-edition = "2018"
+edition = "2021"
 name = "team_login"
 version = "0.1.0"
 

--- a/setup-deploy-keys/Cargo.toml
+++ b/setup-deploy-keys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "setup-deploy-keys"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-edition = "2018"
+edition = "2021"
 
 [[bin]]
 name = "deploy"


### PR DESCRIPTION
Calling cargo command into the project was giving this warning:

```
warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
note: for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
```

The workspace.resolver is updated to version 2 and each crates set edition = 2021