### PR TITLE
feat(ci-staging): add connection for rust-lang-ci gh org

### DIFF
--- a/terragrunt/accounts/ci-staging/ci-runners/terragrunt.hcl
+++ b/terragrunt/accounts/ci-staging/ci-runners/terragrunt.hcl
@@ -8,5 +8,6 @@ include {
 }
 
 inputs = {
-  code_connection_arn = "arn:aws:codeconnections:us-east-2:442426873467:connection/98864d5c-b905-4f8e-bd76-2f69cf181818"
+  rust_lang_code_connection_arn    = "arn:aws:codeconnections:us-east-2:442426873467:connection/98864d5c-b905-4f8e-bd76-2f69cf181818"
+  rust_lang_ci_code_connection_arn = "arn:aws:codeconnections:us-east-2:442426873467:connection/dfa33048-75a5-4409-8700-5f099d558c52"
 }

--- a/terragrunt/modules/ci-runners/codebuild.tf
+++ b/terragrunt/modules/ci-runners/codebuild.tf
@@ -43,9 +43,12 @@ resource "aws_codebuild_project" "ubuntu_small" {
 
   source {
     type = "GITHUB"
-    // Dummy repository.
-    // TODO: can we put the real repos even if we use github app?
-    location        = "https://github.com/rust-lang/infra-team.git"
+    // test repository
+    location        = "https://github.com/rust-lang/aws-runners-test"
     git_clone_depth = 1
+
+    git_submodules_config {
+      fetch_submodules = false
+    }
   }
 }

--- a/terragrunt/modules/ci-runners/iam.tf
+++ b/terragrunt/modules/ci-runners/iam.tf
@@ -32,7 +32,8 @@ resource "aws_iam_role_policy" "codebuild_policy" {
           "codeconnections:GetConnection"
         ]
         Resource = [
-          var.code_connection_arn
+          var.rust_lang_code_connection_arn,
+          var.rust_lang_ci_code_connection_arn
         ]
       }
     ]

--- a/terragrunt/modules/ci-runners/variables.tf
+++ b/terragrunt/modules/ci-runners/variables.tf
@@ -1,6 +1,10 @@
 // Since you can't create the connection from the terraform provider (as of Dec 2024),
 // you need to create the connection manually at
 // https://us-east-2.console.aws.amazon.com/codesuite/settings/connections
-variable "code_connection_arn" {
-  description = "Arn of the GitHub CodeConnection"
+variable "rust_lang_code_connection_arn" {
+  description = "Arn of the GitHub CodeConnection for https://github.com/rust-lang"
+}
+
+variable "rust_lang_ci_code_connection_arn" {
+  description = "Arn of the GitHub CodeConnection for https://github.com/rust-lang-ci"
 }


### PR DESCRIPTION
Plan
```
12:12:17.667 STDOUT terraform: Terraform will perform the following actions:
12:12:17.667 STDOUT terraform:   # aws_iam_role_policy.codebuild_policy will be updated in-place
12:12:17.667 STDOUT terraform:   ~ resource "aws_iam_role_policy" "codebuild_policy" {
12:12:17.667 STDOUT terraform:         id     = "codebuild-github-runner-role:codebuild-github-runner-policy"
12:12:17.667 STDOUT terraform:         name   = "codebuild-github-runner-policy"
12:12:17.667 STDOUT terraform:       ~ policy = jsonencode(
12:12:17.667 STDOUT terraform:           ~ {
12:12:17.667 STDOUT terraform:               ~ Statement = [
12:12:17.667 STDOUT terraform:                   ~ {
12:12:17.667 STDOUT terraform:                       ~ Resource = [
12:12:17.667 STDOUT terraform:                             "arn:aws:codeconnections:us-east-2:442426873467:connection/98864d5c-b905-4f8e-bd76-2f69cf181818",
12:12:17.667 STDOUT terraform:                           + "arn:aws:codeconnections:us-east-2:442426873467:connection/dfa33048-75a5-4409-8700-5f099d558c52",
12:12:17.667 STDOUT terraform:                         ]
12:12:17.667 STDOUT terraform:                         # (2 unchanged attributes hidden)
12:12:17.667 STDOUT terraform:                     },
12:12:17.667 STDOUT terraform:                 ]
12:12:17.667 STDOUT terraform:                 # (1 unchanged attribute hidden)
12:12:17.667 STDOUT terraform:             }
12:12:17.667 STDOUT terraform:         )
12:12:17.667 STDOUT terraform:         # (1 unchanged attribute hidden)
12:12:17.667 STDOUT terraform:     }
12:12:17.667 STDOUT terraform: Plan: 0 to add, 1 to change, 0 to destroy.
```