### PR TITLE
dev-desktops: Add cryptography packages for puppeteer chrome

### DIFF
--- a/ansible/roles/dev-desktop/tasks/dependencies.yml
+++ b/ansible/roles/dev-desktop/tasks/dependencies.yml
@@ -33,6 +33,8 @@
       - "linux-tools-{{ kernel.stdout }}"
       - "linux-tools-{{ kernel_flavor.stdout }}"
       - libatk1.0-0 # Allows running `x test rustdoc-gui`
+      - libnss3
+      - libnspr4
       - libatk-bridge2.0-0
       - libcups2
       - libxkbcommon0


### PR DESCRIPTION
Currently, running `./x test ./tests/rustdoc-gui/ --stage 2` on an x86 [^1] dev desktop it fails with

```
== STACKTRACE ==
Error: Failed to launch the browser process!
/home/gh-aDotInTheVoid/.cache/puppeteer/chrome/linux-127.0.6533.88/chrome-linux64/chrome: error while loading shared libraries: libnss3.so: cannot open shared object file: No such file or directory
```

Indeed, running `ldd` on the chrome binary shows many missing dependencies:

```
gh-aDotInTheVoid@dev-desktop-eu-2:~/rust$ ldd ~/.cache/puppeteer/chrome/linux-127.0.6533.88/chrome-linux64/chrome | grep not
        libnss3.so => not found
        libnssutil3.so => not found
        libsmime3.so => not found
        libnspr4.so => not found
```

These packages allegedly have the missing deps, but I can't check that (or even that this works)


[^1]: On arm, it currently fails with an extreamly misterious error that I think it because it's running an x86 chome binary, and not handling the error well/at all