### PR TITLE
dev-desktops: Install flex

### DIFF
--- a/ansible/roles/dev-desktop/tasks/dependencies.yml
+++ b/ansible/roles/dev-desktop/tasks/dependencies.yml
@@ -50,6 +50,7 @@
       - libsecret-1-dev # used by cargo
       - libfuse3-dev
       - emacs
+      - flex # Allows running `x build gcc`
       - lld
       - lldb
       - m4


### PR DESCRIPTION
Flex [1] is a lexical analyzer required to build GCC, which `x build` can handle to support the cg_gcc backend.

[1]: https://github.com/westes/flex