### PR TITLE
Give infra team admin access to staging bors

### DIFF
--- a/terragrunt/modules/aws-organization/groups.tf
+++ b/terragrunt/modules/aws-organization/groups.tf
@@ -234,7 +234,7 @@ locals {
       account : aws_organizations_account.bors_staging,
       groups : [
         { group : aws_identitystore_group.infra,
-        permissions : [aws_ssoadmin_permission_set.read_only_access] },
+        permissions : [aws_ssoadmin_permission_set.read_only_access, aws_ssoadmin_permission_set.administrator_access] },
         { group : aws_identitystore_group.infra-admins,
         permissions : [aws_ssoadmin_permission_set.read_only_access, aws_ssoadmin_permission_set.administrator_access] },
       ]

--- a/terragrunt/modules/bors/main.tf
+++ b/terragrunt/modules/bors/main.tf
@@ -70,7 +70,7 @@ resource "aws_iam_role" "gha" {
         }
         Condition = {
           StringLike = {
-            "token.actions.githubusercontent.com:sub" : "repo:rust-lang/bors:ref:refs/heads/staging"
+            "token.actions.githubusercontent.com:sub" : "repo:rust-lang/bors:ref:refs/heads/main"
           }
           StringEquals = {
             "token.actions.githubusercontent.com:aud" : "sts.amazonaws.com"


### PR DESCRIPTION
Let me know if you want me to create a separate bors team for this, rather than giving infra team the permissions. But I think that the staging environment shouldn't be too sensitive (provided that we uninstall the staging bors GH app from rust-lang/rust).