### PR TITLE
Add tagging/attribute perms in T-content AWS buckets

### DIFF
--- a/terragrunt/modules/aws-organization/content.tf
+++ b/terragrunt/modules/aws-organization/content.tf
@@ -27,8 +27,12 @@ resource "aws_ssoadmin_permission_set_inline_policy" "content_s3_write" {
         Effect = "Allow"
         Action = [
           "s3:GetObject",
+          "s3:GetObjectAttributes",
+          "s3:GetObjectTagging",
           "s3:PutObject",
+          "s3:PutObjectTagging",
           "s3:DeleteObject",
+          "s3:DeleteObjectTagging",
         ]
         Resource = [
           "arn:aws:s3:::rust-content-internal/*",


### PR DESCRIPTION
To rename an object in S3 using the CLI, one needs the tagging permissions.  Let's set those perms.  We'll also set `s3:GetObjectAttributes` as that's another one that a tool might commonly expect to have.

cc @marcoieni @tmandry
