### PR TITLE
Allow new-bors to promote artifacts to rustc-builds

### DIFF
--- a/terraform/rustc-ci/impl/artifacts.tf
+++ b/terraform/rustc-ci/impl/artifacts.tf
@@ -180,10 +180,10 @@ resource "aws_iam_role" "try_builds" {
           Sid    = "ArtifactsBucketWrite"
           Effect = "Allow"
           Resource = [
-            "${aws_s3_bucket.artifacts.arn}/rustc-builds-try",
-            "${aws_s3_bucket.artifacts.arn}/rustc-builds-try/*",
-            "${aws_s3_bucket.artifacts.arn}/rustc-builds-try-alt",
-            "${aws_s3_bucket.artifacts.arn}/rustc-builds-try-alt/*",
+            "${aws_s3_bucket.artifacts.arn}/rustc-builds",
+            "${aws_s3_bucket.artifacts.arn}/rustc-builds/*",
+            "${aws_s3_bucket.artifacts.arn}/rustc-builds-alt",
+            "${aws_s3_bucket.artifacts.arn}/rustc-builds-alt/*",
           ]
           Action = [
             "s3:GetObject",


### PR DESCRIPTION
This lets us use the built artifacts in tooling (e.g. perf, crater), paving the way for starting to move towards new bors by default.

cc @Kobzol 