### PR TITLE
dev-desktops: disable `apport` service

### DIFF
--- a/ansible/roles/dev-desktop/tasks/main.yml
+++ b/ansible/roles/dev-desktop/tasks/main.yml
@@ -12,3 +12,4 @@
 - include_tasks: github.yml
 - include_tasks: motd.yml
 - include_tasks: scripts.yml
+- include_tasks: services.yml

--- a/ansible/roles/dev-desktop/tasks/services.yml
+++ b/ansible/roles/dev-desktop/tasks/services.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Disable the apport service
+  ansible.builtin.systemd:
+    enabled: false
+    state: stopped
+    name: apport.service
+  # Not all of our hosts actually have this, just ignore it if it fails.
+  ignore_errors: true


### PR DESCRIPTION
This service causes a lot of overhead for process crashes. This specifically causes issues the `panic-uninitialized-zeroed` test (which does a lot of forking and crashing) to take almost 2 minutes on dev desktops