### PR TITLE
Remove Rust Foundation website

### DIFF
--- a/terraform/domain-redirects/redirects.tf
+++ b/terraform/domain-redirects/redirects.tf
@@ -75,21 +75,6 @@ module "arewewebyet_org" {
   permanent = true
 }
 
-module "rustfoundation_org" {
-  source = "./impl"
-  providers = {
-    aws       = aws
-    aws.east1 = aws.east1
-  }
-
-  to_host = "foundation.rust-lang.org"
-  from = [
-    "rustfoundation.org",
-    "www.rustfoundation.org",
-  ]
-  permanent = false
-}
-
 // https://github.com/rust-lang/docs.rs/issues/1210
 module "docs_rs_metadata" {
   source = "./impl"


### PR DESCRIPTION
The Rust Foundation website has been moved from GitHub Pages to Wordpress hosting. Both `rustfoundation.org` and
`foundation.rust-lang.org` have been manually updated to point to the new host, making the redirect obsolete.