### PR TITLE
Install sappling-scm ( see https://sapling-scm.com )

### DIFF
--- a/ansible/roles/dev-desktop/tasks/dependencies.yml
+++ b/ansible/roles/dev-desktop/tasks/dependencies.yml
@@ -53,6 +53,7 @@
       - mold
       - neovim
       - parallel
+      - sapling # see https://sapling-scm.com/ for more information
       # Necessary for building rr
       - capnproto
       - libcapnp-dev


### PR DESCRIPTION
It is personally a better scm and supports git under the hood. I can not justify getting it installed system wide, can I please get it for user gh-mav3ri3k.