### PR TITLE
crates-io-prod: use fastly anycast IPs for apex domain

### DIFF
--- a/terragrunt/modules/fastly-tls-subscription/outputs.tf
+++ b/terragrunt/modules/fastly-tls-subscription/outputs.tf
@@ -20,3 +20,7 @@ output "destinations" {
     startswith(pool, "dualstack.") ? pool : "dualstack.${pool}"
   ]
 }
+
+output "tls_configuration_id" {
+  value = fastly_tls_subscription.subscription.configuration_id
+}


### PR DESCRIPTION
when applying, I got the error:

```
╷
│ Error: creating Route53 Record: operation error Route 53: ChangeResourceRecordSets, https response error StatusCode: 400, RequestID: f14394a2-881c-4880-8883-98126cb2fc05, InvalidChangeBatch: [Tried to create an alias that targets fastly-app.crates.io., type A in zone Z3HLPL7SRE1VK5, but that target was not found]
│
│   with aws_route53_record.weighted_webapp_fastly_apex["A"],
│   on fastly-webapp.tf line 115, in resource "aws_route53_record" "weighted_webapp_fastly_apex":
│  115: resource "aws_route53_record" "weighted_webapp_fastly_apex" {
│
╵
╷
│ Error: creating Route53 Record: operation error Route 53: ChangeResourceRecordSets, https response error StatusCode: 400, RequestID: afb23a75-384d-49e3-9ca9-9d09a733f66d, InvalidChangeBatch: [Tried to create an alias that targets fastly-app.crates.io., type AAAA in zone Z3HLPL7SRE1VK5, but that target was not found]
│
│   with aws_route53_record.weighted_webapp_fastly_apex["AAAA"],
│   on fastly-webapp.tf line 115, in resource "aws_route53_record" "weighted_webapp_fastly_apex":
│  115: resource "aws_route53_record" "weighted_webapp_fastly_apex" {
│
```

This should fix this issue.