### PR TITLE
don't monitor `play-1` EC2

### DIFF
--- a/ansible/envs/prod/hosts
+++ b/ansible/envs/prod/hosts
@@ -9,7 +9,6 @@ crater-azure-1.infra.rust-lang.org
 crater-azure-2.infra.rust-lang.org
 
 [playground]
-play-1.infra.rust-lang.org
 play-2.infra.rust-lang.org
 
 [dev-desktop]

--- a/ansible/playbooks/monitoring.yml
+++ b/ansible/playbooks/monitoring.yml
@@ -61,7 +61,6 @@
               - crater.infra.rust-lang.org:9100
               - docsrs.infra.rust-lang.org:9100
               - bastion.infra.rust-lang.org:9100
-              - play-1.infra.rust-lang.org:9100
               - play-2.infra.rust-lang.org:9100
               - dev-desktop-staging.infra.rust-lang.org:9100
               - dev-desktop-eu-1.infra.rust-lang.org:9100
@@ -131,7 +130,6 @@
           scheme: https
           static_configs:
             - targets:
-              - play-1.infra.rust-lang.org:443
               - play-2.infra.rust-lang.org:443
 
         - job_name: playground-docker
@@ -139,7 +137,6 @@
           scheme: https
           static_configs:
             - targets:
-              - play-1.infra.rust-lang.org:443
               - play-2.infra.rust-lang.org:443
 
         - job_name: cratesio_heroku_metrics


### PR DESCRIPTION
This PR removes `play-1` from monitoring and ansible.

Only merge this once we are ready to delete the instance.