### PR TITLE
Allow promote-release to upload manifests.txt

### DIFF
--- a/terraform/releases/impl/promote-release.tf
+++ b/terraform/releases/impl/promote-release.tf
@@ -209,6 +209,7 @@ resource "aws_iam_role_policy" "promote_release" {
           "${aws_s3_bucket.static.arn}/doc/*",
           "${aws_s3_bucket.static.arn}/dist",
           "${aws_s3_bucket.static.arn}/dist/*",
+          "${aws_s3_bucket.static.arn}/manifests.txt",
 
           // Artifacts bucket
           "${data.aws_s3_bucket.artifacts.arn}/rustc-builds",


### PR DESCRIPTION
Permissions side of https://github.com/rust-lang/promote-release/pull/89. This is already deployed.