### PR TITLE
Add cvise to dev-desktops

### DIFF
--- a/ansible/roles/dev-desktop/tasks/dependencies.yml
+++ b/ansible/roles/dev-desktop/tasks/dependencies.yml
@@ -17,6 +17,7 @@
       - cmake
       - gcc-mingw-w64-x86-64 # Allows running `x check --target x86_64-pc-windows-gnu`
       - jq
+      - cvise
       - libssl-dev
       - llvm
       - ninja-build


### PR DESCRIPTION
cvise is a test case reducer that I want to use on fuzzer findings: https://github.com/marxin/cvise