### PR TITLE
Allow the crates.io team to manage log pipelines

### DIFF
--- a/terraform/team-members-datadog/crates-io.tf
+++ b/terraform/team-members-datadog/crates-io.tf
@@ -13,6 +13,8 @@ resource "datadog_role" "crates_io" {
       data.datadog_permissions.all.permissions.logs_read_index_data,
       data.datadog_permissions.all.permissions.logs_read_data,
       data.datadog_permissions.all.permissions.logs_live_tail,
+      data.datadog_permissions.all.permissions.logs_write_pipelines,
+      data.datadog_permissions.all.permissions.logs_write_processors,
       data.datadog_permissions.all.permissions.logs_read_archives,
       data.datadog_permissions.all.permissions.dashboards_write,
     ])


### PR DESCRIPTION
We use Datadog among other reasons for the application logs from crates.io. As new features or services are added, the crates.io team reguarly wants to tweak the pipelines slightly to improve the parsing of logs and extract data into metrics. This requires elevated permissions to the log pipelines and processors. While ideally, we would only grant these permissions for the specific pipeline used by crates.io, this is not possible through the API as far as we know.