### PR TITLE
add CORS headers to index.crates.io

### DIFF
--- a/terragrunt/modules/crates-io/compute-static/fastly.toml
+++ b/terragrunt/modules/crates-io/compute-static/fastly.toml
@@ -9,4 +9,4 @@ name = "compute-static"
 service_id = ""
 
 [scripts]
-  build = "cargo build --bin compute-static --release --target wasm32-wasi --color always"
+build = "cargo build --bin compute-static --release --target wasm32-wasip1 --color always"

--- a/terragrunt/modules/crates-io/compute-static/rust-toolchain.toml
+++ b/terragrunt/modules/crates-io/compute-static/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "stable"
-targets = [ "wasm32-wasi" ]
+targets = ["wasm32-wasip1"]

--- a/terragrunt/modules/crates-io/s3-index.tf
+++ b/terragrunt/modules/crates-io/s3-index.tf
@@ -4,6 +4,14 @@ resource "aws_s3_bucket" "index" {
   versioning {
     enabled = true
   }
+
+  // Allow browsers to fetch index files from JavaScript.
+  cors_rule {
+    allowed_methods = ["GET"]
+    allowed_headers = ["*"]
+    allowed_origins = ["*"]
+    max_age_seconds = 3000
+  }
 }
 
 resource "aws_s3_bucket_policy" "index" {


### PR DESCRIPTION
Context: [zulip chat thread](https://rust-lang.zulipchat.com/#narrow/channel/318791-t-crates-io/topic/CORS.20headers.20on.20https.3A.2F.2Findex.2Ecrates.2Eio/near/518212938)

Currently despite a [permissive data access policy](https://crates.io/data-access#crate-index), `index.crates.io` doesn't return CORS headers. This prevents client-side javascript lookups of versions and other metadata per crate. Such lookups are useful for other websites that are visualizing crate information.

Per our discussion in Zulip, I'm adding simple Cloudfront-injected viewer response headers to add `access-control-allow-origin = "*"`. I'm not adding `OPTIONS` headers, support for non-simple fetch headers, or other more complex CORS support. It shouldn't be relevant given that we want to support clients that are simply retrieving crate metadata via `fetch` `GET` calls.

## Testing

I didn't directly test this code, though I did copy most of it from similar files. The CORS config came directly from the [hashicorp reference](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_response_headers_policy#cors_config-1)

The instructions on testing in the README involve needing permissions to make CLI calls that I don't have. I could probably install `terragrunt` and figure out how to get it to run `terragrunt validate` if you prefer... I don't think Github CI is doing that, just formatting. Let me know!