### PR TITLE
Fix the Ansible playbook for dev-desktops

### DIFF
--- a/ansible/playbooks/dev-desktop.yml
+++ b/ansible/playbooks/dev-desktop.yml
@@ -17,6 +17,7 @@
         datadog_api_key: "{{ vars_datadog_api_key }}"
         datadog_site: "datadoghq.com"
 
+        datadog_agent_version: "7.56.2"
         datadog_config:
           tags:
             - "env:{{ vars_environment }}"

--- a/ansible/roles/dev-desktop/defaults/main.yml
+++ b/ansible/roles/dev-desktop/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+vars_rustup_version: "1.24.1"
+vars_rustup_checksum: "a3cb081f88a6789d104518b30d4aa410009cd08c3822a1226991d6cf0442a0f8"
 
 vars_team_login_path: "/root/team_login"
 allow_ssh_extra_groups: "dev-desktop-allow-ssh"

--- a/ansible/roles/dev-desktop/defaults/main.yml
+++ b/ansible/roles/dev-desktop/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-vars_rustup_version: "1.24.1"
-vars_rustup_checksum: "a3cb081f88a6789d104518b30d4aa410009cd08c3822a1226991d6cf0442a0f8"
+vars_rustup_version: "1.27.1"
+vars_rustup_checksum: "32a680a84cf76014915b3f8aa44e3e40731f3af92cd45eb0fcc6264fd257c428"
 
 vars_team_login_path: "/root/team_login"
 allow_ssh_extra_groups: "dev-desktop-allow-ssh"

--- a/ansible/roles/dev-desktop/tasks/dependencies.yml
+++ b/ansible/roles/dev-desktop/tasks/dependencies.yml
@@ -16,7 +16,6 @@
       - clang
       - cmake
       - gcc-mingw-w64-x86-64 # Allows running `x check --target x86_64-pc-windows-gnu`
-      - earlyoom # Earlyoom kills processes using too much memory before they can cause trouble.
       - jq
       - libssl-dev
       - llvm

--- a/ansible/roles/dev-desktop/tasks/dependencies.yml
+++ b/ansible/roles/dev-desktop/tasks/dependencies.yml
@@ -115,15 +115,20 @@
       - linux-image-extra-virtual
   when: kernel_flavor.stdout == "generic"
 
-- name: Install rustup in userspace for root
-  shell: |
-    set -eu
-    RUSTUP_VERSION=1.24.3
-    RUSTUP_SHA="a3cb081f88a6789d104518b30d4aa410009cd08c3822a1226991d6cf0442a0f8"
-    curl --proto '=https' --tlsv1.2 -sSf -O \
-      https://raw.githubusercontent.com/rust-lang/rustup/${RUSTUP_VERSION}/rustup-init.sh
-    echo "${RUSTUP_SHA}  rustup-init.sh" | sha256sum --check --
-    sh rustup-init.sh --default-toolchain nightly -y --component rust-src
+- name: Download Rustup installer
+  ansible.builtin.get_url:
+    url: "https://raw.githubusercontent.com/rust-lang/rustup/{{ vars_rustup_version }}/rustup-init.sh"
+    dest: /tmp/rustup-init.sh
+    mode: 0744
+    checksum: "sha256:{{ vars_rustup_checksum }}"
+
+- name: Install Rustup in userspace for root
+  ansible.builtin.command: /tmp/rustup-init.sh --default-toolchain nightly -y --component rust-src
+
+- name: Clean up Rustup installer
+  ansible.builtin.file:
+    path: /tmp/rustup-init.sh
+    state: absent
 
 - name: Check if Node is installed
   command: node --version

--- a/ansible/roles/dev-desktop/tasks/main.yml
+++ b/ansible/roles/dev-desktop/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 
+- include_tasks: oom.yml
 - include_tasks: dependencies.yml
 - include_tasks: podman.yml
 - include_tasks: quota.yml

--- a/ansible/roles/dev-desktop/tasks/oom.yml
+++ b/ansible/roles/dev-desktop/tasks/oom.yml
@@ -1,0 +1,15 @@
+---
+# earlyoom kills processes using too much memory before they can cause trouble.
+- name: Install earlyoom
+  ansible.builtin.apt:
+    name: earlyoom
+    state: present
+
+# The staging instance is so small that earlyoom prevents Ansible from executing
+# the playbook successfully.
+- name: Disable earlyoom on staging
+  ansible.builtin.service:
+    name: earlyoom
+    enabled: no
+    state: stopped
+  when: ansible_hostname == "dev-desktop-staging"


### PR DESCRIPTION
The Ansible playbook for the dev-desktops did not apply cleanly anymore after a few recent changes.

- The latest minor version of the Datadog agent (`7.57.x`) fails to install with an `unexpected end of file or stream` error from dpkg.
- After installing `earlyoom` in #480, the Ansible playbook cannot be applied to staging anymore since `earlyoom` will kill the Rustup installer.
- Debugging the installation step for Rust was quite painful. The inline script with multiple steps has been refactored into separate Ansible tasks, which makes this much better.
- The previous Rustup version was from June 2021 and has been upgraded to the latest release.