### PR TITLE
docs.rs cloudfront: forward cache validator headers to origin

### DIFF
--- a/terraform/docs-rs/cloudfront.tf
+++ b/terraform/docs-rs/cloudfront.tf
@@ -57,7 +57,12 @@ resource "aws_cloudfront_origin_request_policy" "docs_rs" {
   headers_config {
     header_behavior = "whitelist"
     headers {
-      items = ["User-Agent", "Referer"]
+      items = [
+        "User-Agent",
+        "Referer",
+        "If-None-Match",
+        "If-Modified-Since"
+      ]
     }
   }
 


### PR DESCRIPTION
related to https://github.com/rust-lang/docs.rs/issues/1560