### PR TITLE
pin rust toolchain in crates-io cdn

### DIFF
--- a/terragrunt/modules/crates-io/compute-static/rust-toolchain.toml
+++ b/terragrunt/modules/crates-io/compute-static/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "1.92"
 targets = ["wasm32-wasip1"]


### PR DESCRIPTION
while applying I got the following error:

```
ERROR: version '1.93.0' of Rust has not been validated for use with Fastly Compute.
```