### PR TITLE
add prometheus scraping for docs.rs nginx metrics

### DIFF
--- a/ansible/playbooks/monitoring.yml
+++ b/ansible/playbooks/monitoring.yml
@@ -86,6 +86,13 @@
             - targets:
               - docs.rs:443
 
+        - job_name: docsrs-nginx
+          metrics_path: /about/metrics/gwlfgmnhpddteabp/nginx
+          scheme: https
+          static_configs:
+            - targets:
+              - docs.rs:443
+
         - job_name: perfrlo
           metrics_path: /perf/metrics
           scheme: https


### PR DESCRIPTION
There were some issues about open-fd count that lead to a bunch of server errors. 

this is based on the integrated nginx `stub_status` and nginx-prometheus-exporter which is running via systemd. 

This will give us metrics around connection & FD-count, among others: 
https://docs.rs/about/metrics/gwlfgmnhpddteabp/nginx

