### PR TITLE
enable shielding in docs-rs cdn

### DIFF
--- a/terraform/docs-rs/fastly.tf
+++ b/terraform/docs-rs/fastly.tf
@@ -28,7 +28,7 @@ resource "fastly_configstore_entries" "docs_rs" {
     # So if things break, just remove this entry.
 
     # this is the "san jose" shield location, closest to our EC2 server in AWS us-west1 (north california)
-    # shield_pop = "sjc-ca-us" tempoarily disabled due to rate limiting issues
+    shield_pop = "sjc-ca-us"
 
     # max age for HSTS header.
     # should be less for test / staging environments


### PR DESCRIPTION
revert https://github.com/rust-lang/simpleinfra/pull/834/ because we found out that rate-limiting issues weren't due to shielding.
Shielding reduced the number of active connections in the docs-rs server.