### PR TITLE
Switch to smaller instance type

### DIFF
--- a/terraform/releases/impl/promote-release.tf
+++ b/terraform/releases/impl/promote-release.tf
@@ -30,7 +30,7 @@ resource "aws_cloudwatch_log_group" "promote_release" {
 resource "aws_codebuild_project" "promote_release" {
   name          = "promote-release--${var.name}"
   description   = "Execute the release process in the ${var.name} environment."
-  build_timeout = 120
+  build_timeout = 240
   service_role  = aws_iam_role.promote_release.arn
 
   source {
@@ -49,7 +49,7 @@ resource "aws_codebuild_project" "promote_release" {
   }
 
   environment {
-    compute_type                = "BUILD_GENERAL1_2XLARGE"
+    compute_type                = "BUILD_GENERAL1_XLARGE"
     type                        = "LINUX_CONTAINER"
     image_pull_credentials_type = "SERVICE_ROLE"
     image                       = var.promote_release_ecr_repo.url


### PR DESCRIPTION
We ran into long QUEUED times with the larger instances, and in testing it seems like the smaller instance type isn't actually significantly slower, and is 2x less expensive, so we should switch to it anyway.

This also bumps the build timeout to give us a bit more buffer (our builds are currently just under 2 hours).

These changes have already been applied as part of [fixing](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/nightly-2024-11-24.20missing/near/484199493) nightly promotions.