### PR TITLE
Set default boot target to `multi-user`

### DIFF
--- a/ansible/playbooks/rustc-perf.yml
+++ b/ansible/playbooks/rustc-perf.yml
@@ -158,6 +158,16 @@
         replace: '#\1\2\3swap\4'
         backup: yes
 
+    - name: Get current systemd default
+      ansible.builtin.command: "systemctl get-default"
+      changed_when: false
+      register: systemdefault
+
+    - name: Set default boot target to multi-user target
+      ansible.builtin.command: "systemctl set-default multi-user.target"
+      when: "'multi-user' not in systemdefault.stdout"
+      changed_when: true
+
     # Periodically clean old entries in /tmp
     - name: Configure systemd-tmpfiles to clean old /tmp dirs
       copy:


### PR DESCRIPTION
No need to boot to the graphical runlevel on the collector.