### PR TITLE
Expand Datadog permissions

### DIFF
--- a/terraform/team-members-datadog/crater.tf
+++ b/terraform/team-members-datadog/crater.tf
@@ -10,6 +10,7 @@ resource "datadog_role" "crater" {
   dynamic "permission" {
     for_each = toset([
       data.datadog_permissions.all.permissions.dashboards_write,
+      data.datadog_permissions.all.permissions.notebooks_write,
       data.datadog_permissions.all.permissions.api_keys_read,
       data.datadog_permissions.all.permissions.user_app_keys,
     ])

--- a/terraform/team-members-datadog/crates-io.tf
+++ b/terraform/team-members-datadog/crates-io.tf
@@ -18,8 +18,8 @@ resource "datadog_role" "crates_io" {
       data.datadog_permissions.all.permissions.logs_write_pipelines,
       data.datadog_permissions.all.permissions.logs_write_processors,
       data.datadog_permissions.all.permissions.logs_read_archives,
-      data.datadog_permissions.all.permissions.logs_write_processors,
       data.datadog_permissions.all.permissions.dashboards_write,
+      data.datadog_permissions.all.permissions.notebooks_write,
     ])
 
     content {

--- a/terraform/team-members-datadog/foundation.tf
+++ b/terraform/team-members-datadog/foundation.tf
@@ -16,6 +16,10 @@ resource "datadog_role" "foundation" {
   dynamic "permission" {
     for_each = toset([
       data.datadog_permissions.all.permissions.dashboards_write,
+      data.datadog_permissions.all.permissions.dashboards_public_share,
+      data.datadog_permissions.all.permissions.notebooks_write,
+      data.datadog_permissions.all.permissions.logs_generate_metrics,
+      data.datadog_permissions.all.permissions.metrics_metadata_write,
     ])
 
     content {

--- a/terraform/team-members-datadog/infra.tf
+++ b/terraform/team-members-datadog/infra.tf
@@ -18,6 +18,7 @@ resource "datadog_role" "infra" {
       data.datadog_permissions.all.permissions.logs_live_tail,
       data.datadog_permissions.all.permissions.logs_read_archives,
       data.datadog_permissions.all.permissions.dashboards_write,
+      data.datadog_permissions.all.permissions.notebooks_write,
       data.datadog_permissions.all.permissions.saved_views_write,
       data.datadog_permissions.all.permissions.api_keys_read,
       data.datadog_permissions.all.permissions.api_keys_write,


### PR DESCRIPTION
More permissions on Datadog have been granted.

Notebooks can be a useful feature for teams to document their processes or create runbooks for debugging. They are free to use, so the permission has been granted to all teams.

The staff of the Rust Foundation has additionally been granted the permissions to create metrics from logs, edit their metadata, and share dashboards publicly. These permissions are limited to staff for now, because custom metrics are a paid feature and we want to limit who can share data publicly.