### PR TITLE
fix(aws-cred): accept any mfa name

### DIFF
--- a/aws-creds.py
+++ b/aws-creds.py
@@ -72,10 +72,7 @@ def load_mfa_device():
 
     serial = None
     for device in mfa_out["MFADevices"]:
-        # Only TOTP devices are supported
         user = device["UserName"]
-        if not device["SerialNumber"].endswith(f":mfa/{user}"):
-            continue
 
         # Only a single TOTP device is supported
         if serial is None:


### PR DESCRIPTION
MFA can have different names. JD said this is a recent change.
With this fix, this script works for me 👍
