### PR TITLE
docs: remove unnecessary manual steps

### DIFF
--- a/terragrunt/modules/ci-runners/README.md
+++ b/terragrunt/modules/ci-runners/README.md
@@ -1,0 +1,10 @@
+# CI runners
+
+Manual steps required to configure CI runners:
+
+- If you want to add a new repository, you need to edit the settings of the
+  GitHub App installed in the organization.
+- If it is the first time you are configuring a new GitHub organization,
+  click on a codebuild project (2c or 4c, etc.) and connect the AWS account
+  to the GitHub app manually. If successful, you should see the following message:
+  `Your account is successfully connected by using an AWS managed GitHub App.`

--- a/terragrunt/modules/ci-runners/codebuild.tf
+++ b/terragrunt/modules/ci-runners/codebuild.tf
@@ -1,11 +1,3 @@
-// Manual steps required after provisioning a project:
-// - Connect the GitHub App of the organization, indicating the repositories.
-// - Set webhooks with event type `WORKFLOW_JOB_QUEUED` in the filter group.
-//
-// These manual steps are required because the terraform provider is missing
-// support for GitHub Actions runners.
-// See https://github.com/hashicorp/terraform-provider-aws/issues/39011
-
 module "ubuntu_22_2c" {
   source = "../../modules/codebuild-project"
 


### PR DESCRIPTION
the latest version of the provider allows us to configure the project correctly, so that no manual steps are necessary when creating a new project. This is handy if we want to add new runners.