### PR TITLE
feat(ci-staging): add ubuntu 36 core runner

### DIFF
--- a/terragrunt/modules/ci-runners/codebuild.tf
+++ b/terragrunt/modules/ci-runners/codebuild.tf
@@ -150,3 +150,52 @@ resource "aws_codebuild_project" "ubuntu_22_8c" {
     }
   }
 }
+
+resource "aws_codebuild_project" "ubuntu_22_36c" {
+  name         = "ubuntu-22-36c"
+  service_role = aws_iam_role.codebuild_role.arn
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  cache {
+    type = "NO_CACHE"
+    // TODO: evaluate if it's worth adding cache
+    // modes = ["LOCAL_DOCKER_LAYER_CACHE", "LOCAL_SOURCE_CACHE"]
+  }
+
+  build_timeout = 60 * 6 // 6 hours
+
+  environment {
+    compute_type = "BUILD_GENERAL1_2XLARGE"
+    // ubuntu 22
+    image                       = "aws/codebuild/standard:7.0-24.10.29"
+    type                        = "LINUX_CONTAINER"
+    image_pull_credentials_type = "CODEBUILD"
+
+    // Whether to enable running the Docker daemon.
+    // The Rust CI uses Docker to build linux artifacts,
+    // so we need this if the target is linux.
+    privileged_mode = true
+  }
+
+  // Disable cloudwatch logs for cost saving.
+  // Logs are available in GitHub Actions.
+  logs_config {
+    cloudwatch_logs {
+      status = "DISABLED"
+    }
+  }
+
+  source {
+    type = "GITHUB"
+    // test repository
+    location        = "https://github.com/rust-lang-ci/rust"
+    git_clone_depth = 1
+
+    git_submodules_config {
+      fetch_submodules = false
+    }
+  }
+}


### PR DESCRIPTION
The 8 core machine doesn't have enough space to run the fuchsia job and 36 core is the next available machine 
![image](https://github.com/user-attachments/assets/3adee5f1-7ee1-4ddf-9fd7-ba11ddead32b)

I'm trying this for testing. If it works, I'll try to free up space in the 8 core job.