### PR TITLE
docs-rs: remove ssl_cert_hostname from fastly backend

### DIFF
--- a/terraform/docs-rs/fastly.tf
+++ b/terraform/docs-rs/fastly.tf
@@ -32,9 +32,8 @@ resource "fastly_service_compute" "docs_rs" {
     address       = local.origin
     override_host = local.origin
 
-    use_ssl           = false
-    port              = 80
-    ssl_cert_hostname = local.origin
+    use_ssl = false
+    port    = 80
   }
 
   resource_link {


### PR DESCRIPTION
This isn't needed because `use_ssl` is false.