### PR TITLE
feat(playground): provision ubuntu 24 ec2

### DIFF
--- a/terraform/playground/instance.tf
+++ b/terraform/playground/instance.tf
@@ -5,6 +5,13 @@ resource "aws_eip" "playground" {
   }
 }
 
+resource "aws_eip" "playground2" {
+  domain = "vpc"
+  tags = {
+    Name = "playground2"
+  }
+}
+
 data "dns_a_record_set" "monitoring" {
   host = "monitoring.infra.rust-lang.org"
 }
@@ -103,8 +110,21 @@ resource "aws_eip_association" "playground" {
   allocation_id        = aws_eip.playground.id
 }
 
+resource "aws_eip_association" "playground2" {
+  network_interface_id = aws_network_interface.playground.id
+  allocation_id        = aws_eip.playground2.id
+}
+
 data "aws_route53_zone" "rust_lang_org" {
   name = "rust-lang.org"
+}
+
+resource "aws_route53_record" "playground2" {
+  zone_id = data.aws_route53_zone.rust_lang_org.id
+  name    = "play-2.infra.rust-lang.org"
+  type    = "A"
+  records = [aws_eip.playground2.public_ip]
+  ttl     = 60
 }
 
 resource "aws_route53_record" "playground" {
@@ -170,6 +190,21 @@ data "aws_ami" "ubuntu" {
   }
 }
 
+data "aws_ami" "ubuntu24" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
 resource "aws_iam_instance_profile" "playground" {
   name = "playground"
   role = aws_iam_role.playground.name
@@ -197,6 +232,36 @@ resource "aws_instance" "playground" {
 
   tags = {
     Name = "play-1"
+  }
+
+  lifecycle {
+    # Don't recreate the instance automatically when the AMI changes.
+    ignore_changes = [ami]
+  }
+}
+
+resource "aws_instance" "playground2" {
+  ami                     = data.aws_ami.ubuntu24.id
+  instance_type           = "c5a.large"
+  key_name                = data.terraform_remote_state.shared.outputs.master_ec2_key_pair
+  iam_instance_profile    = aws_iam_instance_profile.playground.name
+  ebs_optimized           = true
+  disable_api_termination = true
+  monitoring              = false
+
+  root_block_device {
+    volume_type           = "gp3"
+    volume_size           = 100
+    delete_on_termination = true
+  }
+
+  network_interface {
+    network_interface_id = aws_network_interface.playground.id
+    device_index         = 0
+  }
+
+  tags = {
+    Name = "play-2"
   }
 
   lifecycle {

--- a/terraform/playground/instance.tf
+++ b/terraform/playground/instance.tf
@@ -105,13 +105,18 @@ resource "aws_network_interface" "playground" {
   security_groups = [aws_security_group.playground.id]
 }
 
+resource "aws_network_interface" "playground2" {
+  subnet_id       = data.terraform_remote_state.shared.outputs.prod_vpc.public_subnets[0]
+  security_groups = [aws_security_group.playground.id]
+}
+
 resource "aws_eip_association" "playground" {
   network_interface_id = aws_network_interface.playground.id
   allocation_id        = aws_eip.playground.id
 }
 
 resource "aws_eip_association" "playground2" {
-  network_interface_id = aws_network_interface.playground.id
+  network_interface_id = aws_network_interface.playground2.id
   allocation_id        = aws_eip.playground2.id
 }
 

--- a/terraform/playground/instance.tf
+++ b/terraform/playground/instance.tf
@@ -261,7 +261,7 @@ resource "aws_instance" "playground2" {
   }
 
   network_interface {
-    network_interface_id = aws_network_interface.playground.id
+    network_interface_id = aws_network_interface.playground2.id
     device_index         = 0
   }
 


### PR DESCRIPTION
We agreed in [zulip](https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/Rust.20Playground.20Ubuntu.20update/near/472263436) to create a new EC2 with ubuntu 24 so that we can migrate to this one and delete the old one.

Plan:

```
Terraform will perform the following actions:

  # aws_eip.playground2 will be created
  + resource "aws_eip" "playground2" {
      + allocation_id        = (known after apply)
      + arn                  = (known after apply)
      + association_id       = (known after apply)
      + carrier_ip           = (known after apply)
      + customer_owned_ip    = (known after apply)
      + domain               = "vpc"
      + id                   = (known after apply)
      + instance             = (known after apply)
      + network_border_group = (known after apply)
      + network_interface    = (known after apply)
      + private_dns          = (known after apply)
      + private_ip           = (known after apply)
      + ptr_record           = (known after apply)
      + public_dns           = (known after apply)
      + public_ip            = (known after apply)
      + public_ipv4_pool     = (known after apply)
      + tags                 = {
          + "Name" = "playground2"
        }
      + tags_all             = {
          + "Name" = "playground2"
        }
      + vpc                  = (known after apply)
    }

  # aws_eip_association.playground2 will be created
  + resource "aws_eip_association" "playground2" {
      + allocation_id        = (known after apply)
      + id                   = (known after apply)
      + instance_id          = (known after apply)
      + network_interface_id = "eni-013da737e0f6aa60a"
      + private_ip_address   = (known after apply)
      + public_ip            = (known after apply)
    }

  # aws_instance.playground2 will be created
  + resource "aws_instance" "playground2" {
      + ami                                  = "ami-02ea6ff8f4d733569"
      + arn                                  = (known after apply)
      + associate_public_ip_address          = (known after apply)
      + availability_zone                    = (known after apply)
      + cpu_core_count                       = (known after apply)
      + cpu_threads_per_core                 = (known after apply)
      + disable_api_stop                     = (known after apply)
      + disable_api_termination              = true
      + ebs_optimized                        = true
      + get_password_data                    = false
      + host_id                              = (known after apply)
      + host_resource_group_arn              = (known after apply)
      + iam_instance_profile                 = "playground"
      + id                                   = (known after apply)
      + instance_initiated_shutdown_behavior = (known after apply)
      + instance_lifecycle                   = (known after apply)
      + instance_state                       = (known after apply)
      + instance_type                        = "c5a.large"
      + ipv6_address_count                   = (known after apply)
      + ipv6_addresses                       = (known after apply)
      + key_name                             = "buildbot-west-slave-key"
      + monitoring                           = false
      + outpost_arn                          = (known after apply)
      + password_data                        = (known after apply)
      + placement_group                      = (known after apply)
      + placement_partition_number           = (known after apply)
      + primary_network_interface_id         = (known after apply)
      + private_dns                          = (known after apply)
      + private_ip                           = (known after apply)
      + public_dns                           = (known after apply)
      + public_ip                            = (known after apply)
      + secondary_private_ips                = (known after apply)
      + security_groups                      = (known after apply)
      + spot_instance_request_id             = (known after apply)
      + subnet_id                            = (known after apply)
      + tags                                 = {
          + "Name" = "play-2"
        }
      + tags_all                             = {
          + "Name" = "play-2"
        }
      + tenancy                              = (known after apply)
      + user_data                            = (known after apply)
      + user_data_base64                     = (known after apply)
      + user_data_replace_on_change          = false
      + vpc_security_group_ids               = (known after apply)

      + network_interface {
          + delete_on_termination = false
          + device_index          = 0
          + network_card_index    = 0
          + network_interface_id  = "eni-013da737e0f6aa60a"
        }

      + root_block_device {
          + delete_on_termination = true
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + kms_key_id            = (known after apply)
          + tags_all              = (known after apply)
          + throughput            = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = 100
          + volume_type           = "gp3"
        }
    }

  # aws_route53_record.playground2 will be created
  + resource "aws_route53_record" "playground2" {
      + allow_overwrite = (known after apply)
      + fqdn            = (known after apply)
      + id              = (known after apply)
      + name            = "play-2.infra.rust-lang.org"
      + records         = (known after apply)
      + ttl             = 60
      + type            = "A"
      + zone_id         = "Z237AC8WS9NFCS"
    }

Plan: 4 to add, 0 to change, 0 to destroy.
```