### PR TITLE
Restore LLVM fix

### DIFF
--- a/ansible/roles/dev-desktop/tasks/fix_llvm_55575.yml
+++ b/ansible/roles/dev-desktop/tasks/fix_llvm_55575.yml
@@ -3,6 +3,8 @@
 # lldb 14 fails to load Python modules due to a wrong path. The workaround for
 # this issue is to symlink the modules to the path that lldb expects.
 # https://github.com/llvm/llvm-project/issues/55575
+#
+# This fix can be removed once we move to llvm 16
 
 - name: Find all lldb Python files
   ansible.builtin.find:

--- a/ansible/roles/dev-desktop/tasks/fix_llvm_55575.yml
+++ b/ansible/roles/dev-desktop/tasks/fix_llvm_55575.yml
@@ -6,13 +6,13 @@
 
 - name: Find all lldb Python files
   ansible.builtin.find:
-    paths: /usr/lib/llvm-14/lib/python3.10/dist-packages/lldb
+    paths: /usr/lib/llvm-14/lib/python3.12/dist-packages/lldb
     file_type: file
   register: lldb_python_files
 
 - name: Find all lldb Python modules
   ansible.builtin.find:
-    paths: /usr/lib/llvm-14/lib/python3.10/dist-packages/lldb
+    paths: /usr/lib/llvm-14/lib/python3.12/dist-packages/lldb
     file_type: directory
   register: lldb_python_directories
 
@@ -26,5 +26,5 @@
 - name: Fix lldb-server-14.0.0
   ansible.builtin.file:
     src: /usr/lib/llvm-14/bin/lldb-server
-    dest: /usr/bin/lldb-server-14.0.0
+    dest: /usr/bin/lldb-server-14.0.6
     state: link

--- a/ansible/roles/dev-desktop/tasks/fix_llvm_55575.yml
+++ b/ansible/roles/dev-desktop/tasks/fix_llvm_55575.yml
@@ -1,0 +1,30 @@
+---
+
+# lldb 14 fails to load Python modules due to a wrong path. The workaround for
+# this issue is to symlink the modules to the path that lldb expects.
+# https://github.com/llvm/llvm-project/issues/55575
+
+- name: Find all lldb Python files
+  ansible.builtin.find:
+    paths: /usr/lib/llvm-14/lib/python3.10/dist-packages/lldb
+    file_type: file
+  register: lldb_python_files
+
+- name: Find all lldb Python modules
+  ansible.builtin.find:
+    paths: /usr/lib/llvm-14/lib/python3.10/dist-packages/lldb
+    file_type: directory
+  register: lldb_python_directories
+
+- name: Fix llvm/llvm-project#55575
+  ansible.builtin.file:
+    src: "{{ item.path }}"
+    dest: "/usr/lib/python3/dist-packages/lldb/{{ item.path | basename }}"
+    state: link
+  with_items: "{{ lldb_python_files.files + lldb_python_directories.files }}"
+
+- name: Fix lldb-server-14.0.0
+  ansible.builtin.file:
+    src: /usr/lib/llvm-14/bin/lldb-server
+    dest: /usr/bin/lldb-server-14.0.0
+    state: link

--- a/ansible/roles/dev-desktop/tasks/main.yml
+++ b/ansible/roles/dev-desktop/tasks/main.yml
@@ -13,4 +13,4 @@
 - include_tasks: github.yml
 - include_tasks: motd.yml
 - include_tasks: scripts.yml
-- include_tasks: services.yml
+- include_tasks: fix_llvm_55575.yml


### PR DESCRIPTION
The prior fix for LLVM that was removed in #562 has been restored. The Python versions in the fix have been updated to match the versions that ship with Ubuntu 24.04.