### PR TITLE
Use local SSDs in crater

### DIFF
--- a/terraform/crater/startup-script.sh
+++ b/terraform/crater/startup-script.sh
@@ -42,6 +42,11 @@ docker pull ${docker_url}
 
 mkdir -p /var/lib/crater-agent-workspace
 
+# Mount the local SSD as the Crater workspace
+sudo mkfs.ext4 -F /dev/disk/by-id/google-local-nvme-ssd-0
+sudo mount /dev/disk/by-id/google-local-nvme-ssd-0 /var/lib/crater-agent-workspace
+sudo chmod a+rwx /var/lib/crater-agent-workspace
+
 curl http://metadata.google.internal/computeMetadata/v1/instance/attributes/update-script \
     -o /opt/update.sh \
     -H "Metadata-Flavor: Google"

--- a/terraform/crater/update.sh
+++ b/terraform/crater/update.sh
@@ -23,7 +23,7 @@ AGENT_TOKEN=$(aws --region us-west-1 \
     --name /prod/ansible/crater-gcp-2/crater-token \
     --with-decryption)
 
-eval $(aws ecr get-login --no-include-email --region us-west-1)
+aws ecr get-login-password --region us-west-1 | docker login --username AWS --password-stdin ${docker_url}
 
 old_id="$(docker images --format "{{.ID}}" "${docker_url}")"
 docker pull "${docker_url}"


### PR DESCRIPTION
These are cheaper per gigabyte than the persistent disks based on google's cost estimator, allowing us to increase our caches from somewhere around 80gb to 375gb.

This has already been deployed.