### PR TITLE
Deploy bors-prod account

### DIFF
--- a/terragrunt/accounts/bors-prod/app/.terraform.lock.hcl
+++ b/terragrunt/accounts/bors-prod/app/.terraform.lock.hcl
@@ -1,0 +1,43 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.8.0"
+  hashes = [
+    "h1:vnjWfeuf4AflWsRq3ivVig8dR8PAg8BHTVyAtOzJ1yQ=",
+    "zh:0974311d5e1becfdcbdae43d022d52689fdad32a4145659e56ac534bcb8cba02",
+    "zh:100dc64a90fc0d36cf6e2882b4358fde17705edd8ab3c5f2c06d219c36b21565",
+    "zh:467a86de8a7d77cde5c3386f9e82d7f1bf5972d1b3d177e797d1d9d2e87fd357",
+    "zh:4ad1f8ef5c5522f81d271b93594a43a7666b3409ca201a1911cd950e489ef12b",
+    "zh:540a50ab7061c6df2057ec9580890a9e86a687233120af738985fa84dde2a20a",
+    "zh:6e7b73b770e92891da94751c3e0cff1e1b852f5121da8c4a689056833eeb7d94",
+    "zh:879d42721e86331b05ff77bd219ca9a062485cdb2fa803d2dcf63084f25d484c",
+    "zh:980563e615fbba127c02df6dc8872ce60f7137df45fdb8cd801cdcbae6cf192a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a6ad25c4d3edde466ea68731097aedad4b68278af0742fc1ab71d2c30491f92e",
+    "zh:af8df9e06f576c11ce67ac2b675d0d8db4aac618fec95d27c10aa59436feebbf",
+    "zh:b625ca7c4b99c6b3af34041b9773ccd9d80b0dde264c40b5d163a6abd73793af",
+    "zh:c9e0ca6aa48ebaa0892ac438392c49052a86605f490950d5317855f35ab7d74a",
+    "zh:dc500a03d3ed6b1fed3f118a55a7fb93bf172965ae6b2f25cc7f4a152e44edd7",
+    "zh:e0438bf67d93a29f0d56f9a4544297155ca85c0f10626778d4c3aa68c7e93581",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.5.1"
+  hashes = [
+    "h1:IL9mSatmwov+e0+++YX2V6uel+dV6bn+fC/cnGDK3Ck=",
+    "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
+    "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
+    "zh:4d2b219d09abf3b1bb4df93d399ed156cadd61f44ad3baf5cf2954df2fba0831",
+    "zh:6130bdde527587bbe2dcaa7150363e96dbc5250ea20154176d82bc69df5d4ce3",
+    "zh:6cc326cd4000f724d3086ee05587e7710f032f94fc9af35e96a386a1c6f2214f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b6d88e1d28cf2dfa24e9fdcc3efc77adcdc1c3c3b5c7ce503a423efbdd6de57b",
+    "zh:ba74c592622ecbcef9dc2a4d81ed321c4e44cddf7da799faa324da9bf52a22b2",
+    "zh:c7c5cde98fe4ef1143bd1b3ec5dc04baf0d4cc3ca2c5c7d40d17c0e9b2076865",
+    "zh:dac4bad52c940cd0dfc27893507c1e92393846b024c5a9db159a93c534a3da03",
+    "zh:de8febe2a2acd9ac454b844a4106ed295ae9520ef54dc8ed2faf29f12716b602",
+    "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
+  ]
+}

--- a/terragrunt/accounts/bors-prod/app/terragrunt.hcl
+++ b/terragrunt/accounts/bors-prod/app/terragrunt.hcl
@@ -8,5 +8,5 @@ include {
 }
 
 inputs = {
-  domain = "bors-staging.rust-lang.net"
+  domain = "bors-prod.rust-lang.net"
 }

--- a/terragrunt/modules/bors/main.tf
+++ b/terragrunt/modules/bors/main.tf
@@ -377,7 +377,7 @@ resource "aws_lb_listener" "primary" {
 }
 
 resource "aws_acm_certificate" "primary" {
-  domain_name       = "bors-staging.rust-lang.net"
+  domain_name       = var.domain
   validation_method = "DNS"
 
   lifecycle {
@@ -386,7 +386,7 @@ resource "aws_acm_certificate" "primary" {
 }
 
 data "aws_route53_zone" "net" {
-  name         = "bors-staging.rust-lang.net"
+  name         = var.domain
   private_zone = false
 }
 
@@ -414,7 +414,7 @@ resource "aws_acm_certificate_validation" "primary" {
 
 resource "aws_route53_record" "lb" {
   zone_id = data.aws_route53_zone.net.zone_id
-  name    = "bors-staging.rust-lang.net"
+  name    = var.domain
   type    = "A"
 
   alias {
@@ -489,4 +489,8 @@ resource "aws_vpc_security_group_egress_rule" "rds_egress_anywhere_v6" {
   from_port   = -1
   ip_protocol = -1
   to_port     = -1
+}
+
+variable "domain" {
+  description = "domain to use"
 }


### PR DESCRIPTION
This adds the DNS name configuration and configures deployment via GHA to the production account.

This has already been deployed.