### PR TITLE
create content.rust-lang.org hosted zone

### DIFF
--- a/terragrunt/modules/content/route53.tf
+++ b/terragrunt/modules/content/route53.tf
@@ -1,0 +1,19 @@
+locals {
+  # Public CloudFront alias hostname.
+  domain_name = "content.rust-lang.org"
+}
+
+resource "aws_route53_zone" "zone" {
+  name = local.domain_name
+}
+
+# TODO
+# Create the DNS record pointing the domain to CloudFront.
+# resource "aws_route53_record" "public" {
+#   zone_id = aws_route53_zone.zone.id
+#   name    = local.domain_name
+#   type    = "CNAME"
+#   ttl     = 300
+#   # TODO Point the record at the distribution hostname.
+#   records = ["rust-lang.org"]
+# }


### PR DESCRIPTION
Same setup as bors:
https://github.com/rust-lang/simpleinfra/blob/479b7c2238b5d4ab6f9caaa99f53f58c002d643c/terragrunt/modules/bors/main.tf#L437

I will add the dns delegation to:
https://github.com/rust-lang/simpleinfra/blob/117d84ebe85d3825a28b3e65dd57ee28a717410e/terraform/dns-delegation/main.tf#L1