### PR TITLE
dev-desktop: install libxcb1-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev

### DIFF
--- a/ansible/roles/dev-desktop/tasks/dependencies.yml
+++ b/ansible/roles/dev-desktop/tasks/dependencies.yml
@@ -73,6 +73,11 @@
       - zlib1g
       - zlib1g-dev
       - unzip
+      # Necessary for jless
+      - libxcb1-dev
+      - libxcb-render0-dev
+      - libxcb-shape0-dev
+      - libxcb-xfixes0-dev
     state: present
 
 # we don't need it because we don't need to send emails


### PR DESCRIPTION
[Jless requires them](https://github.com/PaulJuliusMartinez/jless?tab=readme-ov-file#dependencies):

> On Linux systems, X11 libraries are needed to build clipboard access if building from source. On Ubuntu you can install these using apt install.

[These libs are supported on both amd64 and arm64.](https://packages.ubuntu.com/search?keywords=libxcb&searchon=names)
