### PR TITLE
add kobzol to rustc_perf and infra_team iam group

### DIFF
--- a/terraform/team-members-access/_users.tf
+++ b/terraform/team-members-access/_users.tf
@@ -18,6 +18,7 @@ locals {
     "shepmaster"    = [aws_iam_group.infra_deploy_playground.name, aws_iam_group.infra_team.name],
     "oli-obk"       = [aws_iam_group.infra_deploy_staging_dev_desktop.name],
     "LawnGnome"     = [aws_iam_group.crates_io.name],
+    "Kobzol"        = [aws_iam_group.rustc_perf.name, aws_iam_group.infra_team.name],
   }
 }
 


### PR DESCRIPTION
Close https://github.com/rust-lang/infra-team/issues/155

- [x] Add Kobzol to AWS

steps for me:
- apply pr
- login to iam
- generate a password for kobzol

kobzol needs to change the password and add a 2fa.


## Docs 📚

- https://forge.rust-lang.org/infra/docs/aws-access.html
- https://forge.rust-lang.org/infra/docs/aws-access-management.html?highlight=iam#granting-access