### PR TITLE
rustc-ci: remove public module

### DIFF
--- a/terraform/rustc-ci/environments.tf
+++ b/terraform/rustc-ci/environments.tf
@@ -1,26 +1,3 @@
-module "public" {
-  source = "./impl"
-  providers = {
-    aws       = aws
-    aws.east1 = aws.east1
-  }
-
-  iam_prefix  = "ci--rust-lang--rust"
-  repo        = "rust-lang-ci/rust"
-  source_repo = "rust-lang/rust"
-
-  caches_bucket    = "rust-lang-ci-sccache2"
-  caches_domain    = "ci-caches.rust-lang.org"
-  artifacts_bucket = "rust-lang-ci2"
-  artifacts_domain = "ci-artifacts.rust-lang.org"
-
-  buckets_public_access = true
-
-  delete_caches_after_days    = 90
-  delete_artifacts_after_days = 168
-  response_policy_id          = data.terraform_remote_state.shared.outputs.mdbook_response_policy
-}
-
 module "security" {
   source = "./impl"
   providers = {


### PR DESCRIPTION
I removed all the resources from the terraform state so the plan is clean.