### PR TITLE
fix(bors): reduce deregistration delay

### DIFF
--- a/terragrunt/modules/bors/main.tf
+++ b/terragrunt/modules/bors/main.tf
@@ -378,6 +378,23 @@ resource "aws_lb_target_group" "primary" {
   vpc_id      = data.aws_vpc.default.id
   target_type = "ip"
 
+  # How many seconds to stay in the deregistering (or deactivating) state.
+  # In this state, the load balancer sends no requests to the target.
+  # So this delay should be long enough to allow in-flight connections to
+  # complete.
+  # After this delay, the ECS task enters the stopping state, and ECS
+  # sends the SIGTERM signal to the container, so that it can shutdown gracefully.
+  # See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-lifecycle-explanation.html
+  deregistration_delay = 30
+
+  health_check {
+    # delay between each health check attempt
+    interval            = 10
+    unhealthy_threshold = 2
+    protocol            = "TCP"
+    healthy_threshold   = 3
+  }
+
   lifecycle {
     create_before_destroy = true
   }


### PR DESCRIPTION
As suggested in [#t-infra > Testing new bors in production @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Testing.20new.20bors.20in.20production/near/567133458)

Plan:

```
15:26:20.968 STDOUT terraform: Terraform will perform the following actions:
15:26:20.968 STDOUT terraform:   # aws_lb_target_group.primary will be updated in-place
15:26:20.968 STDOUT terraform:   ~ resource "aws_lb_target_group" "primary" {
15:26:20.968 STDOUT terraform:       ~ deregistration_delay               = "300" -> "30"
15:26:20.968 STDOUT terraform:         id                                 = "arn:aws:elasticloadbalancing:us-east-2:392478027976:targetgroup/bors20230716211838777100000001/bd2045049651e0cc"
15:26:20.968 STDOUT terraform:         name                               = "bors20230716211838777100000001"
15:26:20.968 STDOUT terraform:         tags                               = {}
15:26:20.968 STDOUT terraform:         # (16 unchanged attributes hidden)
15:26:20.968 STDOUT terraform:       ~ health_check {
15:26:20.968 STDOUT terraform:           ~ healthy_threshold   = 5 -> 3
15:26:20.968 STDOUT terraform:           ~ interval            = 30 -> 10
15:26:20.968 STDOUT terraform:             # (5 unchanged attributes hidden)
15:26:20.968 STDOUT terraform:         }
15:26:20.968 STDOUT terraform:         # (4 unchanged blocks hidden)
15:26:20.969 STDOUT terraform:     }
15:26:20.969 STDOUT terraform: Plan: 0 to add, 1 to change, 0 to destroy.
```