### PR TITLE
Unlock Datadog version again

### DIFF
--- a/ansible/playbooks/dev-desktop.yml
+++ b/ansible/playbooks/dev-desktop.yml
@@ -17,7 +17,6 @@
         datadog_api_key: "{{ vars_datadog_api_key }}"
         datadog_site: "datadoghq.com"
 
-        datadog_agent_version: "7.56.2"
         datadog_config:
           tags:
             - "env:{{ vars_environment }}"


### PR DESCRIPTION
The version of the Datadog agent has been unlocked again. After running `apt update` and `apt upgrade`, it seems that the playbook runs through fine again.

Closes #621 