### PR TITLE
chore: update static-website action to ubuntu 24

### DIFF
--- a/github-actions/static-websites/Dockerfile
+++ b/github-actions/static-websites/Dockerfile
@@ -1,6 +1,16 @@
-FROM ubuntu:bionic
+FROM ubuntu:24.04
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y git awscli
+RUN set -eux; \
+    apt-get update; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        git \
+        curl \
+        unzip \
+        ; \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-$(arch).zip" -o "awscliv2.zip"; \
+    unzip awscliv2.zip; \
+    rm awscliv2.zip; \
+    ./aws/install
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/github-actions/static-websites/entrypoint.sh
+++ b/github-actions/static-websites/entrypoint.sh
@@ -8,6 +8,9 @@ cloudfront_distribution="${INPUT_CLOUDFRONT_DISTRIBUTION-}"
 
 export AWS_ACCESS_KEY_ID="${INPUT_AWS_ACCESS_KEY_ID-}"
 export AWS_SECRET_ACCESS_KEY="${INPUT_AWS_SECRET_ACCESS_KEY-}"
+# The region is required by the AWS CLI, but it doesn't matter
+# because CloudFront is a global service.
+export AWS_DEFAULT_REGION="us-west-1"
 
 # Ensure GitHub doesn't mess around with the uploaded file.
 # Without the file, for example, files with an underscore in the name won't be
@@ -24,6 +27,9 @@ git config user.email ""
 git add .
 git commit -m "Deploy ${GITHUB_SHA} to gh-pages"
 git push -f "https://x-token:${github_token}@github.com/${GITHUB_REPOSITORY}" master:gh-pages
+
+# Print the AWS CLI version
+aws --version
 
 # Invalidate the CloudFront caches to prevent stale content from being served.
 if [[ -n "${cloudfront_distribution}" ]]; then


### PR DESCRIPTION
awscli is not present in apt anymore. In the playground we install it with snap, but snap isn't available in docker.

So we need to do this ugly thing to install awscli in ubuntu now.

I want to test this in https://github.com/rust-lang/thanks/pull/72