### PR TITLE
chore: delete old bastion EC2

### DIFF
--- a/terraform/bastion/instance.tf
+++ b/terraform/bastion/instance.tf
@@ -2,13 +2,6 @@
 
 // Associate an elastic IP to the instance.
 
-resource "aws_eip" "bastion" {
-  vpc = true
-  tags = {
-    Name = "bastion"
-  }
-}
-
 resource "aws_eip" "bastion2" {
   domain = "vpc"
   tags = {
@@ -16,19 +9,9 @@ resource "aws_eip" "bastion2" {
   }
 }
 
-resource "aws_network_interface" "bastion" {
-  subnet_id       = data.terraform_remote_state.shared.outputs.prod_vpc.public_subnets[0]
-  security_groups = [aws_security_group.bastion.id]
-}
-
 resource "aws_network_interface" "bastion2" {
   subnet_id       = data.terraform_remote_state.shared.outputs.prod_vpc.public_subnets[0]
   security_groups = [aws_security_group.bastion.id]
-}
-
-resource "aws_eip_association" "bastion" {
-  network_interface_id = aws_network_interface.bastion.id
-  allocation_id        = aws_eip.bastion.id
 }
 
 resource "aws_eip_association" "bastion2" {
@@ -42,14 +25,6 @@ data "aws_route53_zone" "rust_lang_org" {
   name = "rust-lang.org"
 }
 
-resource "aws_route53_record" "bastion" {
-  zone_id = data.aws_route53_zone.rust_lang_org.id
-  name    = "bastion1.infra.rust-lang.org"
-  type    = "A"
-  records = [aws_eip.bastion.public_ip]
-  ttl     = 300
-}
-
 resource "aws_route53_record" "bastion2" {
   zone_id = data.aws_route53_zone.rust_lang_org.id
   name    = "bastion.infra.rust-lang.org"
@@ -59,21 +34,6 @@ resource "aws_route53_record" "bastion2" {
 }
 
 // Create the EC2 instance itself.
-
-data "aws_ami" "ubuntu_bionic" {
-  most_recent = true
-  owners      = ["099720109477"] # Canonical
-
-  filter {
-    name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-}
 
 data "aws_ami" "ubuntu24" {
   most_recent = true
@@ -87,35 +47,6 @@ data "aws_ami" "ubuntu24" {
   filter {
     name   = "virtualization-type"
     values = ["hvm"]
-  }
-}
-
-resource "aws_instance" "bastion" {
-  ami                     = data.aws_ami.ubuntu_bionic.id
-  instance_type           = "t3a.micro"
-  key_name                = data.terraform_remote_state.shared.outputs.master_ec2_key_pair
-  ebs_optimized           = true
-  disable_api_termination = true
-  monitoring              = false
-
-  root_block_device {
-    volume_type           = "gp3"
-    volume_size           = 8
-    delete_on_termination = true
-  }
-
-  network_interface {
-    network_interface_id = aws_network_interface.bastion.id
-    device_index         = 0
-  }
-
-  tags = {
-    Name = "bastion"
-  }
-
-  lifecycle {
-    # Don't recreate the instance automatically when the AMI changes.
-    ignore_changes = [ami]
   }
 }
 


### PR DESCRIPTION
The new instance (with ubuntu 24) is working since 1 week.

## Plan

```

  # aws_eip.bastion will be destroyed
  # (because aws_eip.bastion is not in configuration)
  - resource "aws_eip" "bastion" {
      - allocation_id        = "eipalloc-05a964939b306e9d7" -> null
      - arn                  = "arn:aws:ec2:us-west-1:890664054962:elastic-ip/eipalloc-05a964939b306e9d7" -> null
      - association_id       = "eipassoc-0f944e14035bd13b3" -> null
      - domain               = "vpc" -> null
      - id                   = "eipalloc-05a964939b306e9d7" -> null
      - instance             = "i-06a1411d4ddb5a59f" -> null
      - network_border_group = "us-west-1" -> null
      - network_interface    = "eni-054fd0b2856a3308b" -> null
      - private_dns          = "ip-10-0-0-243.us-west-1.compute.internal" -> null
      - private_ip           = "10.0.0.243" -> null
      - public_dns           = "ec2-13-57-108-180.us-west-1.compute.amazonaws.com" -> null
      - public_ip            = "13.57.108.180" -> null
      - public_ipv4_pool     = "amazon" -> null
      - tags                 = {
          - "Name" = "bastion"
        } -> null
      - tags_all             = {
          - "Name" = "bastion"
        } -> null
      - vpc                  = true -> null

      - timeouts {}
    }

  # aws_eip_association.bastion will be destroyed
  # (because aws_eip_association.bastion is not in configuration)
  - resource "aws_eip_association" "bastion" {
      - allocation_id        = "eipalloc-05a964939b306e9d7" -> null
      - id                   = "eipassoc-0f944e14035bd13b3" -> null
      - instance_id          = "i-06a1411d4ddb5a59f" -> null
      - network_interface_id = "eni-054fd0b2856a3308b" -> null
      - private_ip_address   = "10.0.0.243" -> null
      - public_ip            = "13.57.108.180" -> null
    }

  # aws_instance.bastion will be destroyed
  # (because aws_instance.bastion is not in configuration)
  - resource "aws_instance" "bastion" {
      - ami                                  = "ami-0b10e1018d4058364" -> null
      - arn                                  = "arn:aws:ec2:us-west-1:890664054962:instance/i-06a1411d4ddb5a59f" -> null
      - associate_public_ip_address          = true -> null
      - availability_zone                    = "us-west-1c" -> null
      - cpu_core_count                       = 1 -> null
      - cpu_threads_per_core                 = 2 -> null
      - disable_api_stop                     = false -> null
      - disable_api_termination              = true -> null
      - ebs_optimized                        = true -> null
      - get_password_data                    = false -> null
      - hibernation                          = false -> null
      - id                                   = "i-06a1411d4ddb5a59f" -> null
      - instance_initiated_shutdown_behavior = "stop" -> null
      - instance_state                       = "running" -> null
      - instance_type                        = "t3a.micro" -> null
      - ipv6_address_count                   = 1 -> null
      - ipv6_addresses                       = [
          - "2600:1f1c:f21:3700:e46e:c66d:6d7e:95ba",
        ] -> null
      - key_name                             = "buildbot-west-slave-key" -> null
      - monitoring                           = false -> null
      - placement_partition_number           = 0 -> null
      - primary_network_interface_id         = "eni-054fd0b2856a3308b" -> null
      - private_dns                          = "ip-10-0-0-243.us-west-1.compute.internal" -> null
      - private_ip                           = "10.0.0.243" -> null
      - public_dns                           = "ec2-13-57-108-180.us-west-1.compute.amazonaws.com" -> null
      - public_ip                            = "13.57.108.180" -> null
      - secondary_private_ips                = [] -> null
      - security_groups                      = [] -> null
      - source_dest_check                    = true -> null
      - subnet_id                            = "subnet-097eabc9181d798ec" -> null
      - tags                                 = {
          - "Name" = "bastion"
        } -> null
      - tags_all                             = {
          - "Name" = "bastion"
        } -> null
      - tenancy                              = "default" -> null
      - volume_tags                          = {} -> null
      - vpc_security_group_ids               = [
          - "sg-01658fb672b62d734",
        ] -> null

      - capacity_reservation_specification {
          - capacity_reservation_preference = "open" -> null
        }

      - cpu_options {
          - core_count       = 1 -> null
          - threads_per_core = 2 -> null
        }

      - credit_specification {
          - cpu_credits = "unlimited" -> null
        }

      - enclave_options {
          - enabled = false -> null
        }

      - maintenance_options {
          - auto_recovery = "default" -> null
        }

      - metadata_options {
          - http_endpoint               = "enabled" -> null
          - http_protocol_ipv6          = "disabled" -> null
          - http_put_response_hop_limit = 1 -> null
          - http_tokens                 = "optional" -> null
          - instance_metadata_tags      = "disabled" -> null
        }

      - network_interface {
          - delete_on_termination = false -> null
          - device_index          = 0 -> null
          - network_card_index    = 0 -> null
          - network_interface_id  = "eni-054fd0b2856a3308b" -> null
        }

      - private_dns_name_options {
          - enable_resource_name_dns_a_record    = false -> null
          - enable_resource_name_dns_aaaa_record = false -> null
        }

      - root_block_device {
          - delete_on_termination = true -> null
          - device_name           = "/dev/sda1" -> null
          - encrypted             = false -> null
          - iops                  = 3000 -> null
          - tags                  = {} -> null
          - tags_all              = {} -> null
          - throughput            = 125 -> null
          - volume_id             = "vol-054265d8be7bb04c4" -> null
          - volume_size           = 8 -> null
          - volume_type           = "gp3" -> null
        }
    }

  # aws_network_interface.bastion will be destroyed
  # (because aws_network_interface.bastion is not in configuration)
  - resource "aws_network_interface" "bastion" {
      - arn                = "arn:aws:ec2:us-west-1:890664054962:network-interface/eni-054fd0b2856a3308b" -> null
      - id                 = "eni-054fd0b2856a3308b" -> null
      - interface_type     = "interface" -> null
      - ipv4_prefix_count  = 0 -> null
      - ipv4_prefixes      = [] -> null
      - ipv6_address_count = 1 -> null
      - ipv6_address_list  = [
          - "2600:1f1c:f21:3700:e46e:c66d:6d7e:95ba",
        ] -> null
      - ipv6_addresses     = [
          - "2600:1f1c:f21:3700:e46e:c66d:6d7e:95ba",
        ] -> null
      - ipv6_prefix_count  = 0 -> null
      - ipv6_prefixes      = [] -> null
      - mac_address        = "02:65:61:92:16:d5" -> null
      - owner_id           = "890664054962" -> null
      - private_dns_name   = "ip-10-0-0-243.us-west-1.compute.internal" -> null
      - private_ip         = "10.0.0.243" -> null
      - private_ip_list    = [
          - "10.0.0.243",
        ] -> null
      - private_ips        = [
          - "10.0.0.243",
        ] -> null
      - private_ips_count  = 0 -> null
      - security_groups    = [
          - "sg-01658fb672b62d734",
        ] -> null
      - source_dest_check  = true -> null
      - subnet_id          = "subnet-097eabc9181d798ec" -> null
      - tags               = {} -> null
      - tags_all           = {} -> null

      - attachment {
          - attachment_id = "eni-attach-0fc90e76bf7412bce" -> null
          - device_index  = 0 -> null
          - instance      = "i-06a1411d4ddb5a59f" -> null
        }
    }

  # aws_route53_record.bastion will be destroyed
  # (because aws_route53_record.bastion is not in configuration)
  - resource "aws_route53_record" "bastion" {
      - fqdn                             = "bastion1.infra.rust-lang.org" -> null
      - id                               = "Z237AC8WS9NFCS_bastion1.infra.rust-lang.org_A" -> null
      - multivalue_answer_routing_policy = false -> null
      - name                             = "bastion1.infra.rust-lang.org" -> null
      - records                          = [
          - "13.57.108.180",
        ] -> null
      - ttl                              = 300 -> null
      - type                             = "A" -> null
      - zone_id                          = "Z237AC8WS9NFCS" -> null
    }
```