### PR TITLE
dev-desktops: Install m4

### DIFF
--- a/ansible/roles/dev-desktop/tasks/dependencies.yml
+++ b/ansible/roles/dev-desktop/tasks/dependencies.yml
@@ -52,6 +52,7 @@
       - emacs
       - lld
       - lldb
+      - m4
       - mold
       - gdb
       - neovim


### PR DESCRIPTION
GNU m4 [1] is a preprocessor required to build some libraries such as MPFR, which we test libm against.

[1]: https://www.gnu.org/software/m4/