### PR TITLE
docs.rs: temporarily disable origin shield

### DIFF
--- a/terraform/docs-rs/fastly.tf
+++ b/terraform/docs-rs/fastly.tf
@@ -27,7 +27,7 @@ resource "fastly_configstore_entries" "docs_rs" {
     # So if things break, just remove this entry.
 
     # this is the "san jose" shield location, closest to our EC2 server in AWS us-west1 (north california)
-    shield_pop = "sjc-ca-us"
+    # shield_pop = "sjc-ca-us"
 
     # max age for HSTS header.
     # should be less for test / staging environments


### PR DESCRIPTION
see [this zulip message]([#t-docs-rs > New docs.rs infrastructure @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/356853-t-docs-rs/topic/New.20docs.2Ers.20infrastructure/near/566951888)). 

I want to see cache ratios & speed after disabling the shield. 

Depending on the result, and how long fastly takes to fix the issue, we might switch to VCL (😢 )