### PR TITLE
increase crates-io index fastly cdn weight

### DIFF
--- a/terragrunt/accounts/legacy/crates-io-prod/crates-io/terragrunt.hcl
+++ b/terragrunt/accounts/legacy/crates-io-prod/crates-io/terragrunt.hcl
@@ -28,8 +28,8 @@ inputs = {
 
   static_cloudfront_weight = 0
   static_fastly_weight = 255
-  index_cloudfront_weight = 99
-  index_fastly_weight = 1
+  index_cloudfront_weight = 50
+  index_fastly_weight = 50
 
   cdn_log_event_queue_arn = "arn:aws:sqs:us-west-1:365596307002:cdn-log-event-queue"
 }


### PR DESCRIPTION
continue to increase fastly weight. Started in https://github.com/rust-lang/simpleinfra/pull/850