### PR TITLE
chore: update `terraform/shared` dns provider

### DIFF
--- a/terraform/shared/.terraform.lock.hcl
+++ b/terraform/shared/.terraform.lock.hcl
@@ -2,42 +2,45 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "4.28.0"
-  constraints = "~> 4.20, ~> 4.28"
+  version     = "4.67.0"
+  constraints = ">= 4.20.0, >= 4.28.0, ~> 4.67, < 6.0.0"
   hashes = [
-    "h1:TXCUuuaf2q54C43bxSNiF9g+cxTr8zqEZem0pW15cjE=",
-    "zh:1d4806e50971d2cd565273cedf3206e38931677a6f546cf2b9fb140b52b80604",
-    "zh:3f076791002b8afa5ba2d2038f1e1db5956022327eb5242152723ed410ae4571",
-    "zh:40e5944a9df0d083dbd316bcc6ac9ceada5c00dab70c21897e62b68c4c936bc9",
-    "zh:68b78d0c1866aa0bcbbadb1cf51349c9af697f8789f5778b7e7e2912a9c4845d",
-    "zh:72d6e66136841c0e5ae264e03555cf59751ddae1b9784eafcb877c624332c70a",
-    "zh:902c8f89dc10d321b87c09270c27a31a42d4e74e4da1608e55b7f241cd010a62",
+    "h1:5Zfo3GfRSWBaXs4TGQNOflr1XaYj6pRnVJLX5VAjFX4=",
+    "zh:0843017ecc24385f2b45f2c5fce79dc25b258e50d516877b3affee3bef34f060",
+    "zh:19876066cfa60de91834ec569a6448dab8c2518b8a71b5ca870b2444febddac6",
+    "zh:24995686b2ad88c1ffaa242e36eee791fc6070e6144f418048c4ce24d0ba5183",
+    "zh:4a002990b9f4d6d225d82cb2fb8805789ffef791999ee5d9cb1fef579aeff8f1",
+    "zh:559a2b5ace06b878c6de3ecf19b94fbae3512562f7a51e930674b16c2f606e29",
+    "zh:6a07da13b86b9753b95d4d8218f6dae874cf34699bca1470d6effbb4dee7f4b7",
+    "zh:768b3bfd126c3b77dc975c7c0e5db3207e4f9997cf41aa3385c63206242ba043",
+    "zh:7be5177e698d4b547083cc738b977742d70ed68487ce6f49ecd0c94dbf9d1362",
+    "zh:8b562a818915fb0d85959257095251a05c76f3467caa3ba95c583ba5fe043f9b",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:bf54c9f55d420b4e1fe68db81a759c40b9f9747159dea3061212a1c9768dcdfd",
-    "zh:bfbe7e745c420a4ebd27ca35dfe5c2acc7cdd05092e1daf60f5ae29a1130d752",
-    "zh:d271a30b16f0861f020e423d120d1458cf1757e740e016ace22084c39dc13550",
-    "zh:f1e4672d1625fd1f1268d4b807cb90e28150d46fb2d0dd0836de65db29c8d5e6",
-    "zh:f5cee910b4db2da3c2a28dae9055cbca4273eb774c362bb7bb5bde04deff4557",
+    "zh:9c385d03a958b54e2afd5279cd8c7cbdd2d6ca5c7d6a333e61092331f38af7cf",
+    "zh:b3ca45f2821a89af417787df8289cb4314b273d29555ad3b2a5ab98bb4816b3b",
+    "zh:da3c317f1db2469615ab40aa6baba63b5643bae7110ff855277a1fb9d8eb4f2c",
+    "zh:dc6430622a8dc5cdab359a8704aec81d3825ea1d305bbb3bbd032b1c6adfae0c",
+    "zh:fac0d2ddeadf9ec53da87922f666e1e73a603a611c57bcbc4b86ac2821619b1d",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/dns" {
-  version     = "2.2.0"
-  constraints = "~> 2.2.0"
+  version     = "3.4.1"
+  constraints = "~> 3.4.1"
   hashes = [
-    "h1:qltTuVDorrumM3+cemZ/9K+6qdFTmVjwbxPFMP/88J8=",
-    "zh:05ebc6f930c9fafaa8e3d929eef6cbb574dd3482c3cf5ac8ed34953567b2f2da",
-    "zh:34ad830cb5612ace4ba1f1fb56b35b3ce37ba565e9bd98b64701a5b8294df1b0",
-    "zh:427d1d0911e5170ffa30c65b7a1c6aed6a6c9eaa6b2a7ca4b955129a25ab2ad4",
-    "zh:5f909596ea24da039cd45c6f7da8155f3ebc582e2798b66dcd72d62d3ad4317b",
-    "zh:6ae64cb2d43e62b494bbc1ef8164895a1fd6303f18fa3164296c2f1f7e703801",
-    "zh:84750bcb90a7762ea2315cd54194255051b0cf4aff55755c6edf87e5f88cc692",
-    "zh:8d4e0710b17dc830f72f4e1bf6a75c05134c137153b5d12e3b7f67ac61dc5a1c",
-    "zh:a9849e99ea2c5c8d18faaf06288abe68271fff9b19ee471226c7e68f3626665e",
-    "zh:bcd463bce6b65a42a9bb6be0b7179e9829d4548e34d5bfaf892958abee7ac2ba",
-    "zh:cf1cdff8c4a09d3c7c3fece74835f9306014b50416a17d3e3966f4bf58596782",
-    "zh:e0cafa962fcccff280e4c74fe3701b2bb09e7d6b99e94a8ef0d5db9566dcc7bf",
-    "zh:eae89d4ad0baefe450be9c5c6f9904f5a4c6e42c42e4556f23c9856ae290e30d",
+    "h1:Ds8mPH2ZDdHsvcZTFaM7KgmRlyIaxv1T6zxUOioNso0=",
+    "zh:00fc9ba46d66a35c0f4cb66d19b402280f5d074a5652b6a378aac9b11b93d069",
+    "zh:0d612631e82f246d1e7ee20d3dff29ad1c328d1cec0a3b030719e6246676737b",
+    "zh:29b847c53ea307acf7ed923c751f3051aae3308a23ba376ad86b120c0f6b978b",
+    "zh:4b5612e01d369ba56abe87daaea12e65114da9befdd080bf26269dfcbd1c07fa",
+    "zh:5a2e3af49eabe6592bc24ff6c718872cc8a3fbc3b7be152b00d124ef1dd5d0bd",
+    "zh:6570128aa7cb71390f78b9aa918c937f1ab0d695e8d7a0b38b84713d2cc92893",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:874cbc34ef9973e4b1f894d910e7f853cc317ee6b5208179d41c1bfa51831425",
+    "zh:946d5fbe75d4fc0fdc1d2deea85a5e02ec46f6830731f9414884276b7c3ec4bc",
+    "zh:b1cde393e83634c733649caea76ef6f4f14f01f2b04e8c90926ccbb49ac6c53d",
+    "zh:b803d82cf6fc8ae6660f896144e065d6ed032273a3eb418e62b39a7dec73f734",
+    "zh:e8d8b93b1c13b199c929819b2b049627a6d3874fd3f16e05b3f594d526233dd6",
   ]
 }
 
@@ -45,6 +48,7 @@ provider "registry.terraform.io/hashicorp/tls" {
   version     = "3.1.0"
   constraints = "3.1.0"
   hashes = [
+    "h1:U+kgPLboCrcs4eZV87esP7iydF8mjMyHKE/mDsrwfkQ=",
     "h1:fUJX8Zxx38e2kBln+zWr1Tl41X+OuiE++REjrEyiOM4=",
     "zh:3d46616b41fea215566f4a957b6d3a1aa43f1f75c26776d72a98bdba79439db6",
     "zh:623a203817a6dafa86f1b4141b645159e07ec418c82fe40acd4d2a27543cbaa2",

--- a/terraform/shared/main.tf
+++ b/terraform/shared/main.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.20"
+      version = "~> 4.67"
     }
     dns = {
       source  = "hashicorp/dns"
-      version = "~> 2.2.0"
+      version = "~> 3.4.1"
     }
     tls = {
       source  = "hashicorp/tls"


### PR DESCRIPTION
## 📃📃 Plan summary 📃📃

Changes detected (apply needed):
❌ terraform/shared

## 📃📃 Plan output 📃📃
👉 terraform/shared:

```


  # aws_iam_openid_connect_provider.github_actions will be updated in-place
  ~ resource "aws_iam_openid_connect_provider" "github_actions" {
        id              = "arn:aws:iam::890664054962:oidc-provider/token.actions.githubusercontent.com"
        tags            = {}
      ~ thumbprint_list = [
          - "6938fd4d98bab03faadb97b34396831e3780aea1",
          - "1c58a3a8518e8759bf075b76b750d4f2df264fcd",
          + "d89e3bd43d5d909b47a18977aa9d5ce36cee184c",
        ]
        # (4 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
╷
│ Warning: Argument is deprecated
│ 
│   with aws_s3_bucket.rust_inventories,
│   on s3.tf line 3, in resource "aws_s3_bucket" "rust_inventories":
│    3: resource "aws_s3_bucket" "rust_inventories" {
│ 
│ Use the aws_s3_bucket_lifecycle_configuration resource instead
│ 
│ (and 13 more similar warnings elsewhere)
╵


```
