### PR TITLE
remove legacy crates-io prod deployed ref

### DIFF
--- a/terragrunt/accounts/legacy/crates-io-prod/crates-io/terragrunt.hcl
+++ b/terragrunt/accounts/legacy/crates-io-prod/crates-io/terragrunt.hcl
@@ -1,5 +1,7 @@
 terraform {
-  source = "git::../../../../..//terragrunt/modules/crates-io?ref=${trimspace(file("../deployed-ref"))}"
+  source = "../../../../modules//crates-io"
+  # Marco removed the deployed ref because too annoying. If you need it, feel free to add it back
+  # source = "git::../../../../..//terragrunt/modules/crates-io?ref=${trimspace(file("../deployed-ref"))}"
 }
 
 include {

--- a/terragrunt/accounts/legacy/crates-io-prod/deployed-ref
+++ b/terragrunt/accounts/legacy/crates-io-prod/deployed-ref
@@ -1,1 +1,0 @@
-762b988cb005e78ad5b058fb00bead9bb76bced9


### PR DESCRIPTION
sorry but I need to make a lot of changes to this module to add support for the webapp CDN to Fastly and I can't be bothered updating the commit hash at every PR 😅