### PR TITLE
Add more CPU/memory to production bors instance

### DIFF
--- a/terragrunt/accounts/bors-prod/app/terragrunt.hcl
+++ b/terragrunt/accounts/bors-prod/app/terragrunt.hcl
@@ -13,6 +13,6 @@ inputs = {
   gh_app_id = "278306"
   trusted_sub = "repo:rust-lang/bors:environment:production"
   oauth_client_id = "Ov23li6CuHNVV4KULH9X"
-  cpu = 512
-  memory = 1024
+  cpu = 1024
+  memory = 2048
 }


### PR DESCRIPTION
I realized that homu had a full CPU available (https://github.com/rust-lang/simpleinfra/blob/e4dd87fafbd4ea0fdb6e75ef4be9b79485609c30/terraform/bors/app.tf#L11), so I think that we can just use the same amount of HW as before, to avoid hamstringing bors unnecessarily; I still think that the queue page could load faster, for example.
