### PR TITLE
Grant ehuss and spastorino access to triagebot logs

### DIFF
--- a/terragrunt/accounts/root/aws-organization/terragrunt.hcl
+++ b/terragrunt/accounts/root/aws-organization/terragrunt.hcl
@@ -25,7 +25,7 @@ inputs = {
       given_name  = "Mark",
       family_name = "Rousskov"
       email       = "mark.simulacrum@gmail.com"
-      groups      = ["infra", "infra-admins"]
+      groups      = ["infra", "infra-admins", "triagebot"]
     }
     "rylev" = {
       given_name  = "Ryan",
@@ -68,6 +68,18 @@ inputs = {
       family_name = "Harvey"
       email = "adam@adamharvey.name"
       groups = ["crates-io"]
+    }
+    "ehuss" = {
+      given_name = "Eric"
+      family_name = "Huss"
+      email = "eric@huss.org"
+      groups = ["triagebot"]
+    }
+    "spastorino" = {
+      given_name = "Santiago"
+      family_name = "Pastorino"
+      email = "spastorino@gmail.com"
+      groups = ["triagebot"]
     }
   }
 }

--- a/terragrunt/modules/aws-organization/groups.tf
+++ b/terragrunt/modules/aws-organization/groups.tf
@@ -35,6 +35,13 @@ resource "aws_identitystore_group" "crates_io" {
   description  = "The crates.io team"
 }
 
+resource "aws_identitystore_group" "triagebot" {
+  identity_store_id = local.identity_store_id
+
+  display_name = "triagebot"
+  description  = "The triagebot maintainers"
+}
+
 # The different permission sets a group may have assigned to it
 
 resource "aws_ssoadmin_permission_set" "administrator_access" {
@@ -85,6 +92,55 @@ resource "aws_ssoadmin_managed_policy_attachment" "read_only_access" {
   permission_set_arn = aws_ssoadmin_permission_set.read_only_access.arn
 }
 
+// Triagebot team read-only access into the legacy account.
+resource "aws_ssoadmin_permission_set" "triagebot_access" {
+  instance_arn = local.instance_arn
+  name         = "TriagebotReadOnly"
+}
+
+data "aws_iam_policy_document" "triagebot_access" {
+  statement {
+    sid    = "ReadLogs"
+    effect = "Allow"
+    actions = [
+      // Subset of CloudwatchReadOnlyAccess
+      // See https://docs.aws.amazon.com/aws-managed-policy/latest/reference/CloudWatchReadOnlyAccess.html
+      "logs:Get*",
+      "logs:List*",
+      "logs:StartQuery",
+      "logs:Describe*",
+      "logs:FilterLogEvents",
+      "logs:StartLiveTail",
+      "logs:StopLiveTail",
+    ]
+    resources = [
+      "arn:aws:logs:us-west-1:890664054962:log-group:/ecs/triagebot",
+      "arn:aws:logs:us-west-1:890664054962:log-group:/ecs/triagebot:*",
+    ]
+  }
+
+  statement {
+    sid    = "NonResourceStatement"
+    effect = "Allow"
+    actions = [
+      // Subset of CloudwatchReadOnlyAccess
+      // See https://docs.aws.amazon.com/aws-managed-policy/latest/reference/CloudWatchReadOnlyAccess.html
+      "logs:StopQuery",
+      "logs:DescribeLogGroups",
+      "logs:DescribeQueries",
+      "logs:DescribeQueryDefinitions",
+      "logs:TestMetricFilter",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_ssoadmin_permission_set_inline_policy" "triagebot_access" {
+  inline_policy      = data.aws_iam_policy_document.triagebot_access.json
+  instance_arn       = local.instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.triagebot_access.arn
+}
+
 # The assignment of groups to accounts with their respective permission sets
 
 locals {
@@ -94,7 +150,7 @@ locals {
       account : aws_organizations_account.admin,
       groups : [
         { group : aws_identitystore_group.infra-admins,
-        permissions : [aws_ssoadmin_permission_set.view_only_access, aws_ssoadmin_permission_set.administrator_access] },
+        permissions : [aws_ssoadmin_permission_set.read_only_access, aws_ssoadmin_permission_set.administrator_access] },
         { group : aws_identitystore_group.billing,
         permissions : [aws_ssoadmin_permission_set.billing_access] },
         { group : aws_identitystore_group.infra,
@@ -106,11 +162,13 @@ locals {
       account : aws_organizations_account.legacy,
       groups : [
         { group : aws_identitystore_group.infra-admins,
-        permissions : [aws_ssoadmin_permission_set.view_only_access, aws_ssoadmin_permission_set.administrator_access] },
+        permissions : [aws_ssoadmin_permission_set.read_only_access, aws_ssoadmin_permission_set.administrator_access] },
         { group : aws_identitystore_group.billing,
         permissions : [aws_ssoadmin_permission_set.billing_access] },
         { group : aws_identitystore_group.infra,
-        permissions : [aws_ssoadmin_permission_set.view_only_access] }
+        permissions : [aws_ssoadmin_permission_set.view_only_access] },
+        { group : aws_identitystore_group.triagebot,
+        permissions : [aws_ssoadmin_permission_set.triagebot_access] },
       ]
     },
     # crates-io Staging
@@ -119,7 +177,6 @@ locals {
       groups : [
         { group : aws_identitystore_group.infra-admins,
           permissions : [
-            aws_ssoadmin_permission_set.view_only_access,
             aws_ssoadmin_permission_set.read_only_access,
             aws_ssoadmin_permission_set.administrator_access
         ] },
@@ -135,7 +192,6 @@ locals {
       groups : [
         { group : aws_identitystore_group.infra-admins,
           permissions : [
-            aws_ssoadmin_permission_set.view_only_access,
             aws_ssoadmin_permission_set.read_only_access,
             aws_ssoadmin_permission_set.administrator_access
         ] },

--- a/terragrunt/modules/aws-organization/users.tf
+++ b/terragrunt/modules/aws-organization/users.tf
@@ -4,6 +4,7 @@ locals {
     infra : aws_identitystore_group.infra
     infra-admins : aws_identitystore_group.infra-admins
     crates-io : aws_identitystore_group.crates_io
+    triagebot : aws_identitystore_group.triagebot
   }
 
   # Expand var.users into collection of group memberships associations


### PR DESCRIPTION
This grants scoped-down access to just the triagebot log group in our legacy AWS account. The console appears to still be usable with the access granted here, so it seems good enough. Note that we do grant ability to list all log groups but this is not particularly meaningful.

cc @ehuss @spastorino