### PR TITLE
chore: rename `bastion2` to `bastion`

### DIFF
--- a/terraform/bastion/instance.tf
+++ b/terraform/bastion/instance.tf
@@ -2,26 +2,21 @@
 
 // Associate an elastic IP to the instance.
 
-// Some resources are named as "bastion2" because when we updated from ubuntu 20 to ubuntu 24
-// we created a new instance (bastion2) and kept the old one (bastion) around for a while.
-// When you migrate to a new bastion instance (e.g. to update to ubuntu 26),
-// you can name the new resources as "bastion" (instead of "bastion3"), to go back to the original name.
-
-resource "aws_eip" "bastion2" {
+resource "aws_eip" "bastion" {
   domain = "vpc"
   tags = {
-    Name = "bastion2"
+    Name = "bastion"
   }
 }
 
-resource "aws_network_interface" "bastion2" {
+resource "aws_network_interface" "bastion" {
   subnet_id       = data.terraform_remote_state.shared.outputs.prod_vpc.public_subnets[0]
   security_groups = [aws_security_group.bastion.id]
 }
 
-resource "aws_eip_association" "bastion2" {
-  network_interface_id = aws_network_interface.bastion2.id
-  allocation_id        = aws_eip.bastion2.id
+resource "aws_eip_association" "bastion" {
+  network_interface_id = aws_network_interface.bastion.id
+  allocation_id        = aws_eip.bastion.id
 }
 
 // Create the bastion.infra.rust-lang.org DNS record.
@@ -30,11 +25,11 @@ data "aws_route53_zone" "rust_lang_org" {
   name = "rust-lang.org"
 }
 
-resource "aws_route53_record" "bastion2" {
+resource "aws_route53_record" "bastion" {
   zone_id = data.aws_route53_zone.rust_lang_org.id
   name    = "bastion.infra.rust-lang.org"
   type    = "A"
-  records = [aws_eip.bastion2.public_ip]
+  records = [aws_eip.bastion.public_ip]
   ttl     = 300
 }
 
@@ -55,7 +50,7 @@ data "aws_ami" "ubuntu24" {
   }
 }
 
-resource "aws_instance" "bastion2" {
+resource "aws_instance" "bastion" {
   ami                     = data.aws_ami.ubuntu24.id
   instance_type           = "t3a.micro"
   key_name                = data.terraform_remote_state.shared.outputs.master_ec2_key_pair
@@ -70,12 +65,12 @@ resource "aws_instance" "bastion2" {
   }
 
   network_interface {
-    network_interface_id = aws_network_interface.bastion2.id
+    network_interface_id = aws_network_interface.bastion.id
     device_index         = 0
   }
 
   tags = {
-    Name    = "bastion2"
+    Name    = "bastion"
     Service = "bastion"
   }
 


### PR DESCRIPTION
I renamed all resources with `terraform state mv` as suggested in https://github.com/rust-lang/simpleinfra/pull/626#issuecomment-2441114098.

## Plan


```
  # aws_eip.bastion will be updated in-place
  ~ resource "aws_eip" "bastion" {
        id                   = "eipalloc-0efe6aeb3b03bcacf"
      ~ tags                 = {
          ~ "Name" = "bastion2" -> "bastion"
        }
      ~ tags_all             = {
          ~ "Name" = "bastion2" -> "bastion"
        }
        # (13 unchanged attributes hidden)
    }

  # aws_instance.bastion will be updated in-place
  ~ resource "aws_instance" "bastion" {
        id                                   = "i-0e24b9259e55a03bb"
      ~ tags                                 = {
          ~ "Name"    = "bastion2" -> "bastion"
            "Service" = "bastion"
        }
      ~ tags_all                             = {
          ~ "Name"    = "bastion2" -> "bastion"
            # (1 unchanged element hidden)
        }
        # (31 unchanged attributes hidden)

        # (9 unchanged blocks hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.
```