### PR TITLE
gha-self-hosted: allow uploading the executor binary

### DIFF
--- a/terragrunt/modules/gha-self-hosted-images/ci.tf
+++ b/terragrunt/modules/gha-self-hosted-images/ci.tf
@@ -35,9 +35,12 @@ resource "aws_iam_role_policy" "ci" {
         Resource = "${aws_s3_bucket.storage.arn}/latest"
       },
       {
-        Effect   = "Allow"
-        Action   = "s3:PutObject"
-        Resource = "${aws_s3_bucket.storage.arn}/images/*"
+        Effect = "Allow"
+        Action = "s3:PutObject"
+        Resource = [
+          "${aws_s3_bucket.storage.arn}/executor/*",
+          "${aws_s3_bucket.storage.arn}/images/*",
+        ]
         Condition = {
           StringEquals = {
             // Enforce that the `if-none-match: *` header is provided when uploading a new file,


### PR DESCRIPTION
As part of the executor rewrite in Rust I'll upload prebuilt copies of the binaries to the bucket. This PR has already been deployed.