### PR TITLE
increase docs.rs cdn timeout to 120s

### DIFF
--- a/terraform/docs-rs/fastly.tf
+++ b/terraform/docs-rs/fastly.tf
@@ -51,10 +51,10 @@ resource "fastly_service_compute" "docs_rs" {
     address       = local.origin
     override_host = local.origin
 
-    between_bytes_timeout = 10000 # ms -> 10s
-    connect_timeout       = 10000 # ms -> 10s
-    first_byte_timeout    = 60000 # ms -> 60s -> same as origin
-    keepalive_time        = 60    # s
+    between_bytes_timeout = 10000  # ms -> 10s
+    connect_timeout       = 10000  # ms -> 10s
+    first_byte_timeout    = 120000 # ms -> 120s -> same as origin
+    keepalive_time        = 60     # s
 
     use_ssl = false
     port    = 80


### PR DESCRIPTION
we'll likely have a lower timeout at our origin. 

related: https://github.com/rust-lang/simpleinfra/pull/1014