### PR TITLE
Create S3 bucket for Rustup build artifacts

### DIFF
--- a/terragrunt/accounts/legacy/rustup-prod/rustup/.terraform.lock.hcl
+++ b/terragrunt/accounts/legacy/rustup-prod/rustup/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.67.0"
+  constraints = "~> 4.20"
+  hashes = [
+    "h1:5Zfo3GfRSWBaXs4TGQNOflr1XaYj6pRnVJLX5VAjFX4=",
+    "zh:0843017ecc24385f2b45f2c5fce79dc25b258e50d516877b3affee3bef34f060",
+    "zh:19876066cfa60de91834ec569a6448dab8c2518b8a71b5ca870b2444febddac6",
+    "zh:24995686b2ad88c1ffaa242e36eee791fc6070e6144f418048c4ce24d0ba5183",
+    "zh:4a002990b9f4d6d225d82cb2fb8805789ffef791999ee5d9cb1fef579aeff8f1",
+    "zh:559a2b5ace06b878c6de3ecf19b94fbae3512562f7a51e930674b16c2f606e29",
+    "zh:6a07da13b86b9753b95d4d8218f6dae874cf34699bca1470d6effbb4dee7f4b7",
+    "zh:768b3bfd126c3b77dc975c7c0e5db3207e4f9997cf41aa3385c63206242ba043",
+    "zh:7be5177e698d4b547083cc738b977742d70ed68487ce6f49ecd0c94dbf9d1362",
+    "zh:8b562a818915fb0d85959257095251a05c76f3467caa3ba95c583ba5fe043f9b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9c385d03a958b54e2afd5279cd8c7cbdd2d6ca5c7d6a333e61092331f38af7cf",
+    "zh:b3ca45f2821a89af417787df8289cb4314b273d29555ad3b2a5ab98bb4816b3b",
+    "zh:da3c317f1db2469615ab40aa6baba63b5643bae7110ff855277a1fb9d8eb4f2c",
+    "zh:dc6430622a8dc5cdab359a8704aec81d3825ea1d305bbb3bbd032b1c6adfae0c",
+    "zh:fac0d2ddeadf9ec53da87922f666e1e73a603a611c57bcbc4b86ac2821619b1d",
+  ]
+}

--- a/terragrunt/accounts/legacy/rustup-prod/rustup/terragrunt.hcl
+++ b/terragrunt/accounts/legacy/rustup-prod/rustup/terragrunt.hcl
@@ -1,0 +1,8 @@
+terraform {
+  source = "git::../../../../..//terragrunt/modules/rustup?ref=${trimspace(file("../deployed-ref"))}"
+}
+
+include {
+  path           = find_in_parent_folders()
+  merge_strategy = "deep"
+}

--- a/terragrunt/accounts/legacy/rustup-prod/rustup/terragrunt.hcl
+++ b/terragrunt/accounts/legacy/rustup-prod/rustup/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "git::../../../../..//terragrunt/modules/rustup?ref=${trimspace(file("../deployed-ref"))}"
+  source = "../../../../..//terragrunt/modules/rustup"
 }
 
 include {

--- a/terragrunt/modules/rustup/_terraform.tf
+++ b/terragrunt/modules/rustup/_terraform.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = "~> 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.20"
+    }
+  }
+}
+

--- a/terragrunt/modules/rustup/s3.tf
+++ b/terragrunt/modules/rustup/s3.tf
@@ -1,0 +1,32 @@
+# The rust-lang/rustup repository on GitHub builds and uploads Rustup artifacts
+# to this S3 bucket.
+resource "aws_s3_bucket" "builds" {
+  provider = aws.us-east-1
+
+  bucket = "rustup-builds"
+}
+
+module "aws_iam_user" {
+  source = "../gha-iam-user"
+  org    = "rust-lang"
+  repo   = "rustup"
+}
+
+data "aws_iam_policy_document" "upload_builds" {
+  statement {
+    sid    = "WriteToRustupBuilds"
+    effect = "Allow"
+
+    actions = [
+      "s3:PutObject",
+    ]
+
+    resources = ["${aws_s3_bucket.builds.arn}/*"]
+  }
+}
+
+resource "aws_iam_user_policy" "upload_builds" {
+  name   = "upload-rustup-builds"
+  user   = module.aws_iam_user.user_name
+  policy = data.aws_iam_policy_document.upload_builds.json
+}

--- a/terragrunt/modules/rustup/s3.tf
+++ b/terragrunt/modules/rustup/s3.tf
@@ -30,3 +30,22 @@ resource "aws_iam_user_policy" "upload_builds" {
   user   = module.aws_iam_user.user_name
   policy = data.aws_iam_policy_document.upload_builds.json
 }
+
+data "aws_iam_policy_document" "legacy_ci" {
+  statement {
+    sid    = "WriteToDevStatic"
+    effect = "Allow"
+
+    actions = [
+      "s3:*",
+    ]
+
+    resources = ["arn:aws:s3:::dev-static-rust-lang-org/rustup/*"]
+  }
+}
+
+resource "aws_iam_user_policy" "legacy_ci" {
+  name   = "legacy-ci"
+  user   = module.aws_iam_user.user_name
+  policy = data.aws_iam_policy_document.legacy_ci.json
+}


### PR DESCRIPTION
A new S3 bucket is being created as part of the effort to rebuild the Rustup release process. The bucket will store the build artifacts for Rustup, which the GitHub Actions in rust-lang/rustup will produce.

Since the bucket is tied to a GitHub repository, only a single bucket in the production environment is being created.