### PR TITLE
Add Terraform configuration for gha-self-hosted's images storage

### DIFF
--- a/terragrunt/accounts/legacy/gha-self-hosted-images/.terraform.lock.hcl
+++ b/terragrunt/accounts/legacy/gha-self-hosted-images/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.98.0"
+  constraints = "~> 5.64"
+  hashes = [
+    "h1:KgOCdSG6euSc2lquuFlISJU/CzQTRhAO7WoaASxLZRc=",
+    "zh:23377bd90204b6203b904f48f53edcae3294eb072d8fc18a4531c0cde531a3a1",
+    "zh:2e55a6ea14cc43b08cf82d43063e96c5c2f58ee953c2628523d0ee918fe3b609",
+    "zh:4885a817c16fdaaeddc5031edc9594c1f300db0e5b23be7cd76a473e7dcc7b4f",
+    "zh:6ca7177ad4e5c9d93dee4be1ac0792b37107df04657fddfe0c976f36abdd18b5",
+    "zh:78bf8eb0a67bae5dede09666676c7a38c9fb8d1b80a90ba06cf36ae268257d6f",
+    "zh:874b5a99457a3f88e2915df8773120846b63d820868a8f43082193f3dc84adcb",
+    "zh:95e1e4cf587cde4537ac9dfee9e94270652c812ab31fce3a431778c053abf354",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a75145b58b241d64570803e6565c72467cd664633df32678755b51871f553e50",
+    "zh:aa31b13d0b0e8432940d6892a48b6268721fa54a02ed62ee42745186ee32f58d",
+    "zh:ae4565770f76672ce8e96528cbb66afdade1f91383123c079c7fdeafcb3d2877",
+    "zh:b99f042c45bf6aa69dd73f3f6d9cbe0b495b30442c526e0b3810089c059ba724",
+    "zh:bbb38e86d926ef101cefafe8fe090c57f2b1356eac9fc5ec81af310c50375897",
+    "zh:d03c89988ba4a0bd3cfc8659f951183ae7027aa8018a7ca1e53a300944af59cb",
+    "zh:d179ef28843fe663fc63169291a211898199009f0d3f63f0a6f65349e77727ec",
+  ]
+}

--- a/terragrunt/accounts/legacy/gha-self-hosted-images/terragrunt.hcl
+++ b/terragrunt/accounts/legacy/gha-self-hosted-images/terragrunt.hcl
@@ -1,0 +1,8 @@
+terraform {
+  source = "../../../..//terragrunt/modules/gha-self-hosted-images"
+}
+
+include {
+  path           = find_in_parent_folders()
+  merge_strategy = "deep"
+}

--- a/terragrunt/modules/gha-self-hosted-images/_terraform.tf
+++ b/terragrunt/modules/gha-self-hosted-images/_terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.64"
+    }
+  }
+}

--- a/terragrunt/modules/gha-self-hosted-images/cdn.tf
+++ b/terragrunt/modules/gha-self-hosted-images/cdn.tf
@@ -14,7 +14,7 @@ resource "aws_cloudfront_distribution" "cdn" {
   viewer_certificate {
     acm_certificate_arn      = module.certificate.arn
     ssl_support_method       = "sni-only"
-    minimum_protocol_version = "TLSv1.1_2016"
+    minimum_protocol_version = "TLSv1.2_2021"
   }
 
   default_cache_behavior {

--- a/terragrunt/modules/gha-self-hosted-images/cdn.tf
+++ b/terragrunt/modules/gha-self-hosted-images/cdn.tf
@@ -1,0 +1,106 @@
+locals {
+  domain_name = "gha-self-hosted-images.infra.rust-lang.org"
+}
+
+resource "aws_cloudfront_distribution" "cdn" {
+  comment = local.domain_name
+  aliases = [local.domain_name]
+
+  enabled             = true
+  wait_for_deployment = false
+  is_ipv6_enabled     = true
+  price_class         = "PriceClass_All"
+
+  viewer_certificate {
+    acm_certificate_arn      = module.certificate.arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.1_2016"
+  }
+
+  default_cache_behavior {
+    target_origin_id       = "s3"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    viewer_protocol_policy = "redirect-to-https"
+
+    // We are serving pre-compressed VM disk images. Enabling CloudFront compression will just slow
+    // things down needlessly.
+    compress = false
+
+    # Cache all objects for a year
+    min_ttl     = 31536000
+    max_ttl     = 31536000
+    default_ttl = 31536000
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  ordered_cache_behavior {
+    path_pattern = "latest"
+
+    target_origin_id       = "s3"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    viewer_protocol_policy = "redirect-to-https"
+
+    # Cache the version pointer just for a minute
+    min_ttl     = 60
+    max_ttl     = 60
+    default_ttl = 60
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  origin {
+    origin_id                = "s3"
+    domain_name              = aws_s3_bucket.storage.bucket_regional_domain_name
+    origin_access_control_id = aws_cloudfront_origin_access_control.cdn.id
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+}
+
+resource "aws_cloudfront_origin_access_control" "cdn" {
+  name = "gha-self-hosted-images"
+
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+module "certificate" {
+  source = "../acm-certificate"
+  providers = {
+    aws = aws.us-east-1
+  }
+
+  domains = [local.domain_name]
+  legacy  = true
+}
+
+data "aws_route53_zone" "zone" {
+  // Get the second-level domain name.
+  name = join(".", reverse(slice(reverse(split(".", local.domain_name)), 0, 2)))
+}
+
+resource "aws_route53_record" "record" {
+  zone_id = data.aws_route53_zone.zone.id
+  name    = local.domain_name
+  type    = "CNAME"
+  ttl     = 300
+  records = [aws_cloudfront_distribution.cdn.domain_name]
+}

--- a/terragrunt/modules/gha-self-hosted-images/ci.tf
+++ b/terragrunt/modules/gha-self-hosted-images/ci.tf
@@ -1,0 +1,55 @@
+resource "aws_iam_role" "ci" {
+  name = "gha-self-hosted-images-upload"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Effect = "Allow"
+        Principal = {
+          Federated = data.aws_iam_openid_connect_provider.gh_oidc.arn
+        }
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+            "token.actions.githubusercontent.com:sub" = "repo:rust-lang/gha-self-hosted:environment:upload"
+          }
+        }
+      }
+    ]
+  })
+}
+
+// To ensure a build cannot affect another build, and that it's possible to rollback to previous
+// builds, we allow unconditional access to override the `latest` file, and enforce that it's not
+// possible to override files in the `builds/` directory.
+resource "aws_iam_role_policy" "ci" {
+  name = "allow-upload"
+  role = aws_iam_role.ci.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "s3:PutObject"
+        Resource = "${aws_s3_bucket.storage.arn}/latest"
+      },
+      {
+        Effect   = "Allow"
+        Action   = "s3:PutObject"
+        Resource = "${aws_s3_bucket.storage.arn}/images/*"
+        Condition = {
+          StringEquals = {
+            // Enforce that the `if-none-match: *` header is provided when uploading a new file,
+            // ensuring CI can never override an existing file.
+            "s3:if-none-match" = "*"
+          }
+        }
+      },
+    ]
+  })
+}
+
+data "aws_iam_openid_connect_provider" "gh_oidc" {
+  url = "https://token.actions.githubusercontent.com"
+}

--- a/terragrunt/modules/gha-self-hosted-images/storage.tf
+++ b/terragrunt/modules/gha-self-hosted-images/storage.tf
@@ -1,0 +1,41 @@
+resource "aws_s3_bucket" "storage" {
+  bucket = "rust-gha-self-hosted-images"
+}
+
+resource "aws_s3_bucket_policy" "storage" {
+  bucket = aws_s3_bucket.storage.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Principal = {
+          Service = "cloudfront.amazonaws.com"
+        }
+        Effect   = "Allow"
+        Action   = "s3:GetObject"
+        Resource = "${aws_s3_bucket.storage.arn}/*"
+        Condition = {
+          StringEquals = {
+            "AWS:SourceArn" = aws_cloudfront_distribution.cdn.arn
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_s3_bucket_versioning" "storage" {
+  bucket = aws_s3_bucket.storage.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "storage" {
+  bucket = aws_s3_bucket.storage.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}


### PR DESCRIPTION
As part of https://github.com/rust-lang/gha-self-hosted/issues/11 we need to host the VM images for gha-self-hosted built by CI *somewhere*. This PR sets up that somewhere in the legacy account, with one storage bucket, an IAM role for CI to upload stuff to the bucket, and a CloudFront distribution serving the content (https://gha-self-hosted-images.infra.rust-lang.org/).

I placed this in the legacy account because there is not really a suitable account, and this will be the only bit of information related to gha-self-hosted to be stored in AWS. I don't want it to live in the `ci-*` accounts, as those are meant to run untrusted CI builds.

This is already deployed.