### PR TITLE
ignore crater in TooMuchRamUsage alert

### DIFF
--- a/ansible/playbooks/monitoring.yml
+++ b/ansible/playbooks/monitoring.yml
@@ -180,8 +180,10 @@
                 summary: "Filesystem {{ '{{ $labels.mountpoint }}' }} on {{ '{{ $labels.instance }}' }} is full"
                 description: "There is less than 10% disk space left on the mount point {{ '{{ $labels.mountpoint }}' }} (device {{ '{{ $labels.device }}' }}) of the instance {{ '{{ $labels.instance }}' }}."
 
+            # This alert is disabled because Crater is expected to
+            # use a lot of RAM.
             - alert: TooMuchRamUsage
-              expr: node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes < 0.2
+              expr: node_memory_MemAvailable_bytes{instance!~"crater\\.infra\\.rust-lang\\.org.*"} / node_memory_MemTotal_bytes{instance!~"crater\\.infra\\.rust-lang\\.org.*"} < 0.2
               for: 1m
               annotations:
                 summary: "High RAM usage on {{ '{{ $labels.instance }}' }}"


### PR DESCRIPTION
## How to test this

1. Go to grafana.rust-lang.org
2. Click on the explore tab
3. Click on code on the top right
4. Copy paste the expression
5. Verifies that "no data" is shown

![image](https://github.com/user-attachments/assets/e14542bf-d296-4405-be01-1fd951fac251)

## Will the alert keep working for the other instances?

Yes, you can check it by changing a letter in the regex. E.g. "cratex":
You can see the crater alert firing. This proves that this alert only filters the crater instance.
![image](https://github.com/user-attachments/assets/47abdee2-9288-4c93-8b57-fa075b43ae62)
