### PR TITLE
Create AWS account for metrics-initiative

### DIFF
--- a/terragrunt/accounts/metrics-initiative-prod/account.json
+++ b/terragrunt/accounts/metrics-initiative-prod/account.json
@@ -1,0 +1,10 @@
+{
+    "aws": {
+        "profile": "metrics-initiative-prod",
+        "regions": [
+            {
+                "region": "us-east-2"
+            }
+        ]
+    }
+}

--- a/terragrunt/accounts/metrics-initiative-prod/datadog-aws/.terraform.lock.hcl
+++ b/terragrunt/accounts/metrics-initiative-prod/datadog-aws/.terraform.lock.hcl
@@ -1,0 +1,47 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/datadog/datadog" {
+  version     = "3.43.1"
+  constraints = "3.43.1"
+  hashes = [
+    "h1:pcyAjQvw5BUajiVGJQ6nVWdocfSnCRdazHwTzjdOh3M=",
+    "zh:115a656d68c9ac95188a3421dd8aa5a9ba4074d42b717fcc87ffd45576231857",
+    "zh:1dc3687237d8c2c947ebd5a3c80404c17dbf210cfb7f3b4464fd6e12f6784398",
+    "zh:24dc4d31edd69977bdf6004d85092d7013f6f7917c24ecb758717962dd7cbfe5",
+    "zh:2e5def7d74f488070443f86d75fb9813736c085efb5fa1f7e0f6151a2f83a30b",
+    "zh:6e4502bbd54b0a782b582c4d22aaa43814eae6a0b66f4835648c27f6015d505d",
+    "zh:8105124f33fa84fd59af3a18ab8534ce7f956c2e8a9d26546adfdbc9e8d7c725",
+    "zh:8ac9fc28cb06326c51ee2a35ee092e0abbaa2545a72f3318c406e9e5f0ef22a1",
+    "zh:a17997d6e2aafd488af6fcede3d20acfe72d5d6f0c1d257880657da1eb0a175e",
+    "zh:b35ea09714425c17578b6473c362380bb9b276d3f8bfff675d1ee7deb11377a7",
+    "zh:b71dfa4bde00632c0ebc9531274f337891303cf2e647b479d5030c22b33347ba",
+    "zh:ba51ddc2dc8c8e72426e873b2e3abac0ebfb9724207ba135bb3aa4775a523429",
+    "zh:bb5631c8c209fc94434164acd7478726f1f8ef40089e68eff12d131a648961bf",
+    "zh:c165ae439b26834858139fe971b702e5baad74db22b6439784b37690d087ffca",
+    "zh:d185755f6a0d4783fb42121109eeec4207f9caf35e7066bdf1101d12ae2c2ec8",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.91.0"
+  constraints = "~> 5.64"
+  hashes = [
+    "h1:bZ3AM8Qd1veQoUJqOb7OVp/ElmLg/hkz3bHL2DZZ5Tk=",
+    "zh:03ee14261b25aee94c735ed6ef7cce47900ab7bdf462335432ca034d0ba74ca2",
+    "zh:32a3759049c9c2cd041d1257cf16cb90a5ce586e1d0a6fe5f8ebd0ec1ba8e071",
+    "zh:334db69bc6d8643ec4ea432f0e54e851c2394bbe889cca29ca5029db0e4699e8",
+    "zh:39957a4a900f100ea8d85845a42164a44c9efea8559a9e74ab4f6a1193e20c3e",
+    "zh:8831396c764815eb367601a522c51c2e9e8fc38bcaa5f5e83f21de771778e9ba",
+    "zh:8e71ab68c27f909892a063f845d92faa487297ad9bbc67c77a67194e509781e6",
+    "zh:944df1084a7ea37a4feea0ee6654fd15891ef4829c5453bc149ffbcc0ab9bad7",
+    "zh:964391527624f2e66a4eb387ad0a30a1b67a896e9395b6d01353f2572723ea03",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:bb956c660185161e8ce1ed1dbf187c9f549d1779673fe798211dd5b02b98c737",
+    "zh:c237199ca8cd88f4aab4c673f848c77670b90d98a484fef6bcd31a71ff63d9b9",
+    "zh:c7522f6072f8ba29f4a6d0f994eda8a381ed2f4a41dbe44c4d989c44852cfe63",
+    "zh:d412a852ced01433c44f222952b60974f7c297a8a21bef62c9a627b050084134",
+    "zh:e420266b772041fa89e5868594ed21c8c3090d76b3ec0262054f768a7807f5a7",
+    "zh:ecfcc7844e9e01123920a4b0e667a4688654e3f22f00890ec80ddd78e7312eda",
+  ]
+}

--- a/terragrunt/accounts/metrics-initiative-prod/datadog-aws/terragrunt.hcl
+++ b/terragrunt/accounts/metrics-initiative-prod/datadog-aws/terragrunt.hcl
@@ -1,0 +1,12 @@
+terraform {
+  source = "../../../modules//datadog-aws"
+}
+
+include {
+  path           = find_in_parent_folders()
+  merge_strategy = "deep"
+}
+
+inputs = {
+  env = "prod"
+}

--- a/terragrunt/accounts/metrics-initiative-prod/grafana/.terraform.lock.hcl
+++ b/terragrunt/accounts/metrics-initiative-prod/grafana/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.94.1"
+  constraints = "~> 5.64"
+  hashes = [
+    "h1:dYdnGlaCJONFyGk/t3Y4iJzQ8EiJr2DaDdZ/2JV5PZU=",
+    "zh:14fb41e50219660d5f02b977e6f786d8ce78766cce8c2f6b8131411b087ae945",
+    "zh:3bc5d12acd5e1a5f1cf78a7f05d0d63f988b57485e7d20c47e80a0b723a99d26",
+    "zh:4835e49377f80a37c6191a092f636e227a9f086e3cc3f0c9e1b554da8793cfe8",
+    "zh:605971275adae25096dca30a94e29931039133c667c1d9b38778a09594312964",
+    "zh:8ae46b4a9a67815facf59da0c56d74ef71bcc77ae79e8bfbac504fa43f267f8e",
+    "zh:913f3f371c3e6d1f040d6284406204b049977c13cb75aae71edb0ef8361da7dd",
+    "zh:91f85ae8c73932547ad7139ce0b047a6a7c7be2fd944e51db13231cc80ce6d8e",
+    "zh:96352ae4323ce137903b9fe879941f894a3ce9ef30df1018a0f29f285a448793",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9b51922c9201b1dc3d05b39f9972715db5f67297deee088793d02dea1832564b",
+    "zh:a689e82112aa71e15647b06502d5b585980cd9002c3cc8458f092e8c8a667696",
+    "zh:c3723fa3e6aff3c1cc0088bdcb1edee168fe60020f2f77161d135bf473f45ab2",
+    "zh:d6a2052b864dd394b01ad1bae32d0a7d257940ee47908d02df7fa7873981d619",
+    "zh:dda4c9c0406cc54ad8ee4f19173a32de7c6e73abb5a948ea0f342d567df26a1d",
+    "zh:f42e0fe592b97cbdf70612f0fbe2bab851835e2d1aaf8cbb87c3ab0f2c96bb27",
+  ]
+}

--- a/terragrunt/accounts/metrics-initiative-prod/grafana/terragrunt.hcl
+++ b/terragrunt/accounts/metrics-initiative-prod/grafana/terragrunt.hcl
@@ -1,0 +1,12 @@
+terraform {
+  source = "../../../..//terragrunt/modules/grafana"
+}
+
+include {
+  path           = find_in_parent_folders()
+  merge_strategy = "deep"
+}
+
+inputs = {
+  workspace_name = "metrics-initiative-prod"
+}

--- a/terragrunt/accounts/metrics-initiative-prod/wiz/.terraform.lock.hcl
+++ b/terragrunt/accounts/metrics-initiative-prod/wiz/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.91.0"
+  constraints = "~> 5.64"
+  hashes = [
+    "h1:bZ3AM8Qd1veQoUJqOb7OVp/ElmLg/hkz3bHL2DZZ5Tk=",
+    "zh:03ee14261b25aee94c735ed6ef7cce47900ab7bdf462335432ca034d0ba74ca2",
+    "zh:32a3759049c9c2cd041d1257cf16cb90a5ce586e1d0a6fe5f8ebd0ec1ba8e071",
+    "zh:334db69bc6d8643ec4ea432f0e54e851c2394bbe889cca29ca5029db0e4699e8",
+    "zh:39957a4a900f100ea8d85845a42164a44c9efea8559a9e74ab4f6a1193e20c3e",
+    "zh:8831396c764815eb367601a522c51c2e9e8fc38bcaa5f5e83f21de771778e9ba",
+    "zh:8e71ab68c27f909892a063f845d92faa487297ad9bbc67c77a67194e509781e6",
+    "zh:944df1084a7ea37a4feea0ee6654fd15891ef4829c5453bc149ffbcc0ab9bad7",
+    "zh:964391527624f2e66a4eb387ad0a30a1b67a896e9395b6d01353f2572723ea03",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:bb956c660185161e8ce1ed1dbf187c9f549d1779673fe798211dd5b02b98c737",
+    "zh:c237199ca8cd88f4aab4c673f848c77670b90d98a484fef6bcd31a71ff63d9b9",
+    "zh:c7522f6072f8ba29f4a6d0f994eda8a381ed2f4a41dbe44c4d989c44852cfe63",
+    "zh:d412a852ced01433c44f222952b60974f7c297a8a21bef62c9a627b050084134",
+    "zh:e420266b772041fa89e5868594ed21c8c3090d76b3ec0262054f768a7807f5a7",
+    "zh:ecfcc7844e9e01123920a4b0e667a4688654e3f22f00890ec80ddd78e7312eda",
+  ]
+}

--- a/terragrunt/accounts/metrics-initiative-prod/wiz/terragrunt.hcl
+++ b/terragrunt/accounts/metrics-initiative-prod/wiz/terragrunt.hcl
@@ -1,0 +1,8 @@
+terraform {
+  source = "../../../..//terragrunt/modules/wiz"
+}
+
+include {
+  path           = find_in_parent_folders()
+  merge_strategy = "deep"
+}

--- a/terragrunt/accounts/root/aws-organization/terragrunt.hcl
+++ b/terragrunt/accounts/root/aws-organization/terragrunt.hcl
@@ -93,5 +93,11 @@ inputs = {
       email       = "cuviper@gmail.com"
       groups      = ["release"]
     }
+    "yaahc" = {
+      given_name  = "Jane"
+      family_name = "Losare-Lusby"
+      email       = "jlusby42@gmail.com"
+      groups      = ["metrics-initiative"]
+    }
   }
 }

--- a/terragrunt/modules/aws-organization/accounts.tf
+++ b/terragrunt/modules/aws-organization/accounts.tf
@@ -51,3 +51,8 @@ resource "aws_organizations_account" "ci_prod" {
   name  = "ci-prod"
   email = "admin+ci-prod@rust-lang.org"
 }
+
+resource "aws_organizations_account" "metrics_initiative_prod" {
+  name  = "metrics-initiative-prod"
+  email = "admin+metrics-initiative-prod@rust-lang.org"
+}

--- a/terragrunt/modules/aws-organization/groups.tf
+++ b/terragrunt/modules/aws-organization/groups.tf
@@ -35,6 +35,13 @@ resource "aws_identitystore_group" "crates_io" {
   description  = "The crates.io team"
 }
 
+resource "aws_identitystore_group" "metrics_initiative" {
+  identity_store_id = local.identity_store_id
+
+  display_name = "metrics-initiative"
+  description  = "The metrics-initiative team"
+}
+
 resource "aws_identitystore_group" "triagebot" {
   identity_store_id = local.identity_store_id
 
@@ -345,6 +352,18 @@ locals {
         { group : aws_identitystore_group.infra-admins,
         permissions : [aws_ssoadmin_permission_set.read_only_access, aws_ssoadmin_permission_set.administrator_access] },
         { group : aws_identitystore_group.infra,
+        permissions : [aws_ssoadmin_permission_set.read_only_access] },
+      ]
+    },
+    # metrics initiative prod
+    {
+      account : aws_organizations_account.metrics_initiative_prod,
+      groups : [
+        { group : aws_identitystore_group.infra-admins,
+        permissions : [aws_ssoadmin_permission_set.read_only_access, aws_ssoadmin_permission_set.administrator_access] },
+        { group : aws_identitystore_group.infra,
+        permissions : [aws_ssoadmin_permission_set.read_only_access] },
+        { group : aws_identitystore_group.metrics_initiative,
         permissions : [aws_ssoadmin_permission_set.read_only_access] },
       ]
     },

--- a/terragrunt/modules/aws-organization/users.tf
+++ b/terragrunt/modules/aws-organization/users.tf
@@ -1,11 +1,12 @@
 locals {
   groups = {
     billing : aws_identitystore_group.billing
+    crates-io : aws_identitystore_group.crates_io
     infra : aws_identitystore_group.infra
     infra-admins : aws_identitystore_group.infra-admins
-    crates-io : aws_identitystore_group.crates_io
-    triagebot : aws_identitystore_group.triagebot
+    metrics-initiative : aws_identitystore_group.metrics_initiative
     release : aws_identitystore_group.release
+    triagebot : aws_identitystore_group.triagebot
   }
 
   # Expand var.users into collection of group memberships associations

--- a/terragrunt/modules/grafana/_terraform.tf
+++ b/terragrunt/modules/grafana/_terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.64"
+    }
+  }
+}

--- a/terragrunt/modules/grafana/main.tf
+++ b/terragrunt/modules/grafana/main.tf
@@ -1,0 +1,35 @@
+resource "aws_grafana_workspace" "grafana" {
+  name = var.workspace_name
+
+  account_access_type = "CURRENT_ACCOUNT"
+  authentication_providers = ["AWS_SSO"]
+
+  // IAM roles and IAM policy attachments are generated automatically
+  permission_type = "SERVICE_MANAGED"
+
+  role_arn = aws_iam_role.assume.arn
+}
+
+resource "aws_iam_role" "assume" {
+  name = "grafana-assume"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "grafana.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_grafana_role_association" "admins" {
+  workspace_id = aws_grafana_workspace.grafana.id
+  role = "ADMIN"
+
+  user_ids = ["44a894b8-d021-705c-5624-3e4485917fa0"]
+}

--- a/terragrunt/modules/grafana/variables.tf
+++ b/terragrunt/modules/grafana/variables.tf
@@ -1,0 +1,4 @@
+variable "workspace_name" {
+    description = "The name of the Grafana workspace"
+    type        = string
+}


### PR DESCRIPTION
The metrics-initiative is an experiment to use data gathered from docs.rs to research compiler flags and their usage. They use a hosted InfluxDB instance as the backend, and a managed Grafana instance on AWS as the frontend.

For this initiative, a new AWS account has been created, a Grafana instance has been provisioned, and Jane has been granted access. Following our organizational best practices, Wiz and Datadog have been deployed in the AWS account.