### PR TITLE
Allow starting the beta release from start-release

### DIFF
--- a/terraform/releases/lambdas/start-release/index.py
+++ b/terraform/releases/lambdas/start-release/index.py
@@ -51,6 +51,9 @@ def handler(event, context):
                 },
             )
 
+        case "publish-rust-prod-beta":
+            return run_build("promote-release", "prod", "beta")
+
         case "publish-rust-prod-stable":
             return run_build("promote-release", "prod", "stable")
 


### PR DESCRIPTION
This PR allows release team members who are not also infra-admins to start beta releases on the production environment. Usually beta releases are published on a schedule every night, and there is no need to manually start them.

When creating the new beta branch as part of the release process it might be helpful to be able to start beta releases earlier than the schedule, so this PR allows release team members to do that. Note that this does *not* allow them to pass the flag to override an existing release, it only allows them to publish a release if none is already published that UTC day.

r? @Mark-Simulacrum 