### PR TITLE
chore(fastly-tls-subscrition): update aws to 5.64

### DIFF
--- a/terragrunt/modules/fastly-tls-subscription/_terraform.tf
+++ b/terragrunt/modules/fastly-tls-subscription/_terraform.tf
@@ -3,9 +3,8 @@ terraform {
 
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      // Allow both 4.x and 5.x while we upgrade everything to 5.x.
-      version = ">= 4.20, < 6"
+      source  = "hashicorp/aws"
+      version = "~> 5.64"
     }
     fastly = {
       source  = "fastly/fastly"


### PR DESCRIPTION
All dependencies of this module moved to aws 5.64 🚀