### PR TITLE
remove dead/broken bootstrap stage detection from link_rust.sh

### DIFF
--- a/ansible/roles/dev-desktop/files/scripts/link_rust.sh
+++ b/ansible/roles/dev-desktop/files/scripts/link_rust.sh
@@ -20,13 +20,7 @@ for D in rust*; do
   if [ -d "$D" ]; then
     pushd "$D"
 
-    bootstrap_version=$(grep 'pub const VERSION' src/bootstrap/lib.rs | grep -o '[0-9]*')
-
-    if [ "$bootstrap_version" -gt 2 ]; then
-      stages=(stage1-sysroot stage2-sysroot)
-    else
-      stages=(stage1 stage2)
-    fi
+    stages=(stage1 stage2)
 
     for stage in "${stages[@]}"; do
       directory="build/${target}/${stage}"


### PR DESCRIPTION
Closes #246

This became even more broken with rust-lang/rust#116196, which renamed `src/bootstrap/lib.rs`

It currently fails with:

```
gh-aDotInTheVoid@dev-desktop-eu-2:~$ /usr/local/bin/link_rust.sh
~/rust ~
grep: src/bootstrap/lib.rs: No such file or directory
```

I've tested locally that the fix works.