### PR TITLE
feat(crates-io): replicate entire bucket in fallback

### DIFF
--- a/terragrunt/modules/crates-io/s3-static.tf
+++ b/terragrunt/modules/crates-io/s3-static.tf
@@ -46,10 +46,6 @@ resource "aws_s3_bucket_replication_configuration" "static" {
     id     = "crates"
     status = "Enabled"
 
-    filter {
-      prefix = "crates/"
-    }
-
     destination {
       bucket        = aws_s3_bucket.fallback.arn
       storage_class = "INTELLIGENT_TIERING"


### PR DESCRIPTION
The crates-io bucket contain many directories:
<img width="444" alt="Screenshot 2024-08-01 at 17 36 30" src="https://github.com/user-attachments/assets/84b43717-e70f-4265-a2af-6653d2871b8a">

However the fallback contains just `crates`:
<img width="371" alt="Screenshot 2024-08-01 at 17 36 10" src="https://github.com/user-attachments/assets/0397254a-d947-4361-a8a2-656503f1bcc3">

I think we should replicate the entire content of the bucket, so I'm removing the filter 👍 