### PR TITLE
Create CloudFront distribution for Rustup builds

### DIFF
--- a/terragrunt/accounts/legacy/rustup-prod/rustup/terragrunt.hcl
+++ b/terragrunt/accounts/legacy/rustup-prod/rustup/terragrunt.hcl
@@ -6,3 +6,7 @@ include {
   path           = find_in_parent_folders()
   merge_strategy = "deep"
 }
+
+inputs = {
+  builds_domain_name = "rustup-builds.rust-lang.org"
+}

--- a/terragrunt/modules/rustup/certificate.tf
+++ b/terragrunt/modules/rustup/certificate.tf
@@ -1,0 +1,13 @@
+module "certificate" {
+  source = "../acm-certificate"
+
+  providers = {
+    aws = aws.us-east-1
+  }
+
+  domains = [
+    var.builds_domain_name,
+  ]
+
+  legacy = true
+}

--- a/terragrunt/modules/rustup/cloudfront.tf
+++ b/terragrunt/modules/rustup/cloudfront.tf
@@ -1,0 +1,53 @@
+resource "aws_cloudfront_distribution" "builds" {
+  comment = var.builds_domain_name
+
+  enabled             = true
+  wait_for_deployment = false
+  is_ipv6_enabled     = true
+  price_class         = "PriceClass_All"
+
+  aliases = [
+    var.builds_domain_name,
+  ]
+
+  viewer_certificate {
+    acm_certificate_arn      = module.certificate.arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.1_2016"
+  }
+
+  default_cache_behavior {
+    target_origin_id       = "builds"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+
+    forwarded_values {
+      headers = [
+        // Following the spec, AWS S3 only replies with the CORS headers when
+        // an Origin is present, and varies its response based on that. If we
+        // don't forward the header CloudFront is going to cache the first CORS
+        // response it receives, even if it's empty.
+        "Origin",
+      ]
+
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  origin {
+    origin_id   = "builds"
+    domain_name = aws_s3_bucket.builds.bucket_regional_domain_name
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+}

--- a/terragrunt/modules/rustup/cloudfront.tf
+++ b/terragrunt/modules/rustup/cloudfront.tf
@@ -41,8 +41,9 @@ resource "aws_cloudfront_distribution" "builds" {
   }
 
   origin {
-    origin_id   = "builds"
-    domain_name = aws_s3_bucket.builds.bucket_regional_domain_name
+    origin_id                = "builds"
+    domain_name              = aws_s3_bucket.builds.bucket_regional_domain_name
+    origin_access_control_id = aws_cloudfront_origin_access_control.builds.id
   }
 
   restrictions {
@@ -50,4 +51,12 @@ resource "aws_cloudfront_distribution" "builds" {
       restriction_type = "none"
     }
   }
+}
+
+resource "aws_cloudfront_origin_access_control" "builds" {
+  name                              = "rustup-builds"
+  description                       = var.builds_domain_name
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
 }

--- a/terragrunt/modules/rustup/dns.tf
+++ b/terragrunt/modules/rustup/dns.tf
@@ -1,0 +1,12 @@
+data "aws_route53_zone" "builds" {
+  // Convert foo.bar.baz into bar.baz
+  name = join(".", reverse(slice(reverse(split(".", var.builds_domain_name)), 0, 2)))
+}
+
+resource "aws_route53_record" "cloudfront_builds_domain" {
+  zone_id = data.aws_route53_zone.builds.id
+  name    = var.builds_domain_name
+  type    = "CNAME"
+  ttl     = 300
+  records = [aws_cloudfront_distribution.builds.domain_name]
+}

--- a/terragrunt/modules/rustup/s3.tf
+++ b/terragrunt/modules/rustup/s3.tf
@@ -13,6 +13,32 @@ module "ci_role" {
   branch = "master"
 }
 
+resource "aws_s3_bucket_policy" "cloudfront" {
+  provider = aws.us-east-1
+
+  bucket = aws_s3_bucket.builds.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowCloudFrontReadOnlyAccess"
+        Effect = "Allow"
+        Principal = {
+          Service = "cloudfront.amazonaws.com"
+        }
+        Action   = ["s3:GetObject"]
+        Resource = ["${aws_s3_bucket.builds.arn}/*"]
+        Condition = {
+          StringEquals = {
+            "AWS:SourceArn" = aws_cloudfront_distribution.builds.arn
+          }
+        }
+      }
+    ]
+  })
+}
+
 resource "aws_iam_policy" "upload_builds" {
   name = "upload-rustup-builds"
   policy = jsonencode({

--- a/terragrunt/modules/rustup/variables.tf
+++ b/terragrunt/modules/rustup/variables.tf
@@ -1,0 +1,4 @@
+variable "builds_domain_name" {
+  description = "The domain for the CloudFront distribution that serves the builds"
+  type        = string
+}


### PR DESCRIPTION
Rustup builds are automatically uploaded to S3 from the CI in `rust-lang/rustup`[^1]. The bucket is not publicly accessible, but we still want to make the build artifacts available to users for pre-release testing or debugging. For this purpose, a new CloudFront distribution has been created.

[^1]: https://github.com/rust-lang/rustup