### PR TITLE
Onboard crates.io on-call team to Datadog

### DIFF
--- a/terraform/team-members-datadog/crates-io-oncall.tf
+++ b/terraform/team-members-datadog/crates-io-oncall.tf
@@ -1,0 +1,39 @@
+locals {
+  crates_io_oncall = {
+    "andrei_listochkin" = local.users.andrei_listochkin
+    "felix_gilcher"     = local.users.felix_gilcher
+    "florian_gilcher"   = local.users.florian_gilcher
+    "pietro_albini"     = local.users.pietro_albini
+    "sebastian_ziebell" = local.users.sebastian_ziebell
+    "thepang_mbambo"    = local.users.tshepang_mbambo
+  }
+}
+
+resource "datadog_role" "crates_io_oncall" {
+  name = "crates.io on-call"
+
+  dynamic "permission" {
+    for_each = toset([
+      data.datadog_permissions.all.permissions.logs_read_index_data,
+      data.datadog_permissions.all.permissions.logs_read_data,
+      data.datadog_permissions.all.permissions.logs_live_tail,
+    ])
+
+    content {
+      id = permission.value
+    }
+  }
+}
+
+resource "datadog_team" "crates_io_oncall" {
+  name        = "crates.io on-call"
+  description = "The on-call team for crates.io"
+  handle      = "crates-io-oncall"
+}
+
+resource "datadog_team_membership" "crates_io_oncall" {
+  for_each = local.crates_io_oncall
+
+  team_id = datadog_team.crates_io_oncall.id
+  user_id = datadog_user.users[each.key].id
+}

--- a/terraform/team-members-datadog/crates-io.tf
+++ b/terraform/team-members-datadog/crates-io.tf
@@ -1,7 +1,9 @@
 locals {
   crates_io = {
-    "adam"   = local.users.adam
-    "tobias" = local.users.tobias
+    "adam"     = local.users.adam
+    "carol"    = local.users.carols10cents
+    "jtgeibel" = local.users.jtgeibel
+    "tobias"   = local.users.tobias
   }
 }
 
@@ -16,6 +18,7 @@ resource "datadog_role" "crates_io" {
       data.datadog_permissions.all.permissions.logs_write_pipelines,
       data.datadog_permissions.all.permissions.logs_write_processors,
       data.datadog_permissions.all.permissions.logs_read_archives,
+      data.datadog_permissions.all.permissions.logs_write_processors,
       data.datadog_permissions.all.permissions.dashboards_write,
     ])
 

--- a/terraform/team-members-datadog/users.tf
+++ b/terraform/team-members-datadog/users.tf
@@ -8,6 +8,22 @@ locals {
       login = "admin@rust-lang.org"
       name  = "Rust Admin"
     }
+    "andrei_listochkin" = {
+      login = "andrei.listochkin@ferrous-systems.com"
+      name  = "Andrei Listochkin"
+    }
+    "carols10cents" = {
+      login = "carol.nichols@gmail.com"
+      name  = "Carol Nichols"
+    }
+    "felix_gilcher" = {
+      login = "felix.gilcher@ferrous-systems.com"
+      name  = "Felix Gilcher"
+    }
+    "florian_gilcher" = {
+      login = "florian.gilcher@ferrous-systems.com"
+      name  = "Florian Gilcher"
+    }
     "jakub" = {
       login = "berykubik@gmail.com"
       name  = "Jakub Beránek"
@@ -19,6 +35,10 @@ locals {
     "joel" = {
       login = "joelmarcey@rustfoundation.org"
       name  = "Joel Marcey"
+    }
+    "jtgeibel" = {
+      login = "jtgeibel@gmail.com"
+      name  = "Justin Geibel"
     }
     "mark" = {
       login = "mark.simulacrum@gmail.com"
@@ -40,9 +60,17 @@ locals {
       login = "pietro@pietroalbini.org"
       name  = "Pietro Albini"
     }
+    "pietro_albini" = {
+      login = "pietro.albini@ferrous-systems.com"
+      name  = "Pietro Albini"
+    }
     "rustfoundation" = {
       login = "infra@rustfoundation.org"
       name  = "Rust Foundation Infrastructure"
+    }
+    "sebastian_ziebell" = {
+      login = "sebastian.ziebell@ferrous-systems.com"
+      name  = "Sebastian Ziebell"
     }
     "seth" = {
       login = "smarkle.aws@gmail.com"
@@ -51,6 +79,10 @@ locals {
     "tobias" = {
       login = "tobiasbieniek@rustfoundation.org"
       name  = "Tobias Bieniek"
+    }
+    "tshepang_mbambo" = {
+      login = "tshepang.mbambo@ferrous-systems.com"
+      name  = "Tshepang Mbambo"
     }
     "walter" = {
       login = "walterpearce@rustfoundation.org"
@@ -71,6 +103,7 @@ locals {
   _do_not_use_all_teams = [
     { for name, user in local.crater : name => merge(user, { roles = [datadog_role.crater.name] }) },
     { for name, user in local.crates_io : name => merge(user, { roles = [datadog_role.crates_io.name] }) },
+    { for name, user in local.crates_io_oncall : name => merge(user, { roles = [datadog_role.crates_io_oncall.name] }) },
     { for name, user in local.foundation : name => merge(user, { roles = [datadog_role.foundation.name] }) },
     { for name, user in local.foundation_board : name => merge(user, { roles = [datadog_role.board_member.name] }) },
     { for name, user in local.infra : name => merge(user, { roles = [datadog_role.infra.name] }) },


### PR DESCRIPTION
Accounts for the on-call team for crates.io have been created in Datadog. The team has read-only access to the logs and dashboards. The crates.io team can assist with any modifications to the log pipeline or any dashboards that the team might need.