### PR TITLE
Move Terraform providers into account.json

### DIFF
--- a/terragrunt/accounts/legacy/account.json
+++ b/terragrunt/accounts/legacy/account.json
@@ -8,6 +8,10 @@
             {
                 "region": "us-east-1",
                 "alias": "us-east-1"
+            },
+            {
+                "region": "eu-west-1",
+                "alias": "eu-west-1"
             }
         ]
     }

--- a/terragrunt/modules/crates-io/_terraform.tf
+++ b/terragrunt/modules/crates-io/_terraform.tf
@@ -12,16 +12,6 @@ terraform {
   }
 }
 
-provider "aws" {
-  alias  = "us-east-1"
-  region = "us-east-1"
-}
-
-provider "aws" {
-  alias  = "eu-west-1"
-  region = "eu-west-1"
-}
-
 provider "fastly" {}
 
 data "aws_caller_identity" "current" {}


### PR DESCRIPTION
Due to how Terragrunt generates the provider configuration, we use the account.json file to declare additional providers for Terraform. The existing providers for the crates.io module have been moved from Terraform to that file to avoid a duplicate provider error when running Terraform.