### PR TITLE
Allow access to the new bors DB from bastion

### DIFF
--- a/terragrunt/modules/bors/main.tf
+++ b/terragrunt/modules/bors/main.tf
@@ -468,6 +468,14 @@ resource "aws_security_group" "rds" {
   name        = "rds"
   description = "Allow necessary communication for rds database"
   vpc_id      = data.aws_vpc.default.id
+
+  ingress {
+      from_port       = 5432
+      to_port         = 5432
+      protocol        = "tcp"
+      security_groups = [data.aws_security_group.bastion.id]
+      description     = "Connections from the bastion"
+    }
 }
 
 resource "aws_vpc_security_group_ingress_rule" "ingress_ecs" {

--- a/terragrunt/modules/bors/main.tf
+++ b/terragrunt/modules/bors/main.tf
@@ -450,6 +450,9 @@ resource "aws_db_instance" "primary" {
   instance_class          = "db.t4g.micro"
   backup_retention_period = 7
 
+  # Make the instance accessible from outside the VPC
+  publicly_accessible = true
+
   vpc_security_group_ids = [aws_security_group.rds.id]
 
   username = "bors"

--- a/terragrunt/modules/bors/main.tf
+++ b/terragrunt/modules/bors/main.tf
@@ -446,7 +446,7 @@ data "aws_vpc" "default" {
 resource "aws_db_instance" "primary" {
   db_name                 = "bors"
   engine                  = "postgres"
-  engine_version          = "15.5"
+  engine_version          = "15.8"
   instance_class          = "db.t4g.micro"
   backup_retention_period = 7
 
@@ -468,14 +468,17 @@ resource "aws_security_group" "rds" {
   name        = "rds"
   description = "Allow necessary communication for rds database"
   vpc_id      = data.aws_vpc.default.id
+}
 
-  ingress {
-      from_port       = 5432
-      to_port         = 5432
-      protocol        = "tcp"
-      security_groups = [data.aws_security_group.bastion.id]
-      description     = "Connections from the bastion"
-    }
+resource "aws_vpc_security_group_ingress_rule" "bastion" {
+  security_group_id = aws_security_group.rds.id
+
+  from_port   = 5432
+  to_port     = 5432
+  ip_protocol = "tcp"
+  # Bastion is in the legacy AWS account, so we hardcode its IP address.
+  cidr_ipv4   = "13.57.121.61/32"
+  description = "Connections from the bastion"
 }
 
 resource "aws_vpc_security_group_ingress_rule" "ingress_ecs" {


### PR DESCRIPTION
I copied stuff that looked relevant over from `terraform/rds-databases/instance.tf`.

Running `terragrunt apply` outputs this:
```
terragrunt plan
terragrunt-locals.py: calculating configuration...
╷
│ Error: Reference to undeclared resource
│ 
│   on main.tf line 476, in resource "aws_security_group" "rds":
│  476:       security_groups = [data.aws_security_group.bastion.id]
│ 
│ A data resource "aws_security_group" "bastion" has not been declared in the
│ root module.
```
which makes sense, I guess, but I have no idea how to link bastion here :see_no_evil: