### PR TITLE
Update AWS access

### DIFF
--- a/terraform/team-members-access/_users.tf
+++ b/terraform/team-members-access/_users.tf
@@ -3,7 +3,6 @@
 
 locals {
   users = {
-    "jynelson"      = [aws_iam_group.docs_rs.name, aws_iam_group.infra_team.name],
     "pietroalbini"  = [aws_iam_group.infra_admins.name],
     "simulacrum"    = [aws_iam_group.infra_admins.name],
     "jdn"           = [aws_iam_group.infra_admins.name],
@@ -12,7 +11,6 @@ locals {
     "carols10cents" = [aws_iam_group.crates_io.name],
     "jtgeibel"      = [aws_iam_group.crates_io.name],
     "Turbo87"       = [aws_iam_group.crates_io.name],
-    "rylev"         = [aws_iam_group.rustc_perf.name, aws_iam_group.infra_team.name],
     "JoelMarcey"    = [aws_iam_group.foundation.name],
     "rebeccarumbul" = [aws_iam_group.foundation.name],
     "abibroom"      = [aws_iam_group.foundation.name],

--- a/terragrunt/accounts/root/aws-organization/terragrunt.hcl
+++ b/terragrunt/accounts/root/aws-organization/terragrunt.hcl
@@ -81,5 +81,17 @@ inputs = {
       email       = "marcoieni@rustfoundation.org"
       groups      = ["infra", "infra-admins"]
     }
+    "boxyuwu" = {
+      given_name  = "Boxy"
+      family_name = "UwU"
+      email       = "rust@boxyuwu.dev"
+      groups      = ["release"]
+    }
+    "cuviper" = {
+      given_name  = "Josh"
+      family_name = "Stone"
+      email       = "cuviper@gmail.com"
+      groups      = ["release"]
+    }
   }
 }

--- a/terragrunt/accounts/root/aws-organization/terragrunt.hcl
+++ b/terragrunt/accounts/root/aws-organization/terragrunt.hcl
@@ -27,12 +27,6 @@ inputs = {
       email       = "mark.simulacrum@gmail.com"
       groups      = ["infra", "infra-admins", "release", "triagebot"]
     }
-    "rylev" = {
-      given_name  = "Ryan",
-      family_name = "Levick"
-      email       = "me@ryanlevick.com"
-      groups      = ["infra"]
-    }
     "shepmaster" = {
       given_name  = "Jake",
       family_name = "Goulding",


### PR DESCRIPTION
This PR removes access from previous members of the infra team, and grants access to the members of t-release who can now publish Rust releases.

This has already been deployed.