### PR TITLE
ci-runners: authenticate with github

### DIFF
--- a/terragrunt/accounts/ci-staging/ci-runners/terragrunt.hcl
+++ b/terragrunt/accounts/ci-staging/ci-runners/terragrunt.hcl
@@ -8,7 +8,6 @@ include {
 }
 
 inputs = {
-  rust_lang_code_connection_arn    = "arn:aws:codeconnections:us-east-2:442426873467:connection/98864d5c-b905-4f8e-bd76-2f69cf181818"
-  rust_lang_ci_code_connection_arn = "arn:aws:codeconnections:us-east-2:442426873467:connection/dfa33048-75a5-4409-8700-5f099d558c52"
+  code_connection_arn    = "arn:aws:codeconnections:us-east-2:442426873467:connection/98864d5c-b905-4f8e-bd76-2f69cf181818"
   repository                       = "rust-lang/aws-runners-test"
 }

--- a/terragrunt/modules/ci-runners/codebuild.tf
+++ b/terragrunt/modules/ci-runners/codebuild.tf
@@ -9,35 +9,39 @@
 module "ubuntu_22_2c" {
   source = "../../modules/codebuild-project"
 
-  name         = "ubuntu-22-2c"
-  service_role = aws_iam_role.codebuild_role.arn
-  compute_type = "BUILD_GENERAL1_SMALL"
-  repository   = var.repository
+  name                = "ubuntu-22-2c"
+  service_role        = aws_iam_role.codebuild_role.arn
+  compute_type        = "BUILD_GENERAL1_SMALL"
+  repository          = var.repository
+  code_connection_arn = var.code_connection_arn
 }
 
 module "ubuntu_22_4c" {
   source = "../../modules/codebuild-project"
 
-  name         = "ubuntu-22-4c"
-  service_role = aws_iam_role.codebuild_role.arn
-  compute_type = "BUILD_GENERAL1_MEDIUM"
-  repository   = var.repository
+  name                = "ubuntu-22-4c"
+  service_role        = aws_iam_role.codebuild_role.arn
+  compute_type        = "BUILD_GENERAL1_MEDIUM"
+  repository          = var.repository
+  code_connection_arn = var.code_connection_arn
 }
 
 module "ubuntu_22_8c" {
   source = "../../modules/codebuild-project"
 
-  name         = "ubuntu-22-8c"
-  service_role = aws_iam_role.codebuild_role.arn
-  compute_type = "BUILD_GENERAL1_LARGE"
-  repository   = var.repository
+  name                = "ubuntu-22-8c"
+  service_role        = aws_iam_role.codebuild_role.arn
+  compute_type        = "BUILD_GENERAL1_LARGE"
+  repository          = var.repository
+  code_connection_arn = var.code_connection_arn
 }
 
 module "ubuntu_22_36c" {
   source = "../../modules/codebuild-project"
 
-  name         = "ubuntu-22-36c"
-  service_role = aws_iam_role.codebuild_role.arn
-  compute_type = "BUILD_GENERAL1_XLARGE"
-  repository   = var.repository
+  name                = "ubuntu-22-36c"
+  service_role        = aws_iam_role.codebuild_role.arn
+  compute_type        = "BUILD_GENERAL1_XLARGE"
+  repository          = var.repository
+  code_connection_arn = var.code_connection_arn
 }

--- a/terragrunt/modules/ci-runners/iam.tf
+++ b/terragrunt/modules/ci-runners/iam.tf
@@ -31,10 +31,7 @@ resource "aws_iam_role_policy" "codebuild_policy" {
           "codeconnections:GetConnectionToken",
           "codeconnections:GetConnection"
         ]
-        Resource = [
-          var.rust_lang_code_connection_arn,
-          var.rust_lang_ci_code_connection_arn
-        ]
+        Resource = [var.code_connection_arn]
       }
     ]
   })

--- a/terragrunt/modules/ci-runners/variables.tf
+++ b/terragrunt/modules/ci-runners/variables.tf
@@ -1,12 +1,8 @@
 // Since you can't create the connection from the terraform provider (as of Dec 2024),
 // you need to create the connection manually at
 // https://us-east-2.console.aws.amazon.com/codesuite/settings/connections
-variable "rust_lang_code_connection_arn" {
-  description = "Arn of the GitHub CodeConnection for https://github.com/rust-lang"
-}
-
-variable "rust_lang_ci_code_connection_arn" {
-  description = "Arn of the GitHub CodeConnection for https://github.com/rust-lang-ci"
+variable "code_connection_arn" {
+  description = "Arn of the GitHub CodeConnection for the GitHub organization."
 }
 
 variable "repository" {

--- a/terragrunt/modules/codebuild-project/project.tf
+++ b/terragrunt/modules/codebuild-project/project.tf
@@ -43,5 +43,10 @@ resource "aws_codebuild_project" "ubuntu_project" {
     git_submodules_config {
       fetch_submodules = false
     }
+
+    auth {
+      type     = "CODECONNECTIONS"
+      resource = var.code_connection_arn
+    }
   }
 }

--- a/terragrunt/modules/codebuild-project/variables.tf
+++ b/terragrunt/modules/codebuild-project/variables.tf
@@ -21,3 +21,7 @@ variable "repository" {
     error_message = "The repository must be in the format 'owner/repo'."
   }
 }
+
+variable "code_connection_arn" {
+  description = "Arn of the GitHub CodeConnection for the GitHub organization."
+}


### PR DESCRIPTION
this should reduce the number of manual steps required to setup each project.