### PR TITLE
Reduce the number of monitorbot tasks to 0

### DIFF
--- a/terraform/monitorbot/.terraform.lock.hcl
+++ b/terraform/monitorbot/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.65.0"
   constraints = ">= 5.64.0, ~> 5.64"
   hashes = [
+    "h1:LTqvpg2APqTRPmQIkOAFwn7Q8rXTXazDXIBaYSfLIm4=",
     "h1:OG8xMZjGZL/OtEV9OwX0CTPcUzvSfcfiB0X9lcs2joY=",
     "zh:036f8557c8c9b58656e1ec08ed5702e44bd338fda17dc4b2add40b234102e29a",
     "zh:0ba0708ece98735540070899a916b7a90c5c887be31ffd693ee1359e40245978",
@@ -29,6 +30,7 @@ provider "registry.terraform.io/hashicorp/random" {
   constraints = "~> 3.6.2"
   hashes = [
     "h1:VavG5unYCa3SYISMKF9pzc3718M0bhPlcbUZZGl7wuo=",
+    "h1:wmG0QFjQ2OfyPy6BB7mQ57WtoZZGGV07uAPQeDmIrAE=",
     "zh:0ef01a4f81147b32c1bea3429974d4d104bbc4be2ba3cfa667031a8183ef88ec",
     "zh:1bcd2d8161e89e39886119965ef0f37fcce2da9c1aca34263dd3002ba05fcb53",
     "zh:37c75d15e9514556a5f4ed02e1548aaa95c0ecd6ff9af1119ac905144c70c114",
@@ -48,6 +50,7 @@ provider "registry.terraform.io/integrations/github" {
   version     = "6.2.3"
   constraints = "~> 6.2.3"
   hashes = [
+    "h1:nHTegsQYYUJZbaTnU1aMJBgnZUbR2zsfCl7DsL/kZjQ=",
     "h1:qBH3fN/NItflQkBoIVdQa7n8WvBOuu7Ao20oeoAubKM=",
     "zh:05874671652a260b12d784cc46b0eea156f493a5f12e00368d1f6cb319156257",
     "zh:0c7a3cae5a66e5c5efc3b25ba646a0d46bfe1fd3edba1f5a75f51aede85a9d1b",

--- a/terraform/monitorbot/app.tf
+++ b/terraform/monitorbot/app.tf
@@ -10,7 +10,7 @@ module "monitorbot" {
 
   cpu              = 256
   memory           = 512
-  tasks_count      = 1
+  tasks_count      = 0 # TODO: currently broken, avoid restarting it constantly
   platform_version = "1.4.0"
 
   environment = {


### PR DESCRIPTION
Monitorbot keeps failing to start up. While we decide what to do with it, avoid it from starting up.