### PR TITLE
Use `@bors` prefix for new bors

### DIFF
--- a/terragrunt/modules/bors/main.tf
+++ b/terragrunt/modules/bors/main.tf
@@ -276,7 +276,7 @@ resource "aws_ecs_task_definition" "bors" {
         },
         {
           name  = "RUST_LOG"
-          value = "bors=debug"
+          value = "bors=trace"
         },
         {
           name  = "CMD_PREFIX",


### PR DESCRIPTION
Part of https://github.com/rust-lang/infra-team/issues/168.

Also updates the default log level to trace, so that we have more information in the logs during the transition from homu.