### PR TITLE
Add direnv and fzf to the dev-desktops

### DIFF
--- a/ansible/roles/dev-desktop/tasks/dependencies.yml
+++ b/ansible/roles/dev-desktop/tasks/dependencies.yml
@@ -15,6 +15,8 @@
       - build-essential
       - clang
       - cmake
+      - direnv
+      - fzf
       - gcc-mingw-w64-x86-64 # Allows running `x check --target x86_64-pc-windows-gnu`
       - jq
       - tidy # Format and diff html for rustdoc


### PR DESCRIPTION
See https://direnv.net/ and https://junegunn.github.io/fzf/ for a description; these are just general utilities and not related to rust specifically.