### PR TITLE
update monitorbot runners repo

### DIFF
--- a/terraform/monitorbot/app.tf
+++ b/terraform/monitorbot/app.tf
@@ -14,7 +14,7 @@ module "monitorbot" {
   platform_version = "1.4.0"
 
   environment = {
-    MONITORBOT_RUNNERS_REPOS               = "rust-lang-ci/rust"
+    MONITORBOT_RUNNERS_REPOS               = "rust-lang/rust"
     MONITORBOT_GH_RATE_LIMIT_STATS_REFRESH = 40
   }
 


### PR DESCRIPTION
I'm not applying this change because the plan isn't clean and monitorbot is disabled right now.
I'm just updating the repo so in case we'll need again monitorbot in the future, we won't use the old rust ci repo.