### PR TITLE
Add domain redirect for rustlings.cool

### DIFF
--- a/terraform/domain-redirects/.terraform.lock.hcl
+++ b/terraform/domain-redirects/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.65.0"
   constraints = ">= 5.64.0, ~> 5.64"
   hashes = [
+    "h1:LTqvpg2APqTRPmQIkOAFwn7Q8rXTXazDXIBaYSfLIm4=",
     "h1:OG8xMZjGZL/OtEV9OwX0CTPcUzvSfcfiB0X9lcs2joY=",
     "zh:036f8557c8c9b58656e1ec08ed5702e44bd338fda17dc4b2add40b234102e29a",
     "zh:0ba0708ece98735540070899a916b7a90c5c887be31ffd693ee1359e40245978",

--- a/terraform/domain-redirects/redirects.tf
+++ b/terraform/domain-redirects/redirects.tf
@@ -76,3 +76,15 @@ module "docs_rs_metadata" {
   ]
   permanent = true
 }
+
+module "rustlings" {
+  source = "./impl"
+  providers = {
+    aws       = aws
+    aws.east1 = aws.east1
+  }
+
+  to_host   = "rustlings.rust-lang.org"
+  from      = ["rustlings.cool"]
+  permanent = true
+}


### PR DESCRIPTION
This PR adds a domain redirect from rustlings.cool to rustlings.rust-lang.org.

While working on this I noticed we didn't update this module to account for the recent terraform and AWS deprecations. I thus split up the S3 website configuration in the standalone resource, and migrated from an ACL to a bucket policy.

This is already deployed. The terraform changes were first tested with `terraform apply -target=module.rustlings`, and only after confirming they didn't break anything I applied them to the existing domain redirects.