### PR TITLE
revoke bastion access to technetos

### DIFF
--- a/ansible/playbooks/bastion.yml
+++ b/ansible/playbooks/bastion.yml
@@ -16,7 +16,6 @@
         - nemo157  # docsrs.infra.rust-lang.org
         - guillaumegomez  # docsrs.infra.rust-lang.org
         - shep  # play.rust-lang.org
-        - technetos  # RDS access to the discord-mods-bot database
         - rylev # RDS access to rustc-perf
         - kobzol # RDS access to bors
 


### PR DESCRIPTION
See https://github.com/rust-lang/simpleinfra/issues/756

We'll delete the discord-mods-bot DB soon, so technetos doesn't need access to bastion anymore as far as I know.
This can be easily reverted in case the access is needed for other reasons.