### PR TITLE
Add libraries needed for building `libgccjit`

### DIFF
--- a/ansible/roles/dev-desktop/tasks/dependencies.yml
+++ b/ansible/roles/dev-desktop/tasks/dependencies.yml
@@ -63,7 +63,7 @@
       - capnproto
       - libcapnp-dev
       - zsh
-      # Needed to build libgccjit(for running `cg_gcc` on architectures other than x86)
+      # The following 4 packages are needed to build libgccjit(for running `cg_gcc` on architectures other than x86)
       - libmpfr-dev
       - libgmp-dev
       - libmpc3

--- a/ansible/roles/dev-desktop/tasks/dependencies.yml
+++ b/ansible/roles/dev-desktop/tasks/dependencies.yml
@@ -63,6 +63,11 @@
       - capnproto
       - libcapnp-dev
       - zsh
+      # Needed to build libgccjit(for running `cg_gcc` on architectures other than x86)
+      - libmpfr-dev
+      - libgmp-dev
+      - libmpc3
+      - libmpc-dev
     state: present
 
 # we don't need it because we don't need to send emails


### PR DESCRIPTION
The development of `rustc_codegen_gcc` requires building `libgccjit`(to test on ARM and to test GCC patches).

This PR adds the dependencies necessary for building GCC to the remote desktops.
