### PR TITLE
Support multiple AWS regions in Terragrunt

### DIFF
--- a/terragrunt/accounts/bors-prod/account.json
+++ b/terragrunt/accounts/bors-prod/account.json
@@ -1,6 +1,10 @@
 {
     "aws": {
         "profile": "bors-prod",
-        "region": "us-east-2"
+        "regions": [
+            {
+                "region": "us-east-2"
+            }
+        ]
     }
 }

--- a/terragrunt/accounts/bors-staging/account.json
+++ b/terragrunt/accounts/bors-staging/account.json
@@ -1,6 +1,10 @@
 {
     "aws": {
         "profile": "bors-staging",
-        "region": "us-east-2"
+        "regions": [
+            {
+                "region": "us-east-2"
+            }
+        ]
     }
 }

--- a/terragrunt/accounts/crates-io-prod/account.json
+++ b/terragrunt/accounts/crates-io-prod/account.json
@@ -1,6 +1,10 @@
 {
     "aws": {
         "profile": "crates-io-prod",
-        "region": "us-west-1"
+        "regions": [
+            {
+                "region": "us-west-1"
+            }
+        ]
     }
 }

--- a/terragrunt/accounts/crates-io-staging/account.json
+++ b/terragrunt/accounts/crates-io-staging/account.json
@@ -1,6 +1,14 @@
 {
     "aws": {
         "profile": "crates-io-staging",
-        "region": "us-west-1"
+        "regions": [
+            {
+                "region": "us-west-1"
+            },
+            {
+                "region": "us-east-1",
+                "alias": "us-east-1"
+            }
+        ]
     }
 }

--- a/terragrunt/accounts/dev-desktops-prod/account.json
+++ b/terragrunt/accounts/dev-desktops-prod/account.json
@@ -1,6 +1,10 @@
 {
     "aws": {
         "profile": "dev-desktops-prod",
-        "region": "us-east-1"
+        "regions": [
+            {
+                "region": "us-east-1"
+            }
+        ]
     }
 }

--- a/terragrunt/accounts/legacy/account.json
+++ b/terragrunt/accounts/legacy/account.json
@@ -1,6 +1,10 @@
 {
     "aws": {
         "profile": null,
-        "region": "us-west-1"
+        "regions": [
+            {
+                "region": "us-west-1"
+            }
+        ]
     }
 }

--- a/terragrunt/accounts/root/account.json
+++ b/terragrunt/accounts/root/account.json
@@ -1,6 +1,10 @@
 {
     "aws": {
         "profile": "rust-root",
-        "region": "us-east-1"
+        "regions": [
+            {
+                "region": "us-east-1"
+            }
+        ]
     }
 }

--- a/terragrunt/accounts/sync-team-prod/account.json
+++ b/terragrunt/accounts/sync-team-prod/account.json
@@ -1,6 +1,10 @@
 {
     "aws": {
         "profile": "sync-team-prod",
-        "region": "us-east-2"
+        "regions": [
+            {
+                "region": "us-east-2"
+            }
+        ]
     }
 }

--- a/terragrunt/terragrunt-locals.py
+++ b/terragrunt/terragrunt-locals.py
@@ -56,19 +56,24 @@ def calculate_remote_state_key(account_json_file, terragrunt_dir):
 
 
 def calculate_providers_content(account_json):
-    if account_json["aws"]["profile"] is not None:
-        return f"""
+    providers = ""
+
+    for region in account_json["aws"]["regions"]:
+        body = f'  region = "{region["region"]}"'
+
+        if account_json["aws"]["profile"] is not None:
+            body += f'\n  profile = "{account_json["aws"]["profile"]}"'
+
+        if "alias" in region:
+            body += f'\n  alias = "{region["alias"]}"'
+
+        providers += f"""
 provider "aws" {{
-  profile = "{account_json["aws"]["profile"]}"
-  region = "{account_json["aws"]["region"]}"
+{body}
 }}
 """
-    else:
-        return f"""
-provider "aws" {{
-  region = "{account_json["aws"]["region"]}"
-}}
-"""
+
+    return providers
 
 
 def profile_args(account_json):


### PR DESCRIPTION
Some of our Terraform modules deploy resources to different regions simultaneously. This is done by defining multiple `provider` blocks for AWS with different regions and different aliases, which can then be references in the Terraform resources.

With Terragrunt, we are dynamically creating the `provider` block and overwriting any additional providers that are defined in Terraform files. Our script has therefore been extended to accept multiple regions in the `account.json` file and expand them to the same structure that we were using before with Terraform.