### PR TITLE
Tag rustup artifacts with surrogate key

### DIFF
--- a/terragrunt/modules/release-distribution/fastly-static.tf
+++ b/terragrunt/modules/release-distribution/fastly-static.tf
@@ -79,6 +79,21 @@ resource "fastly_service_vcl" "static" {
     VCL
   }
 
+  # When a new version of rustup is released, the release script invalidates
+  # the CloudFront cache for `/rustup/*` and any object that is tagged with
+  # the `rustup` key on Fastly.
+  # See https://github.com/rust-lang/rustup/blob/master/ci/sync-dist.py for
+  # details.
+  snippet {
+    name    = "set cache key for rustup"
+    type    = "fetch"
+    content = <<-VCL
+      if (req.url ~ "^\/rustup\/") {
+        set beresp.http.Surrogate-Key = "rustup";
+      }
+    VCL
+  }
+
   snippet {
     name    = "redirect rustup.sh to rustup.rs"
     type    = "error"


### PR DESCRIPTION
We use surrogate keys[^1] on Fastly to invalidate the cache for specific objects, e.g. when new versions of Rust or rustup are released. Surrogate keys are transparently set in the Fastly configuration based on the request path.

A new VCL snippet has been added that tags every rustup artifact with the `rustup` surrogate key so that we can purge them from the cache when a new rustup version is released.

This is part of #415.

[^1]: https://www.fastly.com/documentation/guides/concepts/edge-state/cache/purging/#surrogate-key-purge