### PR TITLE
Remove `dev-desktop-*-2` from monitoring

### DIFF
--- a/ansible/playbooks/monitoring.yml
+++ b/ansible/playbooks/monitoring.yml
@@ -64,9 +64,7 @@
               - play-2.infra.rust-lang.org:9100
               - dev-desktop-staging.infra.rust-lang.org:9100
               - dev-desktop-eu-1.infra.rust-lang.org:9100
-              - dev-desktop-eu-2.infra.rust-lang.org:9100
               - dev-desktop-us-1.infra.rust-lang.org:9100
-              - dev-desktop-us-2.infra.rust-lang.org:9100
 
         # Metrics scraped from apps hosted in our ECS clusters
         - job_name: ecs-sd  # Will be overridden by each job


### PR DESCRIPTION
We are decommissioning the dev-desktops running on Azure and have stopped the instances. We will not remove the machines yet to give people time to recover data if necessary, but have already removed them from monitoring to stop alerts from spamming the team.