### PR TITLE
ensure unattended-upgrades is enabled

### DIFF
--- a/ansible/roles/common/README.md
+++ b/ansible/roles/common/README.md
@@ -58,3 +58,37 @@ want to preserve.
   # If the URL is missing logs will not be shipped to Papertrail.
   papertrail_url: logsN.papertrailapp.com:NNNNN
 ```
+
+## Unattended Upgrades
+
+Unattended-upgrades is a package that allows automatic installation of security updates on Debian-based systems.
+The `unattended-upgrades.yml` task configures unattended-upgrades to ensure that security updates are applied automatically.
+
+This service is enabled by default on Ubuntu, but the task ensures it wasn't
+disabled.
+
+### Monitoring
+
+Log files:
+
+- `/var/log/dpkg.log`
+- `/var/log/unattended-upgrades/`
+
+Check the status of unattended-upgrades with:
+
+```bash
+sudo systemctl status unattended-upgrades
+```
+
+### Tips
+
+To test the outcome of unattended-upgrades without making any changes, you can run the following command:
+
+```bash
+sudo unattended-upgrades --dry-run --debug
+```
+
+### Docs
+
+- [Ubuntu help](https://help.ubuntu.com/community/AutomaticSecurityUpdates)
+- [Debian wiki](https://wiki.debian.org/UnattendedUpgrades)

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -9,3 +9,4 @@
 - include_tasks: papertrail.yml
 - include_tasks: cleanup.yml
 - include_tasks: services.yml
+- include_tasks: unattended-upgrades.yml

--- a/ansible/roles/common/tasks/unattended-upgrades.yml
+++ b/ansible/roles/common/tasks/unattended-upgrades.yml
@@ -1,0 +1,13 @@
+---
+
+# The default configuration of unattended-upgrades is to install security updates only.
+- name: install the unattended-upgrades package
+  apt:
+    name: unattended-upgrades
+    state: present
+
+- name: ensure unattended-upgrades is running and enabled
+  service:
+    name: unattended-upgrades
+    state: started
+    enabled: yes


### PR DESCRIPTION
Close https://github.com/rust-lang/infra-team/issues/134

I applied it in the staging dev desktop and it worked:

```
TASK [common : include_tasks] ***************************************************************************************************************************************************************************
included: /Users/marco/proj/simpleinfra/ansible/roles/common/tasks/unattended-upgrades.yml for dev-desktop-staging.infra.rust-lang.org

TASK [common : install the unattended-upgrades package] *************************************************************************************************************************************************
ok: [dev-desktop-staging.infra.rust-lang.org]

TASK [common : ensure unattended-upgrades is running and enabled] ***************************************************************************************************************************************
ok: [dev-desktop-staging.infra.rust-lang.org]
```