### PR TITLE
Disable swap on rustc-perf

### DIFF
--- a/ansible/playbooks/rustc-perf.yml
+++ b/ansible/playbooks/rustc-perf.yml
@@ -124,6 +124,17 @@
         daemon_reload: yes
       become: yes
 
+    - name: Disable swap for current session
+      command: swapoff -a
+      become: true
+
+    - name: Disable swap permanently, persist reboots
+      replace:
+        path: /etc/fstab
+        regexp: '^(\s*)([^#\n]+\s+)(\w+\s+)swap(\s+.*)$'
+        replace: '#\1\2\3swap\4'
+        backup: yes
+
     # Periodically clean old entries in /tmp
     - name: Configure systemd-tmpfiles to clean old /tmp dirs
       copy:


### PR DESCRIPTION
Even with the configured swappinnes, it was still swapping something. The machine has 64 GiB of RAM, so we shouldn't be running out of memory; if that happens, something should crash rather than start swapping.