### PR TITLE
dev-desktops: Install bison, zlib1g, zlib1g-dev, and unzip

### DIFF
--- a/ansible/roles/dev-desktop/tasks/dependencies.yml
+++ b/ansible/roles/dev-desktop/tasks/dependencies.yml
@@ -68,6 +68,11 @@
       - libgmp-dev
       - libmpc3
       - libmpc-dev
+      # Necessary for kani
+      - bison
+      - zlib1g
+      - zlib1g-dev
+      - unzip
     state: present
 
 # we don't need it because we don't need to send emails


### PR DESCRIPTION
Kani or verify-rust-std requires these dependencies:

* [bison](https://packages.ubuntu.com/jammy/bison): YACC-compatible parser generator
* [zlib1g](https://packages.ubuntu.com/jammy/zlib1g) and [zlib1g-dev](https://packages.ubuntu.com/jammy/zlib1g-dev): compression library - runtime and development
* [unzip](https://packages.ubuntu.com/jammy/unzip): De-archiver for .zip files