### PR TITLE
reflect datadog UI changes in terraform

### DIFF
--- a/terraform/team-members-datadog/foundation.tf
+++ b/terraform/team-members-datadog/foundation.tf
@@ -2,7 +2,6 @@ locals {
   foundation = {
     "adam"           = local.users.adam
     "joel"           = local.users.joel
-    "jon"            = local.users.jon
     "marcoieni"      = local.users.marcoieni
     "rustfoundation" = local.users.rustfoundation
     "tobias"         = local.users.tobias
@@ -23,6 +22,7 @@ resource "datadog_role" "foundation" {
       data.datadog_permissions.all.permissions.logs_write_exclusion_filters,
       data.datadog_permissions.all.permissions.logs_generate_metrics,
       data.datadog_permissions.all.permissions.metrics_metadata_write,
+      data.datadog_permissions.all.permissions.monitors_write,
       data.datadog_permissions.all.permissions.dbm_read,
     ])
 

--- a/terraform/team-members-datadog/users.tf
+++ b/terraform/team-members-datadog/users.tf
@@ -28,10 +28,6 @@ locals {
       login = "joelmarcey@rustfoundation.org"
       name  = "Joel Marcey"
     }
-    "jon" = {
-      login = "jonbauman@rustfoundation.org"
-      name  = "Jon Bauman"
-    }
     "jtgeibel" = {
       login = "jtgeibel@gmail.com"
       name  = "Justin Geibel"


### PR DESCRIPTION
```
Terraform will perform the following actions:

  # datadog_team_membership.foundation["jon"] will be destroyed
  # (because key ["jon"] is not in for_each map)
  - resource "datadog_team_membership" "foundation" {
      - id      = "TeamMembership-5f860007-74fa-419d-8b81-591bae1485b2-33470539" -> null
      - team_id = "5f860007-74fa-419d-8b81-591bae1485b2" -> null
      - user_id = "e3dac2b4-4b7e-11f0-b4ec-b26f2998c7a5" -> null
    }

  # datadog_user.users["jon"] will be destroyed
  # (because key ["jon"] is not in for_each map)
  - resource "datadog_user" "users" {
      - disabled             = true -> null
      - email                = "jonbauman@rustfoundation.org" -> null
      - id                   = "e3dac2b4-4b7e-11f0-b4ec-b26f2998c7a5" -> null
      - name                 = "Jon Bauman" -> null
      - roles                = [
          - "786371e8-cbef-11ee-9a91-da7ad0900002",
        ] -> null
      - send_user_invitation = true -> null
      - user_invitation_id   = "e41ef47e-4b7e-11f0-a657-da7ad0900002" -> null
      - verified             = true -> null
    }

Plan: 0 to add, 0 to change, 2 to destroy.
```