### PR TITLE
docs-rs: replace autoscaling group with EC2

### DIFF
--- a/terragrunt/accounts/docs-rs-staging/docs-rs/terragrunt.hcl
+++ b/terragrunt/accounts/docs-rs-staging/docs-rs/terragrunt.hcl
@@ -25,6 +25,5 @@ inputs = {
   private_subnet_ids        = dependency.vpc.outputs.private_subnets
   domain                    = "docs-rs-staging.rust-lang.net"
   bastion_security_group_id = dependency.vpc.outputs.bastion_security_group_id
-  min_num_builder_instances = 1
-  max_num_builder_instances = 1
+  builder_instance_type     = "c6a.large" # 2 vCPU. 4 GiB RAM.
 }

--- a/terragrunt/modules/docs-rs/README.md
+++ b/terragrunt/modules/docs-rs/README.md
@@ -9,7 +9,7 @@ This is the [Terraform] module that defines the infrastructure for [docs.rs].
 [docs.rs] consists of a few different components:
 
 - A web frontend hosted as a container running in an [ECS] cluster.
-- A background documentation builder running on [ec2](https://aws.amazon.com/ec2) instances as part of an [autoscaling](https://aws.amazon.com/ec2/autoscaling) group.
+- A background documentation builder running on a dedicated [ec2](https://aws.amazon.com/ec2) instance.
 - A background utility (**TODO**: this is currently not configured) which includes:
   - crate registry watcher that watches for changes to the crates registry and enqueues doc builds
   - the repository stats updater that ensures # stars, # issues, etc. from GitHub & GitLab are up-to-date

--- a/terragrunt/modules/docs-rs/variables.tf
+++ b/terragrunt/modules/docs-rs/variables.tf
@@ -30,12 +30,7 @@ variable "cluster_config" {
   description = "The configuration for the cluster this is running in"
 }
 
-variable "min_num_builder_instances" {
-  type        = number
-  description = "The minimum number of builder instances there should be"
-}
-
-variable "max_num_builder_instances" {
-  type        = number
-  description = "The maximum number of builder instances there should be"
+variable "builder_instance_type" {
+  type        = string
+  description = "The EC2 instance type for the docs-rs builder"
 }


### PR DESCRIPTION
For a more gradual migration. We can reintroduce autoscaling groups later.