### PR TITLE
Add foundation domains access for foundation folks

### DIFF
--- a/terragrunt/accounts/root/aws-organization/.terraform.lock.hcl
+++ b/terragrunt/accounts/root/aws-organization/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.64.0"
   constraints = "~> 5.64"
   hashes = [
+    "h1:Xasb457vfMG/1SGu6KSApCzAqUHMlsL028OQu3dZVv8=",
     "h1:YH4I78rsS9t+YoGMPNzrM53aWi0Rb9Nud16iusrSXMg=",
     "zh:1d361f8062c68c9d5ac14b0aa8390709542129b8a9b258e61bbbabc706078b44",
     "zh:39dcbf53e3896bdd77071384c8fad4a5862c222c73f3bcf356aca488101f22fd",

--- a/terragrunt/accounts/root/aws-organization/terragrunt.hcl
+++ b/terragrunt/accounts/root/aws-organization/terragrunt.hcl
@@ -43,7 +43,13 @@ inputs = {
       given_name = "Joel"
       family_name = "Marcey"
       email = "joelmarcey@rustfoundation.org"
-      groups = ["billing"]
+      groups = ["billing", "foundation"]
+    }
+    "walterpearce" = {
+      given_name = "Walter"
+      family_name = "Pearce"
+      email = "walterpearce@rustfoundation.org"
+      groups = ["foundation"]
     }
     "kobzol" = {
       given_name = "Jakub"

--- a/terragrunt/modules/aws-organization/users.tf
+++ b/terragrunt/modules/aws-organization/users.tf
@@ -7,6 +7,7 @@ locals {
     metrics-initiative : aws_identitystore_group.metrics_initiative
     release : aws_identitystore_group.release
     triagebot : aws_identitystore_group.triagebot
+    foundation : aws_identitystore_group.foundation
   }
 
   # Expand var.users into collection of group memberships associations


### PR DESCRIPTION
This PR migrates the Route53 access given to foundation staff in https://github.com/rust-lang/simpleinfra/blob/master/terraform/team-members-access/foundation.tf to IAM Identity Center, and adds Walter to that group.

This does *not* remove the old IAM User based system, we'll clean it up later.