### PR TITLE
don't synchronize periodically sync-team from aws

### DIFF
--- a/terraform/team-repo/sync-team.tf
+++ b/terraform/team-repo/sync-team.tf
@@ -72,20 +72,6 @@ resource "aws_codebuild_project" "sync_team" {
   }
 }
 
-// CloudWatch rule to run the synchronization every day.
-
-resource "aws_cloudwatch_event_rule" "start_daily" {
-  name                = "cloudbuild--sync-team"
-  description         = "Run the sync-team CodeBuild every day."
-  schedule_expression = "cron(0 * * * ? *)"
-}
-
-resource "aws_cloudwatch_event_target" "start_daily" {
-  rule     = aws_cloudwatch_event_rule.start_daily.name
-  arn      = aws_codebuild_project.sync_team.arn
-  role_arn = aws_iam_role.start_execution.arn
-}
-
 // IAM Role that CodeBuild will assume when running the build. The role will
 // grant access to write the logs, read parameters and pull the ECR image.
 


### PR DESCRIPTION
We want to synchronize from the `team` repo, in GitHub Actions.

plan:
```
Terraform will perform the following actions:

  # aws_cloudwatch_event_rule.start_daily will be destroyed
  # (because aws_cloudwatch_event_rule.start_daily is not in configuration)
  - resource "aws_cloudwatch_event_rule" "start_daily" {
      - arn                 = "arn:aws:events:us-west-1:890664054962:rule/cloudbuild--sync-team" -> null
      - description         = "Run the sync-team CodeBuild every day." -> null
      - event_bus_name      = "default" -> null
      - force_destroy       = false -> null
      - id                  = "cloudbuild--sync-team" -> null
      - is_enabled          = true -> null
      - name                = "cloudbuild--sync-team" -> null
      - schedule_expression = "cron(0 * * * ? *)" -> null
      - state               = "ENABLED" -> null
      - tags                = {} -> null
      - tags_all            = {} -> null
    }

  # aws_cloudwatch_event_target.start_daily will be destroyed
  # (because aws_cloudwatch_event_target.start_daily is not in configuration)
  - resource "aws_cloudwatch_event_target" "start_daily" {
      - arn            = "arn:aws:codebuild:us-west-1:890664054962:project/sync-team" -> null
      - event_bus_name = "default" -> null
      - force_destroy  = false -> null
      - id             = "cloudbuild--sync-team-terraform-20200625124714186400000002" -> null
      - role_arn       = "arn:aws:iam::890664054962:role/start-sync-team" -> null
      - rule           = "cloudbuild--sync-team" -> null
      - target_id      = "terraform-20200625124714186400000002" -> null
    }

Plan: 0 to add, 0 to change, 2 to destroy.
```