### PR TITLE
add "disk full" alert for docs.rs

### DIFF
--- a/ansible/playbooks/monitoring.yml
+++ b/ansible/playbooks/monitoring.yml
@@ -215,6 +215,13 @@
                 summary: "No successful docs.rs builds in the last hour"
                 description: "no documentation builds were successful in the last hour."
 
+            - alert: DiskFull
+              expr: node_filesystem_avail_bytes{job="node",instance="docsrs.infra.rust-lang.org:9100", mountpoint="/"} / node_filesystem_size_bytes{job="node",instance="docsrs.infra.rust-lang.org:9100",mountpoint="/"} < 0.10
+              for: 1m
+              annotations:
+                summary: "Filesystem is full"
+                description: "There is less than 10% disk space left on disk."
+
             - alert: DocsRsQueueLocked
               expr: docsrs_queue_is_locked{job="docsrs"} == 1
               for: 1m


### PR DESCRIPTION
Not sure if this is the best way. 

I saw there is a disk space alert [here](https://github.com/rust-lang/simpleinfra/blob/19fb0d20a1bee3e59dccd894a105359efe90914a/ansible/playbooks/monitoring.yml#L176-L181), but wasn't sure how I could get alerts in the private docs.rs channel only for disk space on our server. 

So I added it as a separate alert here. 

The query is tested in grafana "explore"