### PR TITLE
dev-desktops: Install `tidy` for rustdoc

### DIFF
--- a/ansible/roles/dev-desktop/tasks/dependencies.yml
+++ b/ansible/roles/dev-desktop/tasks/dependencies.yml
@@ -17,6 +17,7 @@
       - cmake
       - gcc-mingw-w64-x86-64 # Allows running `x check --target x86_64-pc-windows-gnu`
       - jq
+      - tidy # Format and diff html for rustdoc
       - cvise
       - libssl-dev
       - llvm


### PR DESCRIPTION
`tidy` (https://www.html-tidy.org/) is used to print nice HTML diffs when rustdoc tests fail:

https://github.com/rust-lang/rust/blob/14863ea0777c68348b3e6e7a8472423d273a52af/src/tools/compiletest/src/main.rs#L22

It'd be nice to have it installed.