### PR TITLE
docs-rs: remove duplicate acm certificate

### DIFF
--- a/terragrunt/modules/ecs-cluster/load-balancer.tf
+++ b/terragrunt/modules/ecs-cluster/load-balancer.tf
@@ -24,12 +24,6 @@ resource "aws_route53_record" "lb" {
   records = [aws_lb.lb.dns_name]
 }
 
-module "certificate" {
-  source  = "../acm-certificate"
-  domains = [var.load_balancer_domain]
-  legacy  = false
-}
-
 resource "aws_security_group" "lb" {
   name        = "${var.cluster_name}-load-balancer"
   description = "Allow incoming traffic for the load balancer"
@@ -116,4 +110,3 @@ resource "aws_lb_listener" "lb_https" {
     }
   }
 }
-


### PR DESCRIPTION
you can see in the same file we have `default_lb_certificate`