### PR TITLE
Fix deletion of SSH keys

### DIFF
--- a/ansible/roles/dev-desktop/files/team_login/src/main.rs
+++ b/ansible/roles/dev-desktop/files/team_login/src/main.rs
@@ -95,15 +95,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for entry in std::fs::read_dir(KEY_DIR)? {
         let entry = entry?;
         let path = entry.path();
-        if !path.is_file() {
-            if let Some(extension) = path.extension() {
-                if extension == "keys" {
-                    if let Some(stem) = path.file_stem() {
-                        if let Some(stem) = stem.to_str() {
-                            if stem.starts_with("gh-") && !users.contains(stem) {
-                                std::fs::remove_file(path)?;
-                            }
-                        }
+        if path.is_file() {
+            if let Some(stem) = path.file_stem() {
+                if let Some(stem) = stem.to_str() {
+                    if stem.starts_with("gh-") && !users.contains(stem) {
+                        std::fs::remove_file(path)?;
                     }
                 }
             }


### PR DESCRIPTION
The team login binary that manages user accounts on the dev-desktops had a bug that caused obsolete SSH keys to never get deleted. Specifically, the script assumed a different structure on disk and thus ignored the files with the keys.