### PR TITLE
update ansible pinned version

### DIFF
--- a/ansible/requirements.txt
+++ b/ansible/requirements.txt
@@ -1,3 +1,3 @@
-ansible==8.7.0
+ansible==10.1.0
 boto3==1.26.94
 passlib==1.7.4


### PR DESCRIPTION
The previous version is not compatible with python 3.14.

I got the following error when applying https://github.com/rust-lang/simpleinfra/pull/982:

```
TASK [Ensure bastion unprivileged users are configured] ************************************
fatal: [bastion.docs-rs-staging.rust-lang.net]: FAILED! => {"msg": "The conditional check 'vars_bastion_unprivileged_users | default([]) | length > 0' failed. The error was: Invalid conditional detected: module 'ast' has no attribute 'Str'"}
```

I updated to a couple of versions more and the error doesn't happen anymore.
To migrate, run `rm -rf ansible/.venv` and run the `apply` script again.