### PR TITLE
increase hardcoded TTL for static.crates.io

### DIFF
--- a/terragrunt/accounts/legacy/crates-io-prod/crates-io/terragrunt.hcl
+++ b/terragrunt/accounts/legacy/crates-io-prod/crates-io/terragrunt.hcl
@@ -18,7 +18,7 @@ inputs = {
   static_bucket_name     = "crates-io"
   index_bucket_name      = "crates-io-index"
 
-  static_ttl = 86400 // 1 day
+  static_ttl = 31536000 // 1 year
 
   webapp_origin_domain = "crates-io.herokuapp.com"
 


### PR DESCRIPTION
Increase hardcoded CDN TTL for static.crates.io. 

We're actively sending purges when things change, so they don't have to expire at all. 

See also: [#t-crates-io > static.crates.io / CDN caching?](https://rust-lang.zulipchat.com/#narrow/channel/318791-t-crates-io/topic/static.2Ecrates.2Eio.20.2F.20CDN.20caching.3F/with/563294377)