### PR TITLE
restart ssh after keys are updated

### DIFF
--- a/ansible/roles/common/tasks/ssh.yml
+++ b/ansible/roles/common/tasks/ssh.yml
@@ -31,4 +31,6 @@
     dest: "/etc/ssh/authorized_keys/{{ item }}"
     mode: 0444
 
+  notify: reload-ssh
+
   loop: "{{ unprivileged_users + sudo_users }}"


### PR DESCRIPTION
If we don't run `sudo systemctl restart ssh`, I can't ssh from my user.

## AI review

Standard behavior for `authorized_keys`
In ansible/roles/common/tasks/ssh.yml:
Standard sshd behavior is to read the AuthorizedKeysFile path upon every connection attempt. It is highly unusual to require a service restart for updated keys to take effect.

While this might solve the symptom described, double-check if permissions or SELinux contexts on the /etc/ssh/authorized_keys/ directory are correct, as those are more
likely root causes for keys not being accepted immediately.

## My response to AI review

Probably we should check what AI suggests, but I'm not doing this because from my test reloading ssh worked.