### PR TITLE
fix(bors): assign valid memory to ecs

### DIFF
--- a/terragrunt/accounts/bors-prod/app/terragrunt.hcl
+++ b/terragrunt/accounts/bors-prod/app/terragrunt.hcl
@@ -14,4 +14,5 @@ inputs = {
   trusted_sub = "repo:rust-lang/bors:environment:production"
   oauth_client_id = "Ov23li6CuHNVV4KULH9X"
   cpu = 512
+  memory = 1024
 }

--- a/terragrunt/accounts/bors-staging/app/terragrunt.hcl
+++ b/terragrunt/accounts/bors-staging/app/terragrunt.hcl
@@ -14,4 +14,5 @@ inputs = {
   trusted_sub = "repo:rust-lang/bors:environment:staging"
   oauth_client_id = "Ov23liTJD2gXjfBvmjZN"
   cpu = 256
+  memory = 512
 }

--- a/terragrunt/modules/bors/main.tf
+++ b/terragrunt/modules/bors/main.tf
@@ -247,7 +247,7 @@ data "aws_region" "current" {}
 resource "aws_ecs_task_definition" "bors" {
   family                   = "bors"
   cpu                      = var.cpu
-  memory                   = 512
+  memory                   = var.memory
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
 
@@ -564,4 +564,8 @@ variable "public_url" {
 
 variable "cpu" {
   description = "How much CPU should be allocated to the bors instance."
+}
+
+variable "memory" {
+  description = "How much memory should be allocated to the bors instance."
 }


### PR DESCRIPTION
While applying https://github.com/rust-lang/simpleinfra/pull/882 I got an error because 512 cpu and 512 memory are not compatible.

See [docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size):

<img width="1202" height="478" alt="image" src="https://github.com/user-attachments/assets/2cb01970-3f20-4a66-972e-49e5d33c5083" />
