### PR TITLE
add fastly CDN for docs-rs via `fastly.docs.rs` domain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,6 +131,15 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -199,7 +214,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -229,6 +244,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "curl"
@@ -261,6 +285,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+dependencies = [
+ "powerfmt",
+ "serde_core",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,7 +311,29 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elsa"
+version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9abf33c656a7256451ebb7d0082c5a471820c31269e49d807c538c252352186e"
+dependencies = [
+ "indexmap",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -294,6 +359,74 @@ checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "fastly"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b98d7e8e27ab8a82e008692581aadd10f57092cc6894a3413046e126d5a646"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "downcast-rs",
+ "elsa",
+ "fastly-macros",
+ "fastly-shared",
+ "fastly-sys",
+ "http 1.3.1",
+ "itertools",
+ "lazy_static",
+ "mime",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "serde_urlencoded",
+ "sha2",
+ "smallvec",
+ "thiserror",
+ "time",
+ "url",
+]
+
+[[package]]
+name = "fastly-compute-project"
+version = "0.1.0"
+dependencies = [
+ "fastly",
+]
+
+[[package]]
+name = "fastly-macros"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3533bdc15fc7b23395f595878c0fb85867b953e3c7423c4fa44b9755e2f256d0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "fastly-shared"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdf9fdc9fba2e372465884c57ea6615cd83711cf8610fb53a8e579a5ed4d0010"
+dependencies = [
+ "bitflags 1.3.2",
+ "http 1.3.1",
+]
+
+[[package]]
+name = "fastly-sys"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e019e42b60a53e24b75c74bb122a047ec1962787fe1479e0382282da92dd58c"
+dependencies = [
+ "bitflags 1.3.2",
+ "fastly-shared",
+ "wasip2",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -387,6 +520,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,7 +546,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
  "indexmap",
  "slab",
  "tokio",
@@ -435,13 +578,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
  "pin-project-lite",
 ]
 
@@ -468,7 +622,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.12",
  "http-body",
  "httparse",
  "httpdate",
@@ -632,7 +786,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -690,6 +844,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,6 +867,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -761,7 +930,7 @@ checksum = "f3cd9f9bbedc1b92683a9847b8db12f3203cf32af6a11db085fa007708dc9555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -813,6 +982,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,6 +1012,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl"
 version = "0.10.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -859,7 +1040,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -905,6 +1086,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,7 +1121,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.12",
  "http-body",
  "hyper",
  "hyper-tls",
@@ -1055,7 +1242,7 @@ checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1068,6 +1255,17 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1092,6 +1290,19 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer",
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -1149,6 +1360,17 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
@@ -1172,7 +1394,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1215,6 +1437,56 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "time"
+version = "0.3.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+
+[[package]]
+name = "time-macros"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -1299,6 +1571,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1340,6 +1618,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1353,6 +1637,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1376,7 +1669,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
  "wasm-bindgen-shared",
 ]
 
@@ -1411,7 +1704,7 @@ checksum = "98c9ae5a76e46f4deecd0f0255cc223cfa18dc9b261213b8aa0c7b36f61b3f1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1600,6 +1893,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1631,7 +1933,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
  "synstructure",
 ]
 
@@ -1652,7 +1954,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
  "synstructure",
 ]
 
@@ -1675,5 +1977,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,11 @@ resolver = "2"
 members = [
     "setup-deploy-keys",
     "ansible/roles/dev-desktop/files/team_login",
+    "terraform/docs-rs/fastly-compute-docs-rs",
 ]
+
+[profile.fastly-release]
+inherits = "release"
+debug = 1
+codegen-units = 1
+lto = "fat"

--- a/terraform/docs-rs/.terraform.lock.hcl
+++ b/terraform/docs-rs/.terraform.lock.hcl
@@ -1,6 +1,28 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/fastly/fastly" {
+  version     = "8.4.0"
+  constraints = "~> 8.4"
+  hashes = [
+    "h1:A8mlNgIlDdaSwbjinYsFx92GOT86iZzBAfyzedj/efk=",
+    "zh:00a09211ba5abcc14c42b5f03abc21cbdb219ad9ec365f130c73c28d56a6cbec",
+    "zh:0276e4aa722ec8fe9b35d55a0925f2411a1b6116de6c9c13b0e76c39a34649a6",
+    "zh:328eea84921ff3cc94d82f3ac47be614a55ccc896bb93666b7c26e9fba3477dd",
+    "zh:3fcbffecaa491e32b03b7fad322b29564ff0ecbc8a37a6fa252ee47b044e33b1",
+    "zh:4104859dd6e292ded4df913952ba6296b86b9868992175eb0580c95ce1b3d251",
+    "zh:4125bded1cf7d411679215df413f413ff67b508342a48b654f5feb422d35267c",
+    "zh:4245beaf1908e9d784b719c72004ddad720021241c06310ae0a64fd8645702ee",
+    "zh:4c1143de7bac3cbb69cc9e29939d1ecd9c18b085fc45037c1e1b717f888aa7a0",
+    "zh:71726937f1055d49c4b4f2ba651bf46aa5373560edefaca17a2d876ae9552bf9",
+    "zh:81f4e9aebc40310b870670b45f17be41b9d974bb664a5f8ea61695f6dfeaf8ee",
+    "zh:8cfb022cc865aed05759e12e040c2ba5a0150afe4fb5dbfb5196dbed0e4afe32",
+    "zh:9fbd63339f9b4ecf39a1e9a44cfe06850388767282eacad8d2f6efd5e6e6435d",
+    "zh:c11dc3cbc0685c1db8fc80cb4bd396775a7dba272b326d83df6434486425bacf",
+    "zh:e40ce6bdd00a1b1ef50d5ddf056f7a78c298daf54402f004ff7f9027ceca76d5",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.65.0"
   constraints = ">= 5.64.0, ~> 5.64"
@@ -21,6 +43,25 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:ec542372c3ffbfc3df6966f77357f8af7319d4bd956ff8e9fde0bbd124352e34",
     "zh:f3dc7b2b5b55173207c2fd35ed6bb8cc66b06af777e221060ca2f0c0afdecbb5",
     "zh:f9631ecc21d6e5cf82ef6ef8d14c39e1dfb2a52cc8f0abb684311885ffdb79a1",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/external" {
+  version = "2.3.5"
+  hashes = [
+    "h1:FnUk98MI5nOh3VJ16cHf8mchQLewLfN1qZG/MqNgPrI=",
+    "zh:6e89509d056091266532fa64de8c06950010498adf9070bf6ff85bc485a82562",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:86868aec05b58dc0aa1904646a2c26b9367d69b890c9ad70c33c0d3aa7b1485a",
+    "zh:a2ce38fda83a62fa5fb5a70e6ca8453b168575feb3459fa39803f6f40bd42154",
+    "zh:a6c72798f4a9a36d1d1433c0372006cc9b904e8cfd60a2ae03ac5b7d2abd2398",
+    "zh:a8a3141d2fc71c86bf7f3c13b0b3be8a1b0f0144a47572a15af4dfafc051e28a",
+    "zh:aa20a1242eb97445ad26ebcfb9babf2cd675bdb81cac5f989268ebefa4ef278c",
+    "zh:b58a22445fb8804e933dcf835ab06c29a0f33148dce61316814783ee7f4e4332",
+    "zh:cb5626a661ee761e0576defb2a2d75230a3244799d380864f3089c66e99d0dcc",
+    "zh:d1acb00d20445f682c4e705c965e5220530209c95609194c2dc39324f3d4fcce",
+    "zh:d91a254ba77b69a29d8eae8ed0e9367cbf0ea6ac1a85b58e190f8cb096a40871",
+    "zh:f6592327673c9f85cdb6f20336faef240abae7621b834f189c4a62276ea5db41",
   ]
 }
 

--- a/terraform/docs-rs/_terraform.tf
+++ b/terraform/docs-rs/_terraform.tf
@@ -12,6 +12,10 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.6.2"
     }
+    fastly = {
+      source  = "fastly/fastly"
+      version = "~> 8.4"
+    }
   }
 
   backend "s3" {

--- a/terraform/docs-rs/fastly-compute-docs-rs/.cargo/config.toml
+++ b/terraform/docs-rs/fastly-compute-docs-rs/.cargo/config.toml
@@ -1,0 +1,5 @@
+[build]
+target = "wasm32-wasip1"
+
+[term]
+color = "always"

--- a/terraform/docs-rs/fastly-compute-docs-rs/.fastlyignore
+++ b/terraform/docs-rs/fastly-compute-docs-rs/.fastlyignore
@@ -1,0 +1,4 @@
+/target
+**/*.rs.bk
+/bin
+/pkg

--- a/terraform/docs-rs/fastly-compute-docs-rs/.gitignore
+++ b/terraform/docs-rs/fastly-compute-docs-rs/.gitignore
@@ -1,0 +1,4 @@
+/target
+**/*.rs.bk
+/bin/*.wasm
+/pkg

--- a/terraform/docs-rs/fastly-compute-docs-rs/Cargo.toml
+++ b/terraform/docs-rs/fastly-compute-docs-rs/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "fastly-compute-project"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+fastly = "0.11.0"

--- a/terraform/docs-rs/fastly-compute-docs-rs/bin/terraform-external-build.sh
+++ b/terraform/docs-rs/fastly-compute-docs-rs/bin/terraform-external-build.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Build script used by Terraform to build the function when planning.
+#
+# This script is called by Terraform to build the function when a user runs
+# `terraform plan`. This ensures that the function is always up-to-date, and
+# prevents users from accidentally uploading a stale version of the WASM module.
+#
+# Terraform expects the script to output a valid JSON object.
+#
+# https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/data_source
+
+# Enable strict mode for Bash
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -euo pipefail
+IFS=$'\n\t'
+
+script_path=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+project_path=$(cd "${script_path}" && cd ".." && pwd)
+project_name="${project_path##*/}"
+
+cd "${project_path}" && fastly compute build &>/dev/null
+
+# Return a valid JSON object that Terraform can consume
+echo "{\"path\": \"./${project_name}/pkg/fastly-compute-docs-rs.tar.gz\"}"

--- a/terraform/docs-rs/fastly-compute-docs-rs/fastly.toml
+++ b/terraform/docs-rs/fastly-compute-docs-rs/fastly.toml
@@ -1,0 +1,21 @@
+# This file describes a Fastly Compute package. To learn more visit:
+# https://www.fastly.com/documentation/reference/compute/fastly-toml
+
+authors = [""]
+cloned_from = "https://github.com/fastly/compute-starter-kit-rust-default"
+description = "Compute@Edge function for docs.rs"
+language = "rust"
+manifest_version = 3
+name = "fastly-compute-docs-rs"
+service_id = ""
+
+[local_server]
+
+[scripts]
+  # workaround to build with custom profile and copy wasm to expected location
+  build = """
+  cargo build --profile fastly-release &&
+  TARGET_DIR=$(cargo metadata --format-version=1 | jq -r .target_directory) &&
+  mkdir -p ${TARGET_DIR}/wasm32-wasip1/release &&
+  command cp -f ${TARGET_DIR}/wasm32-wasip1/fastly-release/fastly-compute-project.wasm ${TARGET_DIR}/wasm32-wasip1/release/fastly-compute-project.wasm
+  """

--- a/terraform/docs-rs/fastly-compute-docs-rs/rust-toolchain.toml
+++ b/terraform/docs-rs/fastly-compute-docs-rs/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.90"
+targets = [ "wasm32-wasip1" ]
+profile = "default"

--- a/terraform/docs-rs/fastly-compute-docs-rs/src/main.rs
+++ b/terraform/docs-rs/fastly-compute-docs-rs/src/main.rs
@@ -1,0 +1,34 @@
+use fastly::{
+    Error, Request, Response,
+    http::{Method, StatusCode},
+};
+
+const ONE_YEAR_IN_SECONDS: u32 = 31536000;
+// Should match the backend name in terraform
+const DOCS_RS_BACKEND: &str = "docs_rs_origin";
+
+#[fastly::main]
+fn main(mut req: Request) -> Result<Response, Error> {
+    match req.get_method() {
+        &Method::GET | &Method::HEAD | &Method::OPTIONS => {
+            // Both Cloudfront and Fastly should have a TTL of one year
+            req.set_ttl(ONE_YEAR_IN_SECONDS);
+        }
+        &Method::PUT | &Method::POST | &Method::PATCH | &Method::DELETE => {
+            // Do not cache other methods
+            req.set_pass(true);
+        }
+        _ => {
+            return Ok(Response::from_status(StatusCode::METHOD_NOT_ALLOWED));
+        }
+    }
+
+    // Send request to backend
+    let mut resp = req.send(DOCS_RS_BACKEND)?;
+
+    // Prevent indexing by search engines
+    // TODO: remove this when we are ready to go live with fastly
+    resp.set_header("X-Robots-Tag", "noindex, nofollow");
+
+    Ok(resp)
+}

--- a/terraform/docs-rs/fastly.tf
+++ b/terraform/docs-rs/fastly.tf
@@ -1,0 +1,67 @@
+locals {
+  fastly_domain_name   = "fastly.${local.domain_name}"
+  static_fastly_weight = 0
+}
+
+data "external" "package" {
+  program     = ["bash", "terraform-external-build.sh"]
+  working_dir = "./fastly-compute-docs-rs/bin"
+}
+
+data "fastly_package_hash" "package" {
+  filename = data.external.package.result.path
+}
+
+resource "fastly_service_compute" "docs_rs" {
+  name = local.domain_name
+
+  domain {
+    name = local.fastly_domain_name
+  }
+
+  # commenting this to avoid conflicts
+  # TODO: uncomment this
+  # domain {
+  #   name = local.domain_name
+  # }
+
+  backend {
+    name = "docs_rs_origin"
+
+    address       = local.origin
+    override_host = local.origin
+
+    use_ssl           = true
+    port              = 443
+    ssl_cert_hostname = local.origin
+  }
+
+  package {
+    filename         = data.external.package.result.path
+    source_code_hash = data.fastly_package_hash.package.hash
+  }
+}
+
+module "fastly_tls_subscription_globalsign" {
+  source = "../fastly-tls-subscription"
+
+  certificate_authority = "globalsign"
+  aws_route53_zone_id   = data.aws_route53_zone.webapp.id
+
+  domains = [
+    local.fastly_domain_name,
+    # TODO: uncomment this
+    # local.domain_name
+  ]
+
+  depends_on = [fastly_service_compute.docs_rs]
+}
+
+resource "aws_route53_record" "fastly_domain" {
+  name            = local.fastly_domain_name
+  type            = "CNAME"
+  zone_id         = data.aws_route53_zone.webapp.id
+  allow_overwrite = true
+  records         = module.fastly_tls_subscription_globalsign.destinations
+  ttl             = 60
+}

--- a/terraform/fastly-tls-subscription/_terraform.tf
+++ b/terraform/fastly-tls-subscription/_terraform.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = "~> 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.64"
+    }
+    fastly = {
+      source  = "fastly/fastly"
+      version = "~> 8.4"
+    }
+  }
+}

--- a/terraform/fastly-tls-subscription/main.tf
+++ b/terraform/fastly-tls-subscription/main.tf
@@ -1,0 +1,34 @@
+resource "fastly_tls_subscription" "subscription" {
+  certificate_authority = var.certificate_authority
+  domains               = var.domains
+}
+
+resource "aws_route53_record" "tls_validation" {
+  depends_on = [fastly_tls_subscription.subscription]
+
+  for_each = {
+    # The following `for` expression (due to the outer {}) will produce an object with key/value pairs:
+    #   - The 'key' is the domain name we've configured (e.g. fastly-static.crates.io)
+    #   - The 'value' is a specific 'challenge' object whose record_name matches the domain
+    #     (e.g. record_name is _acme-challenge.fastly-static.crates.io).
+    for domain in fastly_tls_subscription.subscription.domains :
+    # `element()` returns the first object in the list which should be the relevant 'challenge' object we need
+    domain => element([
+      for obj in fastly_tls_subscription.subscription.managed_dns_challenges :
+      # We use an `if` conditional to filter the list to a single element
+      obj if obj.record_name == "_acme-challenge.${domain}"
+    ], 0)
+  }
+
+  name            = each.value.record_name
+  type            = each.value.record_type
+  zone_id         = var.aws_route53_zone_id
+  allow_overwrite = true
+  records         = [each.value.record_value]
+  ttl             = 60
+}
+
+resource "fastly_tls_subscription_validation" "subscription" {
+  depends_on      = [aws_route53_record.tls_validation]
+  subscription_id = fastly_tls_subscription.subscription.id
+}

--- a/terraform/fastly-tls-subscription/outputs.tf
+++ b/terraform/fastly-tls-subscription/outputs.tf
@@ -1,0 +1,17 @@
+locals {
+  # It is currently not possible to get the CNAME for TLS-enabled hostnames as a
+  # Terraform resource. But the ACME HTTP challenge redirects production traffic
+  # to Fastly, for which it uses the CNAME that we are looking for.
+  #
+  # The below snippet is a hack to get the CNAME for the static domain from the
+  # HTTP challenge, until Fastly exposes it in the Terraform provider.
+  address_pools = flatten([
+    for record in fastly_tls_subscription.subscription.managed_http_challenges :
+    record.record_values if record.record_type == "CNAME"
+  ])
+}
+
+output "destinations" {
+  # Prefix address pools for Fastly to enable IPv6 support
+  value = [for pool in local.address_pools : "dualstack.${pool}"]
+}

--- a/terraform/fastly-tls-subscription/variables.tf
+++ b/terraform/fastly-tls-subscription/variables.tf
@@ -1,0 +1,20 @@
+variable "certificate_authority" {
+  type        = string
+  description = "The certificate authority to use"
+  validation {
+    condition     = contains(["lets-encrypt", "globalsign"], var.certificate_authority)
+    error_message = "The certificate authority must be either 'lets-encrypt' or 'globalsign'."
+  }
+}
+
+variable "domains" {
+  type        = list(string)
+  default     = []
+  description = "The list of domains to add to the certificate"
+}
+
+variable "aws_route53_zone_id" {
+  type        = string
+  description = "The AWS Route53 zone in which to create the DNS records"
+}
+


### PR DESCRIPTION
This adds the `fastly-docs.rs` domain, which goes through the fastly CDN.
we aren't changing the behavior of `docs.rs` with this PR.