### PR TITLE
add docs.rs domain to fastly

### DIFF
--- a/terraform/docs-rs/fastly.tf
+++ b/terraform/docs-rs/fastly.tf
@@ -20,11 +20,9 @@ resource "fastly_service_compute" "docs_rs" {
     name = local.fastly_domain_name
   }
 
-  # commenting this to avoid conflicts
-  # TODO: uncomment this
-  # domain {
-  #   name = local.domain_name
-  # }
+  domain {
+    name = local.domain_name
+  }
 
   backend {
     name = "docs_rs_origin"


### PR DESCRIPTION
The same is present in https://github.com/rust-lang/simpleinfra/blob/b7764c9a8982384d58bfc13452295ee6886fbccf/terragrunt/modules/crates-io/fastly-static.tf#L33