### PR TITLE
docs.rs: allow POST requests

### DIFF
--- a/terraform/docs-rs/cloudfront.tf
+++ b/terraform/docs-rs/cloudfront.tf
@@ -90,7 +90,7 @@ resource "aws_cloudfront_distribution" "webapp" {
 
   default_cache_behavior {
     target_origin_id       = "ec2"
-    allowed_methods        = ["GET", "HEAD", "OPTIONS"]
+    allowed_methods        = ["GET", "HEAD", "OPTIONS", "POST"]
     cached_methods         = ["GET", "HEAD", "OPTIONS"]
     compress               = true
     viewer_protocol_policy = "redirect-to-https"


### PR DESCRIPTION
For https://github.com/rust-lang/docs.rs/pull/2534 we need to allow `POST` requests. 

( I'm not 100% sure if this change is enough? I looked at the crates.io web-app policy )