### PR TITLE
feat(playground): use `play-2` instance

### DIFF
--- a/terraform/playground/cloudfront.tf
+++ b/terraform/playground/cloudfront.tf
@@ -45,7 +45,7 @@ resource "aws_cloudfront_distribution" "playground" {
 
   origin {
     origin_id   = "main"
-    domain_name = "play-1.infra.rust-lang.org"
+    domain_name = "play-2.infra.rust-lang.org"
 
     custom_origin_config {
       http_port              = 80


### PR DESCRIPTION
We are not ready to merge this yet. Check [zulip](https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/Rust.20Playground.20Ubuntu.20update/near/472933364).