### PR TITLE
swap bastion EC2

### DIFF
--- a/terraform/bastion/instance.tf
+++ b/terraform/bastion/instance.tf
@@ -44,7 +44,7 @@ data "aws_route53_zone" "rust_lang_org" {
 
 resource "aws_route53_record" "bastion" {
   zone_id = data.aws_route53_zone.rust_lang_org.id
-  name    = "bastion.infra.rust-lang.org"
+  name    = "bastion1.infra.rust-lang.org"
   type    = "A"
   records = [aws_eip.bastion.public_ip]
   ttl     = 300
@@ -52,7 +52,7 @@ resource "aws_route53_record" "bastion" {
 
 resource "aws_route53_record" "bastion2" {
   zone_id = data.aws_route53_zone.rust_lang_org.id
-  name    = "bastion2.infra.rust-lang.org"
+  name    = "bastion.infra.rust-lang.org"
   type    = "A"
   records = [aws_eip.bastion.public_ip]
   ttl     = 300


### PR DESCRIPTION
based on https://github.com/rust-lang/simpleinfra/pull/595#issuecomment-2386238252

```
  # aws_route53_record.bastion must be replaced
-/+ resource "aws_route53_record" "bastion" {
      + allow_overwrite                  = (known after apply)
      ~ fqdn                             = "bastion.infra.rust-lang.org" -> (known after apply)
      ~ id                               = "Z237AC8WS9NFCS_bastion.infra.rust-lang.org_A" -> (known after apply)
      - multivalue_answer_routing_policy = false -> null
      ~ name                             = "bastion.infra.rust-lang.org" -> "bastion1.infra.rust-lang.org" # forces replacement
        # (4 unchanged attributes hidden)
    }

  # aws_route53_record.bastion2 must be replaced
-/+ resource "aws_route53_record" "bastion2" {
      + allow_overwrite                  = (known after apply)
      ~ fqdn                             = "bastion2.infra.rust-lang.org" -> (known after apply)
      ~ id                               = "Z237AC8WS9NFCS_bastion2.infra.rust-lang.org_A" -> (known after apply)
      - multivalue_answer_routing_policy = false -> null
      ~ name                             = "bastion2.infra.rust-lang.org" -> "bastion.infra.rust-lang.org" # forces replacement
        # (4 unchanged attributes hidden)
    }

Plan: 2 to add, 0 to change, 2 to destroy.
```