### PR TITLE
chore(legacy-account): delete unused docs-rs db

### DIFF
--- a/terraform/docs-rs/rds.tf
+++ b/terraform/docs-rs/rds.tf
@@ -48,47 +48,47 @@ resource "aws_security_group" "db" {
   }
 }
 
-resource "aws_db_instance" "db" {
-  identifier = "docs-rs-prod"
-
-  engine         = "postgres"
-  engine_version = "14.7"
-
-  instance_class        = "db.t4g.small"
-  storage_type          = "gp2"
-  db_subnet_group_name  = aws_db_subnet_group.db.name
-  allocated_storage     = 20
-  max_allocated_storage = 100
-
-  publicly_accessible    = false
-  vpc_security_group_ids = [aws_security_group.db.id]
-
-  db_name  = "docsrs"
-  username = "docsrs"
-  password = random_password.db.result
-
-  backup_retention_period = 30
-  backup_window           = "05:00-06:00" # UTC
-
-  deletion_protection      = true
-  delete_automated_backups = false
-
-  allow_major_version_upgrade = false
-  auto_minor_version_upgrade  = true
-  maintenance_window          = "Tue:15:00-Tue:16:00" # UTC
-
-  enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
-  performance_insights_enabled    = true
-
-  lifecycle {
-    ignore_changes = [
-      engine_version,
-    ]
-  }
-}
-
-resource "aws_ssm_parameter" "connection_url" {
-  name  = "/prod/docs-rs/database-url"
-  type  = "SecureString"
-  value = "postgres://docsrs:${random_password.db.result}@${aws_db_instance.db.address}/docsrs"
-}
+# resource "aws_db_instance" "db" {
+#   identifier = "docs-rs-prod"
+#
+#   engine         = "postgres"
+#   engine_version = "14.7"
+#
+#   instance_class        = "db.t4g.small"
+#   storage_type          = "gp2"
+#   db_subnet_group_name  = aws_db_subnet_group.db.name
+#   allocated_storage     = 20
+#   max_allocated_storage = 100
+#
+#   publicly_accessible    = false
+#   vpc_security_group_ids = [aws_security_group.db.id]
+#
+#   db_name  = "docsrs"
+#   username = "docsrs"
+#   password = random_password.db.result
+#
+#   backup_retention_period = 30
+#   backup_window           = "05:00-06:00" # UTC
+#
+#   deletion_protection      = true
+#   delete_automated_backups = false
+#
+#   allow_major_version_upgrade = false
+#   auto_minor_version_upgrade  = true
+#   maintenance_window          = "Tue:15:00-Tue:16:00" # UTC
+#
+#   enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
+#   performance_insights_enabled    = true
+#
+#   lifecycle {
+#     ignore_changes = [
+#       engine_version,
+#     ]
+#   }
+# }
+#
+# resource "aws_ssm_parameter" "connection_url" {
+#   name  = "/prod/docs-rs/database-url"
+#   type  = "SecureString"
+#   value = "postgres://docsrs:${random_password.db.result}@${aws_db_instance.db.address}/docsrs"
+# }

--- a/terraform/docs-rs/web-server.tf
+++ b/terraform/docs-rs/web-server.tf
@@ -29,9 +29,9 @@ module "web" {
     DOCSRS_GITHUB_ACCESSTOKEN = "/prod/docs-rs/github-access-token"
   }
 
-  computed_secrets = {
-    DOCSRS_DATABASE_URL = aws_ssm_parameter.connection_url.arn
-  }
+  # computed_secrets = {
+  #   DOCSRS_DATABASE_URL = aws_ssm_parameter.connection_url.arn
+  # }
 
   expose_http = {
     container_port = 80


### PR DESCRIPTION
Discussed [here](https://rust-lang.zulipchat.com/#narrow/stream/356853-t-docs-rs/topic/Can.20we.20delete.20.60docs-rs-prod.60.20db.3F/near/456798204).

Final snapshot is called `docs-rs-prod-final-snapshot-legacy-account`