### PR TITLE
rustc-ci: clean terraform cdn code

### DIFF
--- a/terraform/rustc-ci/impl/artifacts.tf
+++ b/terraform/rustc-ci/impl/artifacts.tf
@@ -55,20 +55,6 @@ resource "aws_s3_bucket_public_access_block" "artifacts" {
   restrict_public_buckets = true
 }
 
-
-module "artifacts_cdn" {
-  for_each = toset(var.artifacts_domain == null ? [] : ["true"])
-
-  source = "../../shared/modules/static-website"
-  providers = {
-    aws = aws.east1
-  }
-
-  domain_name        = var.artifacts_domain
-  origin_domain_name = aws_s3_bucket.artifacts.bucket_regional_domain_name
-  response_policy_id = var.response_policy_id
-}
-
 data "aws_s3_bucket" "inventories" {
   bucket = "rust-inventories"
 }

--- a/terraform/rustc-ci/impl/caches.tf
+++ b/terraform/rustc-ci/impl/caches.tf
@@ -49,16 +49,3 @@ resource "aws_s3_bucket_public_access_block" "caches" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
-
-module "caches_cdn" {
-  for_each = toset(var.caches_domain == null ? [] : ["true"])
-
-  source = "../../shared/modules/static-website"
-  providers = {
-    aws = aws.east1
-  }
-
-  domain_name        = var.caches_domain
-  origin_domain_name = aws_s3_bucket.caches.bucket_regional_domain_name
-  response_policy_id = var.response_policy_id
-}


### PR DESCRIPTION
I removed some resources from the state.

This is the plan:

```
Terraform will perform the following actions:

  # module.public.module.artifacts_cdn["true"].module.certificate.aws_acm_certificate_validation.cert will be destroyed
  # (because aws_acm_certificate_validation.cert is not in configuration)
  - resource "aws_acm_certificate_validation" "cert" {
      - certificate_arn         = "arn:aws:acm:us-east-1:890664054962:certificate/58cce1dd-adfa-4fd2-8cdd-539b89f5f500" -> null
      - id                      = "2022-03-11 02:49:52.482 +0000 UTC" -> null
      - validation_record_fqdns = [
          - "_d8b0665760c58453311c4c28e03e32d2.ci-artifacts.rust-lang.org",
        ] -> null
    }

  # module.public.module.caches_cdn["true"].module.certificate.aws_acm_certificate_validation.cert will be destroyed
  # (because aws_acm_certificate_validation.cert is not in configuration)
  - resource "aws_acm_certificate_validation" "cert" {
      - certificate_arn         = "arn:aws:acm:us-east-1:890664054962:certificate/e99c2320-f3e6-4bfb-b115-94bfc39a56d5" -> null
      - id                      = "2022-03-11 03:37:40.453 +0000 UTC" -> null
      - validation_record_fqdns = [
          - "_0062654447e2b1cc2c228f28a2ffd38d.ci-caches.rust-lang.org",
        ] -> null
    }

Plan: 0 to add, 0 to change, 2 to destroy.
╷
│ Warning: Argument is deprecated
│
│   with module.public.aws_s3_bucket.artifacts,
│   on impl/artifacts.tf line 1, in resource "aws_s3_bucket" "artifacts":
│    1: resource "aws_s3_bucket" "artifacts" {
│
│ Use the aws_s3_bucket_lifecycle_configuration resource instead
│
│ (and 9 more similar warnings elsewhere)
```