### PR TITLE
create `ci-staging` aws account

### DIFF
--- a/terragrunt/modules/aws-organization/accounts.tf
+++ b/terragrunt/modules/aws-organization/accounts.tf
@@ -41,3 +41,8 @@ resource "aws_organizations_account" "bors_prod" {
   name  = "bors-prod"
   email = "admin+bors-prod@rust-lang.org"
 }
+
+resource "aws_organizations_account" "ci_staging" {
+  name  = "ci-staging"
+  email = "admin+ci-staging@rust-lang.org"
+}


### PR DESCRIPTION
We want to test running github actions into aws, so I created a new aws account.

## Name
Do you like the name of the account or is it too minimal?

I also considered `ci-runners-{staging, prod}`

## Plan
```
12:21:59.778 STDOUT terraform: Terraform will perform the following actions:
12:21:59.778 STDOUT terraform:   # aws_organizations_account.ci_staging will be created
12:21:59.778 STDOUT terraform:   + resource "aws_organizations_account" "ci_staging" {
12:21:59.778 STDOUT terraform:       + arn               = (known after apply)
12:21:59.778 STDOUT terraform:       + close_on_deletion = false
12:21:59.778 STDOUT terraform:       + create_govcloud   = false
12:21:59.778 STDOUT terraform:       + email             = "admin+ci-staging@rust-lang.org"
12:21:59.778 STDOUT terraform:       + govcloud_id       = (known after apply)
12:21:59.778 STDOUT terraform:       + id                = (known after apply)
12:21:59.778 STDOUT terraform:       + joined_method     = (known after apply)
12:21:59.778 STDOUT terraform:       + joined_timestamp  = (known after apply)
12:21:59.778 STDOUT terraform:       + name              = "ci-staging"
12:21:59.778 STDOUT terraform:       + parent_id         = (known after apply)
12:21:59.778 STDOUT terraform:       + status            = (known after apply)
12:21:59.778 STDOUT terraform:       + tags_all          = (known after apply)
12:21:59.778 STDOUT terraform:     }
12:21:59.778 STDOUT terraform: Plan: 1 to add, 0 to change, 0 to destroy.
```