### PR TITLE
chore(dev-desktops): remove postfix

### DIFF
--- a/ansible/roles/dev-desktop/tasks/dependencies.yml
+++ b/ansible/roles/dev-desktop/tasks/dependencies.yml
@@ -59,6 +59,12 @@
       - zsh
     state: present
 
+# we don't need it because we don't need to send emails
+- name: Uninstall postfix
+  apt:
+    name: postfix
+    state: absent
+
 - name: Uninstall fish from apt
   apt:
     name: fish


### PR DESCRIPTION
I removed postfix because when updating to ubuntu 24 there was an alert related to it.
Instead of fixing it I decided to remove this package as we don't need it imo.

I want to merge this and apply to all ubuntu 22 images so that when we upgrade there's no error.