### PR TITLE
change dev-desktop-staging instance_type from t3a.micro to t3a.small

### DIFF
--- a/terraform/dev-desktops/regions.tf
+++ b/terraform/dev-desktops/regions.tf
@@ -6,7 +6,7 @@ module "aws_eu_central_1" {
 
   instances = {
     "dev-desktop-staging" = {
-      instance_type = "t3a.micro"
+      instance_type = "t3a.small"
       instance_arch = "amd64"
       storage       = 250
     }


### PR DESCRIPTION
applying ansible failed because cpu throttled. Let's see if increase the instance type will fix this issue.