### PR TITLE
update ci-runners aws requirement

### DIFF
--- a/terragrunt/modules/ci-runners/main.tf
+++ b/terragrunt/modules/ci-runners/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.64"
+      version = "~> 5.91"
     }
   }
 }

--- a/terragrunt/modules/codebuild-project/main.tf
+++ b/terragrunt/modules/codebuild-project/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.64"
+      version = "~> 5.91"
     }
   }
 }


### PR DESCRIPTION
we use a feature from the latest aws version.