### PR TITLE
Stream request logs for static.crates.io from Fastly to Datadog

### DIFF
--- a/terragrunt/accounts/legacy/crates-io-prod/crates-io/terragrunt.hcl
+++ b/terragrunt/accounts/legacy/crates-io-prod/crates-io/terragrunt.hcl
@@ -8,6 +8,8 @@ include {
 }
 
 inputs = {
+  env = "prod"
+
   webapp_domain_name = "crates.io"
   static_domain_name = "static.crates.io"
   index_domain_name  = "index.crates.io"
@@ -26,8 +28,6 @@ inputs = {
 
   static_cloudfront_weight = 5
   static_fastly_weight = 95
-
-  fastly_customer_id_ssm_parameter = "/prod/crates-io/fastly/customer-id"
 
   cdn_log_event_queue_arn = "arn:aws:sqs:us-west-1:365596307002:cdn-log-event-queue"
 }

--- a/terragrunt/accounts/legacy/crates-io-staging/crates-io/terragrunt.hcl
+++ b/terragrunt/accounts/legacy/crates-io-staging/crates-io/terragrunt.hcl
@@ -8,6 +8,8 @@ include {
 }
 
 inputs = {
+  env = "staging"
+
   webapp_domain_name = "staging.crates.io"
   static_domain_name = "static.staging.crates.io"
   index_domain_name  = "index.staging.crates.io"
@@ -25,8 +27,6 @@ inputs = {
 
   static_cloudfront_weight = 0
   static_fastly_weight = 100
-
-  fastly_customer_id_ssm_parameter = "/staging/crates-io/fastly/customer-id"
 
   cdn_log_event_queue_arn = "arn:aws:sqs:us-west-1:359172468976:cdn-log-event-queue"
 }

--- a/terragrunt/modules/crates-io/_terraform.tf
+++ b/terragrunt/modules/crates-io/_terraform.tf
@@ -92,11 +92,6 @@ variable "static_fastly_weight" {
   type        = number
 }
 
-variable "fastly_customer_id_ssm_parameter" {
-  description = "Name of the SSM parameter with our Fastly customer id"
-  type        = string
-}
-
 variable "fastly_aws_account_id" {
   # See https://docs.fastly.com/en/guides/creating-an-aws-iam-role-for-fastly-logging
   description = "The AWS account ID that Fastly uses to write logs"

--- a/terragrunt/modules/crates-io/_terraform.tf
+++ b/terragrunt/modules/crates-io/_terraform.tf
@@ -108,3 +108,11 @@ variable "cdn_log_event_queue_arn" {
   description = "ARN of the SQS queue that receives S3 notifications for CDN logs"
   type        = string
 }
+
+variable "env" {
+  type = string
+  validation {
+    condition     = contains(["staging", "prod"], var.env)
+    error_message = "The environment must be 'staging' or 'prod'."
+  }
+}

--- a/terragrunt/modules/crates-io/compute-static/src/config.rs
+++ b/terragrunt/modules/crates-io/compute-static/src/config.rs
@@ -18,11 +18,14 @@ const FALLBACK_HOST: &str = "s3-fallback-host";
 // Name of the dictionary item with the TTL for the static bucket
 const STATIC_TTL: &str = "static-ttl";
 
-// Name of the directory item with the logging endpoint for requests
-const REQUEST_LOGS_ENDPOINT: &str = "request-logs-endpoint";
+// Name of the directory item with the Datadog logging endpoint for requests
+const DATADOG_REQUEST_LOGS_ENDPOINT: &str = "datadog-request-logs-endpoint";
 
-// Name of the directory item with the logging endpoint for the worker
-const SERVICE_LOGS_ENDPOINT: &str = "service-logs-endpoint";
+// Name of the directory item with the S3 logging endpoint for requests
+const S3_REQUEST_LOGS_ENDPOINT: &str = "s3-request-logs-endpoint";
+
+// Name of the directory item with the S3 logging endpoint for the worker
+const S3_SERVICE_LOGS_ENDPOINT: &str = "s3-service-logs-endpoint";
 
 #[derive(Debug)]
 pub struct Config {
@@ -31,8 +34,9 @@ pub struct Config {
     pub fallback_host: String,
     pub static_ttl: u32,
     pub cloudfront_url: String,
-    pub request_logs_endpoint: String,
-    pub service_logs_endpoint: String,
+    pub datadog_request_logs_endpoint: String,
+    pub s3_request_logs_endpoint: String,
+    pub s3_service_logs_endpoint: String,
 }
 
 impl Config {
@@ -63,11 +67,14 @@ impl Config {
             .expect("failed to get CloudFront URL from dictionary");
 
         // Look up the endpoints for logging
-        let request_logs_endpoint = dictionary
-            .get(REQUEST_LOGS_ENDPOINT)
+        let datadog_request_logs_endpoint = dictionary
+            .get(DATADOG_REQUEST_LOGS_ENDPOINT)
             .expect("failed to get endpoint for request logs from dictionary");
-        let service_logs_endpoint = dictionary
-            .get(SERVICE_LOGS_ENDPOINT)
+        let s3_request_logs_endpoint = dictionary
+            .get(S3_REQUEST_LOGS_ENDPOINT)
+            .expect("failed to get endpoint for request logs from dictionary");
+        let s3_service_logs_endpoint = dictionary
+            .get(S3_SERVICE_LOGS_ENDPOINT)
             .expect("failed to get endpoint for service logs from dictionary");
 
         Self {
@@ -76,8 +83,9 @@ impl Config {
             fallback_host,
             static_ttl,
             cloudfront_url,
-            request_logs_endpoint,
-            service_logs_endpoint,
+            datadog_request_logs_endpoint,
+            s3_request_logs_endpoint,
+            s3_service_logs_endpoint,
         }
     }
 }

--- a/terragrunt/modules/crates-io/compute-static/src/config.rs
+++ b/terragrunt/modules/crates-io/compute-static/src/config.rs
@@ -15,9 +15,6 @@ const FALLBACK_HOST: &str = "s3-fallback-host";
 // Name of the dictionary item with the TTL for the static bucket
 const STATIC_TTL: &str = "static-ttl";
 
-// Name of the directory item with the Datadog app tag
-const DATADOG_APP: &str = "datadog-app";
-
 // Name of the directory item with the Datadog environment tag
 const DATADOG_ENV: &str = "datadog-env";
 
@@ -26,9 +23,6 @@ const DATADOG_HOST: &str = "datadog-host";
 
 // Name of the directory item with the Datadog logging endpoint for requests
 const DATADOG_REQUEST_LOGS_ENDPOINT: &str = "datadog-request-logs-endpoint";
-
-// Name of the directory item with the Datadog service tag
-const DATADOG_SERVICE: &str = "datadog-service";
 
 // Name of the directory item with the S3 logging endpoint for requests
 const S3_REQUEST_LOGS_ENDPOINT: &str = "s3-request-logs-endpoint";
@@ -42,11 +36,9 @@ pub struct Config {
     pub fallback_host: String,
     pub static_ttl: u32,
     pub cloudfront_url: String,
-    pub datadog_app: String,
     pub datadog_env: String,
     pub datadog_host: String,
     pub datadog_request_logs_endpoint: String,
-    pub datadog_service: String,
     pub s3_request_logs_endpoint: String,
     pub s3_service_logs_endpoint: String,
 }
@@ -85,29 +77,21 @@ impl Config {
             .expect("failed to get endpoint for service logs from dictionary");
 
         // Look up the tags for Datadog
-        let datadog_app = dictionary
-            .get(DATADOG_APP)
-            .expect("failed to get Datadog app tag from dictionary");
         let datadog_env = dictionary
             .get(DATADOG_ENV)
             .expect("failed to get Datadog environment tag from dictionary");
         let datadog_host = dictionary
             .get(DATADOG_HOST)
             .expect("failed to get Datadog host tag from dictionary");
-        let datadog_service = dictionary
-            .get(DATADOG_SERVICE)
-            .expect("failed to get Datadog service tag from dictionary");
 
         Self {
             primary_host,
             fallback_host,
             static_ttl,
             cloudfront_url,
-            datadog_app,
             datadog_env,
             datadog_host,
             datadog_request_logs_endpoint,
-            datadog_service,
             s3_request_logs_endpoint,
             s3_service_logs_endpoint,
         }

--- a/terragrunt/modules/crates-io/compute-static/src/config.rs
+++ b/terragrunt/modules/crates-io/compute-static/src/config.rs
@@ -6,6 +6,9 @@ const DICTIONARY_NAME: &str = "compute_static";
 // Name of the dictionary item with the CloudFront URL
 const CLOUDFRONT_URL: &str = "cloudfront-url";
 
+// Name of the dictionary item with the name of the service.
+const SERVICE_NAME: &str = "service-name";
+
 // Name of the dictionary item with the name of the primary host.
 const PRIMARY_HOST: &str = "s3-primary-host";
 
@@ -23,6 +26,7 @@ const SERVICE_LOGS_ENDPOINT: &str = "service-logs-endpoint";
 
 #[derive(Debug)]
 pub struct Config {
+    pub service_name: String,
     pub primary_host: String,
     pub fallback_host: String,
     pub static_ttl: u32,
@@ -34,6 +38,11 @@ pub struct Config {
 impl Config {
     pub fn from_dictionary() -> Self {
         let dictionary = ConfigStore::open(DICTIONARY_NAME);
+
+        // Look up the name of the service
+        let service_name = dictionary
+            .get(SERVICE_NAME)
+            .expect("failed to get service name from dictionary");
 
         // Look up S3 hosts for current environment
         let primary_host = dictionary
@@ -62,6 +71,7 @@ impl Config {
             .expect("failed to get endpoint for service logs from dictionary");
 
         Self {
+            service_name,
             primary_host,
             fallback_host,
             static_ttl,

--- a/terragrunt/modules/crates-io/compute-static/src/config.rs
+++ b/terragrunt/modules/crates-io/compute-static/src/config.rs
@@ -6,9 +6,6 @@ const DICTIONARY_NAME: &str = "compute_static";
 // Name of the dictionary item with the CloudFront URL
 const CLOUDFRONT_URL: &str = "cloudfront-url";
 
-// Name of the dictionary item with the name of the service.
-const SERVICE_NAME: &str = "service-name";
-
 // Name of the dictionary item with the name of the primary host.
 const PRIMARY_HOST: &str = "s3-primary-host";
 
@@ -18,8 +15,20 @@ const FALLBACK_HOST: &str = "s3-fallback-host";
 // Name of the dictionary item with the TTL for the static bucket
 const STATIC_TTL: &str = "static-ttl";
 
+// Name of the directory item with the Datadog app tag
+const DATADOG_APP: &str = "datadog-app";
+
+// Name of the directory item with the Datadog environment tag
+const DATADOG_ENV: &str = "datadog-env";
+
+// Name of the directory item with the Datadog host tag
+const DATADOG_HOST: &str = "datadog-host";
+
 // Name of the directory item with the Datadog logging endpoint for requests
 const DATADOG_REQUEST_LOGS_ENDPOINT: &str = "datadog-request-logs-endpoint";
+
+// Name of the directory item with the Datadog service tag
+const DATADOG_SERVICE: &str = "datadog-service";
 
 // Name of the directory item with the S3 logging endpoint for requests
 const S3_REQUEST_LOGS_ENDPOINT: &str = "s3-request-logs-endpoint";
@@ -29,12 +38,15 @@ const S3_SERVICE_LOGS_ENDPOINT: &str = "s3-service-logs-endpoint";
 
 #[derive(Debug)]
 pub struct Config {
-    pub service_name: String,
     pub primary_host: String,
     pub fallback_host: String,
     pub static_ttl: u32,
     pub cloudfront_url: String,
+    pub datadog_app: String,
+    pub datadog_env: String,
+    pub datadog_host: String,
     pub datadog_request_logs_endpoint: String,
+    pub datadog_service: String,
     pub s3_request_logs_endpoint: String,
     pub s3_service_logs_endpoint: String,
 }
@@ -42,11 +54,6 @@ pub struct Config {
 impl Config {
     pub fn from_dictionary() -> Self {
         let dictionary = ConfigStore::open(DICTIONARY_NAME);
-
-        // Look up the name of the service
-        let service_name = dictionary
-            .get(SERVICE_NAME)
-            .expect("failed to get service name from dictionary");
 
         // Look up S3 hosts for current environment
         let primary_host = dictionary
@@ -77,13 +84,30 @@ impl Config {
             .get(S3_SERVICE_LOGS_ENDPOINT)
             .expect("failed to get endpoint for service logs from dictionary");
 
+        // Look up the tags for Datadog
+        let datadog_app = dictionary
+            .get(DATADOG_APP)
+            .expect("failed to get Datadog app tag from dictionary");
+        let datadog_env = dictionary
+            .get(DATADOG_ENV)
+            .expect("failed to get Datadog environment tag from dictionary");
+        let datadog_host = dictionary
+            .get(DATADOG_HOST)
+            .expect("failed to get Datadog host tag from dictionary");
+        let datadog_service = dictionary
+            .get(DATADOG_SERVICE)
+            .expect("failed to get Datadog service tag from dictionary");
+
         Self {
-            service_name,
             primary_host,
             fallback_host,
             static_ttl,
             cloudfront_url,
+            datadog_app,
+            datadog_env,
+            datadog_host,
             datadog_request_logs_endpoint,
+            datadog_service,
             s3_request_logs_endpoint,
             s3_service_logs_endpoint,
         }

--- a/terragrunt/modules/crates-io/compute-static/src/log_line.rs
+++ b/terragrunt/modules/crates-io/compute-static/src/log_line.rs
@@ -11,24 +11,41 @@ pub enum LogLine {
     V1(LogLineV1),
 }
 
-// `source` and `service` are reserved log attributes on Datadog that have a special meaning.
-// https://docs.datadoghq.com/logs/log_configuration/attributes_naming_convention
+// `ddsource`, `ddtags`, and `service` are reserved log attributes on Datadog that have a special
+// meaning. See https://docs.datadoghq.com/logs/log_configuration/attributes_naming_convention.
 #[derive(Debug, Builder, Serialize)]
 pub struct LogLineV1 {
     #[builder(default = "default_source()")]
     ddsource: &'static str,
     ddtags: String,
     service: String,
-    hostname: String,
+    bytes: Option<usize>,
+    content_type: Option<String>,
     #[serde(with = "time::serde::rfc3339")]
     date_time: OffsetDateTime,
-    url: String,
-    bytes: Option<usize>,
+    edge_location: Option<String>,
+    host: Option<String>,
+    http: Option<HttpDetails>,
     ip: Option<IpAddr>,
-    method: Option<String>,
     status: Option<u16>,
+    tls: Option<TlsDetails>,
+    url: String,
 }
 
 fn default_source() -> &'static str {
     "fastly"
+}
+
+#[derive(Clone, Debug, Builder, Serialize)]
+pub struct HttpDetails {
+    method: String,
+    protocol: Option<String>,
+    referer: Option<String>,
+    useragent: Option<String>,
+}
+
+#[derive(Clone, Debug, Builder, Serialize)]
+pub struct TlsDetails {
+    cipher: Option<&'static str>,
+    protocol: Option<&'static str>,
 }

--- a/terragrunt/modules/crates-io/compute-static/src/log_line.rs
+++ b/terragrunt/modules/crates-io/compute-static/src/log_line.rs
@@ -17,7 +17,10 @@ pub enum LogLine {
 pub struct LogLineV1 {
     #[builder(default = "default_source()")]
     source: &'static str,
+    app: String,
     service: String,
+    env: String,
+    host: String,
     #[serde(with = "time::serde::rfc3339")]
     date_time: OffsetDateTime,
     url: String,

--- a/terragrunt/modules/crates-io/compute-static/src/log_line.rs
+++ b/terragrunt/modules/crates-io/compute-static/src/log_line.rs
@@ -27,6 +27,7 @@ pub struct LogLineV1 {
     host: Option<String>,
     http: Option<HttpDetails>,
     ip: Option<IpAddr>,
+    method: Option<String>,
     status: Option<u16>,
     tls: Option<TlsDetails>,
     url: String,
@@ -38,7 +39,6 @@ fn default_source() -> &'static str {
 
 #[derive(Clone, Debug, Builder, Serialize)]
 pub struct HttpDetails {
-    method: String,
     protocol: Option<String>,
     referer: Option<String>,
     useragent: Option<String>,

--- a/terragrunt/modules/crates-io/compute-static/src/log_line.rs
+++ b/terragrunt/modules/crates-io/compute-static/src/log_line.rs
@@ -16,11 +16,10 @@ pub enum LogLine {
 #[derive(Debug, Builder, Serialize)]
 pub struct LogLineV1 {
     #[builder(default = "default_source()")]
-    source: &'static str,
-    app: String,
+    ddsource: &'static str,
+    ddtags: String,
     service: String,
-    env: String,
-    host: String,
+    hostname: String,
     #[serde(with = "time::serde::rfc3339")]
     date_time: OffsetDateTime,
     url: String,

--- a/terragrunt/modules/crates-io/compute-static/src/log_line.rs
+++ b/terragrunt/modules/crates-io/compute-static/src/log_line.rs
@@ -18,7 +18,7 @@ pub struct LogLineV1 {
     #[builder(default = "default_source()")]
     ddsource: &'static str,
     ddtags: String,
-    service: String,
+    service: &'static str,
     bytes: Option<usize>,
     content_type: Option<String>,
     #[serde(with = "time::serde::rfc3339")]

--- a/terragrunt/modules/crates-io/compute-static/src/log_line.rs
+++ b/terragrunt/modules/crates-io/compute-static/src/log_line.rs
@@ -11,8 +11,13 @@ pub enum LogLine {
     V1(LogLineV1),
 }
 
+// `source` and `service` are reserved log attributes on Datadog that have a special meaning.
+// https://docs.datadoghq.com/logs/log_configuration/attributes_naming_convention
 #[derive(Debug, Builder, Serialize)]
 pub struct LogLineV1 {
+    #[builder(default = "default_source()")]
+    source: &'static str,
+    service: String,
     #[serde(with = "time::serde::rfc3339")]
     date_time: OffsetDateTime,
     url: String,
@@ -20,4 +25,8 @@ pub struct LogLineV1 {
     ip: Option<IpAddr>,
     method: Option<String>,
     status: Option<u16>,
+}
+
+fn default_source() -> &'static str {
+    "fastly"
 }

--- a/terragrunt/modules/crates-io/compute-static/src/main.rs
+++ b/terragrunt/modules/crates-io/compute-static/src/main.rs
@@ -57,7 +57,10 @@ fn init_logging(config: &Config) {
 /// Collect data for the logs from the request
 fn collect_request(config: &Config, request: &Request) -> LogLineV1Builder {
     LogLineV1Builder::default()
-        .service(config.service_name.clone())
+        .app(config.datadog_app.clone())
+        .service(config.datadog_service.clone())
+        .env(config.datadog_env.clone())
+        .host(config.datadog_host.clone())
         .date_time(OffsetDateTime::now_utc())
         .url(request.get_url_str().into())
         .ip(request.get_client_ip_addr())

--- a/terragrunt/modules/crates-io/compute-static/src/main.rs
+++ b/terragrunt/modules/crates-io/compute-static/src/main.rs
@@ -48,6 +48,7 @@ fn main(request: Request) -> Result<Response, Error> {
 fn init_logging(config: &Config) {
     Logger::builder()
         .max_level(LevelFilter::Debug)
+        .endpoint(config.datadog_request_logs_endpoint.clone())
         .endpoint(config.s3_request_logs_endpoint.clone())
         .default_endpoint(config.s3_service_logs_endpoint.clone())
         .echo_stdout(true)

--- a/terragrunt/modules/crates-io/compute-static/src/main.rs
+++ b/terragrunt/modules/crates-io/compute-static/src/main.rs
@@ -24,7 +24,7 @@ fn main(request: Request) -> Result<Response, Error> {
     }
 
     init_logging(&config);
-    let mut log = collect_request(&request);
+    let mut log = collect_request(&config, &request);
 
     let has_origin_header = request.get_header("Origin").is_some();
     let mut response = handle_request(&config, request);
@@ -55,8 +55,9 @@ fn init_logging(config: &Config) {
 }
 
 /// Collect data for the logs from the request
-fn collect_request(request: &Request) -> LogLineV1Builder {
+fn collect_request(config: &Config, request: &Request) -> LogLineV1Builder {
     LogLineV1Builder::default()
+        .service(config.service_name.clone())
         .date_time(OffsetDateTime::now_utc())
         .url(request.get_url_str().into())
         .ip(request.get_client_ip_addr())

--- a/terragrunt/modules/crates-io/compute-static/src/main.rs
+++ b/terragrunt/modules/crates-io/compute-static/src/main.rs
@@ -14,6 +14,9 @@ use crate::log_line::{HttpDetailsBuilder, LogLine, LogLineV1Builder, TlsDetailsB
 mod config;
 mod log_line;
 
+const DATADOG_APP: &str = "crates.io";
+const DATADOG_SERVICE: &str = "static.crates.io";
+
 #[fastly::main]
 fn main(request: Request) -> Result<Response, Error> {
     let config = Config::from_dictionary();
@@ -82,11 +85,8 @@ fn collect_request(config: &Config, request: &Request) -> LogLineV1Builder {
         .ok();
 
     let log_line = LogLineV1Builder::default()
-        .ddtags(format!(
-            "app:{},env:{}",
-            config.datadog_app, config.datadog_env
-        ))
-        .service(config.datadog_service.clone())
+        .ddtags(format!("app:{},env:{}", DATADOG_APP, config.datadog_env))
+        .service(DATADOG_SERVICE)
         .date_time(OffsetDateTime::now_utc())
         .edge_location(var("FASTLY_POP").ok())
         .host(request.get_url().host().map(|s| s.to_string()))

--- a/terragrunt/modules/crates-io/compute-static/src/main.rs
+++ b/terragrunt/modules/crates-io/compute-static/src/main.rs
@@ -59,7 +59,6 @@ fn init_logging(config: &Config) {
 /// Collect data for the logs from the request
 fn collect_request(config: &Config, request: &Request) -> LogLineV1Builder {
     let http_details = HttpDetailsBuilder::default()
-        .method(request.get_method().to_string())
         .protocol(http_version_to_string(request.get_version()))
         .referer(
             request
@@ -93,6 +92,7 @@ fn collect_request(config: &Config, request: &Request) -> LogLineV1Builder {
         .host(request.get_url().host().map(|s| s.to_string()))
         .http(http_details)
         .ip(request.get_client_ip_addr())
+        .method(Some(request.get_method().to_string()))
         .url(request.get_url_str().into())
         .tls(tls_details)
         .to_owned();

--- a/terragrunt/modules/crates-io/compute-static/src/main.rs
+++ b/terragrunt/modules/crates-io/compute-static/src/main.rs
@@ -57,10 +57,12 @@ fn init_logging(config: &Config) {
 /// Collect data for the logs from the request
 fn collect_request(config: &Config, request: &Request) -> LogLineV1Builder {
     LogLineV1Builder::default()
-        .app(config.datadog_app.clone())
         .service(config.datadog_service.clone())
-        .env(config.datadog_env.clone())
-        .host(config.datadog_host.clone())
+        .hostname(config.datadog_host.clone())
+        .ddtags(format!(
+            "app:{},env:{}",
+            config.datadog_app, config.datadog_env
+        ))
         .date_time(OffsetDateTime::now_utc())
         .url(request.get_url_str().into())
         .ip(request.get_client_ip_addr())

--- a/terragrunt/modules/crates-io/fastly-iam-role.tf
+++ b/terragrunt/modules/crates-io/fastly-iam-role.tf
@@ -1,5 +1,5 @@
 data "aws_ssm_parameter" "fastly_customer_id" {
-  name = var.fastly_customer_id_ssm_parameter
+  name = "/${var.env}/crates-io/fastly/customer-id"
 }
 
 resource "aws_iam_role" "fastly_assume_role" {

--- a/terragrunt/modules/crates-io/fastly-static.tf
+++ b/terragrunt/modules/crates-io/fastly-static.tf
@@ -106,11 +106,9 @@ resource "fastly_service_dictionary_items" "compute_static" {
 
   items = {
     "cloudfront-url" : local.cloudfront_domain_name
-    "datadog-app" : "crates.io"
     "datadog-env" : var.env
     "datadog-host" : var.static_domain_name
     "datadog-request-logs-endpoint" : "datadog-${local.request_logs_endpoint}"
-    "datadog-service" : "static.crates.io"
     "s3-fallback-host" : local.fallback_host_name
     "s3-primary-host" : local.primary_host_name
     "s3-request-logs-endpoint" : "s3-${local.request_logs_endpoint}"

--- a/terragrunt/modules/crates-io/fastly-static.tf
+++ b/terragrunt/modules/crates-io/fastly-static.tf
@@ -99,6 +99,7 @@ resource "fastly_service_dictionary_items" "compute_static" {
     "cloudfront-url" : local.cloudfront_domain_name
     "s3-primary-host" : local.primary_host_name
     "s3-fallback-host" : local.fallback_host_name
+    "service-name": var.static_domain_name
     "static-ttl" : var.static_ttl
     "request-logs-endpoint" : local.request_logs_endpoint
     "service-logs-endpoint" : local.service_logs_endpoint

--- a/terragrunt/modules/crates-io/fastly-static.tf
+++ b/terragrunt/modules/crates-io/fastly-static.tf
@@ -106,12 +106,15 @@ resource "fastly_service_dictionary_items" "compute_static" {
 
   items = {
     "cloudfront-url" : local.cloudfront_domain_name
+    "datadog-app" : "crates.io"
+    "datadog-env" : var.env
+    "datadog-host" : var.static_domain_name
     "datadog-request-logs-endpoint" : "datadog-${local.request_logs_endpoint}"
+    "datadog-service" : "static.crates.io"
     "s3-fallback-host" : local.fallback_host_name
     "s3-primary-host" : local.primary_host_name
     "s3-request-logs-endpoint" : "s3-${local.request_logs_endpoint}"
     "s3-service-logs-endpoint" : "s3-${local.service_logs_endpoint}"
-    "service-name" : var.static_domain_name
     "static-ttl" : var.static_ttl
   }
 }

--- a/terragrunt/modules/crates-io/fastly-static.tf
+++ b/terragrunt/modules/crates-io/fastly-static.tf
@@ -6,8 +6,12 @@ locals {
 
   dictionary_name = "compute_static"
 
-  request_logs_endpoint = "s3-request-logs"
-  service_logs_endpoint = "s3-service-logs"
+  request_logs_endpoint = "request-logs"
+  service_logs_endpoint = "service-logs"
+}
+
+data "aws_ssm_parameter" "datadog_token" {
+  name = "/${var.env}/crates-io/fastly/datadog-token"
 }
 
 data "external" "package" {
@@ -64,7 +68,7 @@ resource "fastly_service_compute" "static" {
   }
 
   logging_s3 {
-    name        = local.request_logs_endpoint
+    name        = "s3-${local.request_logs_endpoint}"
     bucket_name = aws_s3_bucket.logs.bucket
 
     s3_iam_role = aws_iam_role.fastly_assume_role.arn
@@ -75,7 +79,7 @@ resource "fastly_service_compute" "static" {
   }
 
   logging_s3 {
-    name        = local.service_logs_endpoint
+    name        = "s3-${local.service_logs_endpoint}"
     bucket_name = aws_s3_bucket.logs.bucket
 
     s3_iam_role = aws_iam_role.fastly_assume_role.arn
@@ -83,6 +87,11 @@ resource "fastly_service_compute" "static" {
     path        = "/fastly-logs/${var.static_domain_name}/"
 
     compression_codec = "zstd"
+  }
+
+  logging_datadog {
+    name  = "datadog-${local.request_logs_endpoint}"
+    token = data.aws_ssm_parameter.datadog_token.value
   }
 }
 
@@ -97,12 +106,13 @@ resource "fastly_service_dictionary_items" "compute_static" {
 
   items = {
     "cloudfront-url" : local.cloudfront_domain_name
-    "s3-primary-host" : local.primary_host_name
+    "datadog-request-logs-endpoint" : "datadog-${local.request_logs_endpoint}"
     "s3-fallback-host" : local.fallback_host_name
-    "service-name": var.static_domain_name
+    "s3-primary-host" : local.primary_host_name
+    "s3-request-logs-endpoint" : "s3-${local.request_logs_endpoint}"
+    "s3-service-logs-endpoint" : "s3-${local.service_logs_endpoint}"
+    "service-name" : var.static_domain_name
     "static-ttl" : var.static_ttl
-    "request-logs-endpoint" : local.request_logs_endpoint
-    "service-logs-endpoint" : local.service_logs_endpoint
   }
 }
 


### PR DESCRIPTION
crates.io recently [implement a few changes](https://blog.rust-lang.org/2024/03/11/crates-io-download-changes.html) that make `cargo` download crates directly from `static.crates.io` without hitting the API of crates.io first. This increases the performance and scalability of crates.io, but means that requests are no longer logged by the application. We want to restore the previous behavior by aggregating request logs from our CDNs in Datadog.

The Fastly service has been extended to include more information in its request logs and to stream them to Datadog. We're also tagging the logs with Datadog's [Unified Service Tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging) to provide visibility across the app (`crates.io`), service (`static.crates.io`), and different environments.