### PR TITLE
configure perf-collector to drop caches before each job

### DIFF
--- a/ansible/playbooks/rustc-perf.yml
+++ b/ansible/playbooks/rustc-perf.yml
@@ -205,6 +205,7 @@
           After=network.target
 
           [Service]
+          # a thin wrapper around rustc-perf/collector/collect-job-queue.sh that sets some secrets
           ExecStart=/home/collector/rustc-perf/run.sh
           WorkingDirectory=/home/collector/rustc-perf
           User=collector


### PR DESCRIPTION
Untested since I don't have a test environment.

companion PR: https://github.com/rust-lang/rustc-perf/pull/2398

Context: [#t-compiler/performance > Cyclical pattern in the wall-time summary charts?](https://rust-lang.zulipchat.com/#narrow/channel/247081-t-compiler.2Fperformance/topic/Cyclical.20pattern.20in.20the.20wall-time.20summary.20charts.3F/with/571316696)