### PR TITLE
copy s3 bucket files from legacy docs-rs account

### DIFF
--- a/terraform/docs-rs/outputs.tf
+++ b/terraform/docs-rs/outputs.tf
@@ -1,0 +1,4 @@
+output "storage_bucket_name" {
+  description = "Legacy docs-rs storage bucket name."
+  value       = aws_s3_bucket.storage.id
+}

--- a/terraform/docs-rs/s3.tf
+++ b/terraform/docs-rs/s3.tf
@@ -60,3 +60,41 @@ resource "aws_s3_bucket_public_access_block" "backups" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+
+// Allow principals in docs-rs-prod account to read this bucket for DataSync.
+resource "aws_s3_bucket_policy" "storage_datasync_cross_account_read" {
+  bucket = aws_s3_bucket.storage.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowDataSyncSourceRoleReadBucket"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::760062276060:root"
+        }
+        Action = [
+          "s3:GetBucketLocation",
+          "s3:ListBucket",
+          "s3:ListBucketMultipartUploads"
+        ]
+        Resource = aws_s3_bucket.storage.arn
+      },
+      {
+        Sid    = "AllowDataSyncSourceRoleReadObjects"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::760062276060:root"
+        }
+        Action = [
+          "s3:GetObject",
+          "s3:GetObjectTagging",
+          "s3:GetObjectVersion",
+          "s3:GetObjectVersionTagging",
+          "s3:ListMultipartUploadParts"
+        ]
+        Resource = "${aws_s3_bucket.storage.arn}/*"
+      }
+    ]
+  })
+}

--- a/terragrunt/accounts/docs-rs-prod/account.json
+++ b/terragrunt/accounts/docs-rs-prod/account.json
@@ -4,6 +4,10 @@
         "regions": [
             {
                 "region": "us-east-1"
+            },
+            {
+                "region": "us-west-1",
+                "alias": "west1"
             }
         ]
     }

--- a/terragrunt/accounts/docs-rs-prod/docs-rs/terragrunt.hcl
+++ b/terragrunt/accounts/docs-rs-prod/docs-rs/terragrunt.hcl
@@ -26,4 +26,8 @@ inputs = {
   domain                    = "docs-rs-prod.rust-lang.net"
   bastion_security_group_id = dependency.vpc.outputs.bastion_security_group_id
   builder_instance_type     = "c6a.8xlarge" # 32 vCPU. 64 GiB RAM.
+
+  # One-time ~10TB migration from the legacy bucket managed in terraform/docs-rs.
+  s3_migration_enabled            = true
+  s3_migration_source_bucket_name = "rust-docs-rs"
 }

--- a/terragrunt/modules/docs-rs/README.md
+++ b/terragrunt/modules/docs-rs/README.md
@@ -40,9 +40,9 @@ The registry watcher watches the registry for new entries. When a new crate is a
 ```mermaid
 flowchart LR
     User -- DNS --> CloudFront
-    CloudFront -- DNS --> ECSLB[Application Load Balancer]    
+    CloudFront -- DNS --> ECSLB[Application Load Balancer]
     ECSLB --> service[ECS Service]
-    
+
     subgraph ecs [ECS Cluster]
         service --> Container
         service -.-> task[Task Definition]

--- a/terragrunt/modules/docs-rs/outputs.tf
+++ b/terragrunt/modules/docs-rs/outputs.tf
@@ -1,0 +1,9 @@
+output "s3_migration_task_arn" {
+  description = "DataSync task ARN used to migrate objects from the legacy source bucket."
+  value       = var.s3_migration_enabled ? aws_datasync_task.migration[0].arn : null
+}
+
+output "storage_bucket_name" {
+  description = "Destination docs-rs storage bucket name."
+  value       = aws_s3_bucket.storage.id
+}

--- a/terragrunt/modules/docs-rs/s3_migration.tf
+++ b/terragrunt/modules/docs-rs/s3_migration.tf
@@ -1,0 +1,160 @@
+// Role assumed by DataSync for reads from the source bucket.
+resource "aws_iam_role" "datasync_source_location" {
+  count = var.s3_migration_enabled ? 1 : 0
+
+  name = "docs-rs-datasync-source-location"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "datasync.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "datasync_source_location_s3" {
+  count = var.s3_migration_enabled ? 1 : 0
+
+  role = aws_iam_role.datasync_source_location[0].id
+  name = "docs-rs-datasync-source-location-s3"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetBucketLocation",
+          "s3:ListBucket",
+          "s3:ListBucketMultipartUploads"
+        ]
+        Resource = "arn:aws:s3:::${var.s3_migration_source_bucket_name}"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:GetObjectTagging",
+          "s3:GetObjectVersion",
+          "s3:GetObjectVersionTagging",
+          "s3:ListMultipartUploadParts"
+        ]
+        Resource = "arn:aws:s3:::${var.s3_migration_source_bucket_name}/*"
+      }
+    ]
+  })
+}
+
+// Role assumed by DataSync for writes into the destination bucket.
+resource "aws_iam_role" "datasync_destination_location" {
+  count = var.s3_migration_enabled ? 1 : 0
+
+  name = "docs-rs-datasync-destination-location"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "datasync.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "datasync_destination_location_s3" {
+  count = var.s3_migration_enabled ? 1 : 0
+
+  role = aws_iam_role.datasync_destination_location[0].id
+  name = "docs-rs-datasync-destination-location-s3"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetBucketLocation",
+          "s3:ListBucket",
+          "s3:ListBucketMultipartUploads"
+        ]
+        Resource = aws_s3_bucket.storage.arn
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:AbortMultipartUpload",
+          "s3:DeleteObject",
+          "s3:GetObject",
+          "s3:GetObjectTagging",
+          "s3:ListMultipartUploadParts",
+          "s3:PutObject",
+          "s3:PutObjectTagging"
+        ]
+        Resource = "${aws_s3_bucket.storage.arn}/*"
+      }
+    ]
+  })
+}
+
+resource "aws_cloudwatch_log_group" "datasync_s3_migration" {
+  count = var.s3_migration_enabled ? 1 : 0
+
+  name              = "/aws/datasync/docs-rs-storage-import"
+  retention_in_days = 30
+}
+
+resource "aws_datasync_location_s3" "migration_source" {
+  provider = aws.west1
+  count    = var.s3_migration_enabled ? 1 : 0
+
+  s3_bucket_arn = "arn:aws:s3:::${var.s3_migration_source_bucket_name}"
+  subdirectory  = "/"
+
+  s3_config {
+    bucket_access_role_arn = aws_iam_role.datasync_source_location[0].arn
+  }
+}
+
+resource "aws_datasync_location_s3" "migration_destination" {
+  count = var.s3_migration_enabled ? 1 : 0
+
+  s3_bucket_arn = aws_s3_bucket.storage.arn
+  subdirectory  = "/"
+
+  s3_config {
+    bucket_access_role_arn = aws_iam_role.datasync_destination_location[0].arn
+  }
+}
+
+resource "aws_datasync_task" "migration" {
+  count = var.s3_migration_enabled ? 1 : 0
+
+  name                     = "docs-rs-storage-import"
+  source_location_arn      = aws_datasync_location_s3.migration_source[0].arn
+  destination_location_arn = aws_datasync_location_s3.migration_destination[0].arn
+  cloudwatch_log_group_arn = aws_cloudwatch_log_group.datasync_s3_migration[0].arn
+
+  options {
+    # Unlimited bandwidth to minimize migration time
+    bytes_per_second = -1
+    log_level        = "BASIC"
+    # For one-time imports with TransferMode=ALL, deleted source objects are not removed from destination.
+    preserve_deleted_files = "PRESERVE"
+    task_queueing          = "ENABLED"
+    # Transfers all the content from the source, without comparing to the destination location
+    transfer_mode = "ALL"
+
+    # Values I had to set to None to avoid aws errors
+    posix_permissions = "NONE"
+    uid               = "NONE"
+    gid               = "NONE"
+  }
+}

--- a/terragrunt/modules/docs-rs/variables.tf
+++ b/terragrunt/modules/docs-rs/variables.tf
@@ -34,3 +34,16 @@ variable "builder_instance_type" {
   type        = string
   description = "The EC2 instance type for the docs-rs builder"
 }
+
+variable "s3_migration_enabled" {
+  type        = bool
+  description = "Enable manual S3 migration from a source bucket to the docs-rs storage bucket."
+  default     = false
+}
+
+variable "s3_migration_source_bucket_name" {
+  type        = string
+  description = "Name of the source S3 bucket to copy from."
+  default     = null
+  nullable    = true
+}


### PR DESCRIPTION
Related to #353 

## Cross-account S3 migration (using DataSync)

This PR add support for migrating data from a source S3 bucket in a different AWS account into the docs-rs storage bucket.

When enabled, the module provisions a DataSync task (`docs-rs-storage-import`) and its source/destination S3 locations.

you can trigger the task manually with:

```bash
aws datasync start-task-execution --task-arn <s3_migration_task_arn>
```