### PR TITLE
dev-desktops: Install npm

### DIFF
--- a/ansible/roles/dev-desktop/tasks/dependencies.yml
+++ b/ansible/roles/dev-desktop/tasks/dependencies.yml
@@ -136,7 +136,9 @@
 
 - name: Install Node
   apt:
-    name: nodejs
+    name: 
+      - nodejs
+      - npm
     state: present
     update_cache: yes
 


### PR DESCRIPTION
NPM is used by rustdoc for the rustdoc-gui tests.

I have no way to check if this is correct/works.