### PR TITLE
fix(podman): add required config fields

### DIFF
--- a/ansible/roles/dev-desktop/files/podman/storage.conf
+++ b/ansible/roles/dev-desktop/files/podman/storage.conf
@@ -1,5 +1,7 @@
 [storage]
   driver = "overlay"
+  runroot = "/run/containers/storage"
+  graphroot = "/var/lib/containers/storage"
 
 [storage.options.overlay]
   mount_program = "/usr/bin/fuse-overlayfs"


### PR DESCRIPTION
This fields will be required in ubuntu 24.

I'm trying to add them in ubuntu 22 already so we avoid breaking podman when we upgrade