### PR TITLE
monitoring: Remove obsolete "cratesio/SlowDownloads" alerting rule

### DIFF
--- a/ansible/playbooks/monitoring.yml
+++ b/ansible/playbooks/monitoring.yml
@@ -189,12 +189,6 @@
               labels:
                 dispatch: pagerduty-cratesio
 
-            - alert: SlowDownloads
-              expr: histogram_quantile(0.99, sum by (le) (rate(cratesio_instance_response_times_bucket{job="cratesio_heroku_metrics",app="crates-io",endpoint="/api/v1/crates/:crate_id/:version/download"}[30s]))) >= 1
-              for: 1m
-              labels:
-                dispatch: pagerduty-cratesio
-
         - name: docsrs
           rules:
             - alert: DocsRsDown


### PR DESCRIPTION
The crate downloads are no longer going through the crates.io API. Since this alerting rule is based on the crates.io API traffic, it no longer serves its purpose. Whether we can implement something similar based on the CDN traffic logs would probably have to be figured out by the infra team 😅