### PR TITLE
don't specify region in terragrunt module

### DIFF
--- a/terragrunt/modules/ecs-cluster/_terraform.tf
+++ b/terragrunt/modules/ecs-cluster/_terraform.tf
@@ -10,7 +10,3 @@ terraform {
     }
   }
 }
-
-provider "aws" {
-  region = "us-east-1"
-}


### PR DESCRIPTION
modules are supposed to be reused, so the region should be specified in the account using it.

This fixes running `terraform plan` in docs-rs-staging account