### PR TITLE
Append `Fastly-FF` header in edge -> shield requests

### DIFF
--- a/terraform/docs-rs/fastly-compute-docs-rs/src/main.rs
+++ b/terraform/docs-rs/fastly-compute-docs-rs/src/main.rs
@@ -128,20 +128,20 @@ fn main(mut req: Request) -> Result<Response, Error> {
     // Send request to backend, shield POP or origin
     let mut resp = req.send(shield.target_backend())?;
 
-    // set HSTS header
     if shield.response_is_for_client() {
+        // set HSTS header
         let ttl: u32 = config
             .get(HSTS_MAX_AGE_KEY)
             .and_then(|ttl| ttl.parse().ok())
             .unwrap_or(31_557_600);
 
         resp.set_header(STRICT_TRANSPORT_SECURITY, format!("max-age={ttl}"));
-    }
 
-    // Workaround for outstanding Fastly platform issue.
-    // See https://github.com/rust-lang/simpleinfra/pull/877
-    resp.remove_header(SURROGATE_CONTROL);
-    resp.remove_header(SURROGATE_KEY);
+        // Workaround for outstanding Fastly platform issue.
+        // See https://github.com/rust-lang/simpleinfra/pull/877
+        resp.remove_header(SURROGATE_CONTROL);
+        resp.remove_header(SURROGATE_KEY);
+    }
 
     // enable dynamic compression at the edge
     // https://www.fastly.com/documentation/guides/concepts/compression/#dynamic-compression


### PR DESCRIPTION
Fastly Compute is showing some unexpected behaviour in handling the `Surrogate-Control` header when shielding is enabled. The header should be forwarded from the shield to the edge node in order for the edge to know the origin's caching preferences, but it's getting stripped.

Having the `Fastly-FF` header present in the request indicates to the runtime that this request is from an edge node, so by including it in the request from the edge to the shield we get the `Surrogate-Control` header back as expected and the edge node will be able to follow that caching policy.

Finally, we remove both `Surrogate-Control` and `Surrogate-Key` from the downstream request to replicate the _expected_ logic of the platform.

This is a temporary workaround which I will revert once the issue has been resolved at a platform level, but I cannot disclose a timeline for that right now.

See discussion at https://rust-lang.zulipchat.com/#narrow/channel/356853-t-docs-rs/topic/New.20docs.2Ers.20infrastructure/near/566536029