### PR TITLE
Prevent infinite redirect for doc-router `/doc[^/]`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,3 +56,15 @@ jobs:
               popd
             fi
           done
+
+  javascript-tests:
+    name: JavaScript Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 24
+      - name: Run tests
+        run: |
+          node --test terragrunt/modules/release-distribution/lambdas/doc-router/test.mjs

--- a/terragrunt/modules/release-distribution/lambdas/doc-router/index.js
+++ b/terragrunt/modules/release-distribution/lambdas/doc-router/index.js
@@ -110,7 +110,7 @@ exports.handler = (event, context, callback) => {
     }
 
     // Docs used to be under /doc, so redirect those for now
-    if (request.uri.startsWith('/doc')) {
+    if (request.uri.startsWith('/doc/')) {
         return redirect(request.uri.slice(4), callback);
     }
 

--- a/terragrunt/modules/release-distribution/lambdas/doc-router/test.mjs
+++ b/terragrunt/modules/release-distribution/lambdas/doc-router/test.mjs
@@ -1,0 +1,70 @@
+import { test } from "node:test";
+import assert from "node:assert";
+import lambda from "./index.js";
+
+function invokeHandler(uri) {
+  return new Promise((res) => {
+    const cb = (_, response) => {
+      res(response);
+    };
+
+    lambda.handler(
+      {
+        Records: [
+          {
+            cf: {
+              request: {
+                uri,
+              },
+            },
+          },
+        ],
+      },
+      undefined,
+      cb
+    );
+  });
+}
+
+test("example expected redirects", async (t) => {
+  const redirects = [
+    // root
+    { from: "/", to: "https://www.rust-lang.org/learn" },
+    { from: "/index.html", to: "https://www.rust-lang.org/learn" },
+    // crate redirects
+    { from: "/regex", to: "https://docs.rs/regex" },
+    { from: "/log", to: "https://docs.rs/log" },
+    { from: "/rand/0.9.1/rand/", to: "https://docs.rs/rand/0.9.1/rand/" },
+    // trpl
+    { from: "/trpl", to: "/stable/book" },
+    { from: "/stable/trpl/hello", to: "/stable/book/hello" },
+    { from: "/nightly/trpl", to: "/nightly/book" },
+    // adv-book
+    { from: "/adv-book", to: "/stable/nomicon" },
+    { from: "/stable/adv-book/hello", to: "/stable/nomicon/hello" },
+    { from: "/nightly/adv-book", to: "/nightly/nomicon" },
+    // master
+    { from: "/master/hello", to: "/nightly/hello" },
+    // /doc
+    { from: "/doc/std", to: "/std" },
+    { from: "/doc/hello", to: "/hello" },
+  ];
+
+  for (const redir of redirects) {
+    await t.test(`redirect ${redir.from}`, async (t) => {
+      const response = await invokeHandler(redir.from);
+
+      assert(["301", "302"].includes(response.status));
+
+      const location = response.headers.location[0];
+      assert.strictEqual(location.key, "Location");
+
+      assert.strictEqual(location.value, redir.to);
+    });
+  }
+});
+
+test("ensure the default rewrite to /stable", async (t) => {
+  const request = await invokeHandler("/std");
+  assert.strictEqual(request.uri, "/stable/std");
+});


### PR DESCRIPTION
Previously, it would just put the slice in the Location with no regards
for what was in there. If there was no slash after the `/doc`, it would
issue a relative redirect, which was still under `/doc`, causing an
infinite redirect.

- /docs/std -> s/std
- /docs/s/std -> s/s/std
- /docs/s/s/s/std -> ...

We prevent this behavior here by only applying the `/doc` redirect if
there is a slash directly after it, causing the default /stable rewrite
fallback to be applied to everything else, which will in practice lead
to nice 404 page.

This should not break anything as all such queries currently run into
these loops, including plain `/doc`.

Making a change to this core part of infrastructure that I can't reasonably test locally scared me, so I just wrote a bunch of unit tests for the thing.