### PR TITLE
fix(crater): install awscli from snap

### DIFF
--- a/ansible/roles/docker/tasks/install.yml
+++ b/ansible/roles/docker/tasks/install.yml
@@ -4,9 +4,20 @@
   apt:
     name:
       - docker.io
-      # Needed to pull images from ECR:
-      - awscli
     state: present
+
+# Install AWS to pull images from ECR
+- name: Install aws (Ubuntu < 24)
+  apt:
+    name: awscli
+    state: present
+  when: ansible_distribution_version is version('24', '<')
+- name: Install aws (Ubuntu >= 24)
+  community.general.snap:
+    name: aws-cli
+    classic: true
+    state: present
+  when: ansible_distribution_version is version('24', '>=')
 
 - name: unmask docker.service
   systemd:


### PR DESCRIPTION
Ansible in master fails on crater (which is now on ubuntu 24).
This is because awscli is not installed anymore in apt.
With this PR we install aws from snap instead of apt.

How to deploy this:
- uninstall awscli with ssh
- run ansible apply

A newer version of the aws cli will be pulled so maybe there are some breaking changes that we need to fix after. ([this](https://github.com/rust-lang/simpleinfra/blob/d5a2b5d10ab290868a49ee0c385db9ca0c564313/ansible/roles/docker/templates/update-images/update.sh#L33) should work)