### PR TITLE
datadog: add more permission to foundation members

### DIFF
--- a/terraform/team-members-datadog/foundation.tf
+++ b/terraform/team-members-datadog/foundation.tf
@@ -8,6 +8,12 @@ locals {
     "ubiratan"       = local.users.ubiratan
     "walter"         = local.users.walter
   }
+
+  # Foundation members inherit all permissions from Datadog's Standard Role.
+  foundation_roles = [
+    "Datadog Standard Role",
+    datadog_role.foundation.name,
+  ]
 }
 
 resource "datadog_role" "foundation" {

--- a/terraform/team-members-datadog/users.tf
+++ b/terraform/team-members-datadog/users.tf
@@ -92,7 +92,7 @@ locals {
     { for name, user in local.crater : name => merge(user, { roles = [datadog_role.crater.name] }) },
     { for name, user in local.crates_io : name => merge(user, { roles = [datadog_role.crates_io.name] }) },
     { for name, user in local.docs_rs : name => merge(user, { roles = [datadog_role.docs_rs.name] }) },
-    { for name, user in local.foundation : name => merge(user, { roles = [datadog_role.foundation.name] }) },
+    { for name, user in local.foundation : name => merge(user, { roles = local.foundation_roles }) },
     { for name, user in local.foundation_board : name => merge(user, { roles = [datadog_role.board_member.name] }) },
     { for name, user in local.infra : name => merge(user, { roles = [datadog_role.infra.name] }) },
     { for name, user in local.infra_admins : name => merge(user, { roles = ["Datadog Admin Role"] }) },


### PR DESCRIPTION
Datadog has 3 managed roles:
- Admin role
- Standard role
- Read only role

This PR gives Foundation members the Standard role, so that they can do they job more easily.