### PR TITLE
feat: serve version downloads `index.html`

### DIFF
--- a/terragrunt/accounts/legacy/crates-io-prod/deployed-ref
+++ b/terragrunt/accounts/legacy/crates-io-prod/deployed-ref
@@ -1,1 +1,1 @@
-585e9aabc4a5387af5c7aaebd68b095c1fcf89af
+fe7f3b92fbe04cd9d36bf36992f653ce27c7e8c7

--- a/terragrunt/modules/crates-io/cloudfront-functions/static-router.js
+++ b/terragrunt/modules/crates-io/cloudfront-functions/static-router.js
@@ -1,10 +1,16 @@
 function handler(event) {
     var request = event.request;
+    var versionDownloads ='/archive/version-downloads/';
 
     // URL-encode the `+` character in the request URI
     // See more: https://github.com/rust-lang/crates.io/issues/4891
     if (request.uri.includes("+")) {
         request.uri = request.uri.replace("+", "%2B");
+    } else if (request.uri === versionDownloads) {
+        request.uri += 'index.html';
+        return request;
+    } else if (request.uri === '/archive/version-downloads') {
+        return permanentRedirect(versionDownloads);
     }
 
     // cargo versions before 1.24 don't support placeholders in the `dl` field
@@ -18,4 +24,14 @@ function handler(event) {
     }
 
     return request;
+}
+
+function permanentRedirect(destination) {
+    return {
+        statusCode: 301,
+        statusDescription: 'Moved Permanently',
+        headers: {
+            'location': { value: destination },
+        },
+    };
 }


### PR DESCRIPTION
- [x] test this after applying it. both in cloudfront and fastly

blocked by https://github.com/rust-lang/crates.io/pull/9207

related to https://github.com/rust-lang/simpleinfra/issues/436