### PR TITLE
Add (disabled) get-all-crates unit to dev desktops

### DIFF
--- a/ansible/roles/dev-desktop/files/refresh-crates.sh
+++ b/ansible/roles/dev-desktop/files/refresh-crates.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+cd /home/crates-io-downloader
+
+# Refresh crates.io index
+if [ -d crates.io-index ]; then
+    git -C crates.io-index pull --force
+else
+    git clone https://github.com/rust-lang/crates.io-index.git
+fi
+
+# Re-fetch latest copies of crates into ./all-crates.
+# This will automatically skip downloading existing crates.
+./.cargo/bin/get-all-crates --index ./crates.io-index --out /var/cache/all-crates

--- a/ansible/roles/dev-desktop/tasks/crates-io.yml
+++ b/ansible/roles/dev-desktop/tasks/crates-io.yml
@@ -1,0 +1,48 @@
+---
+
+- name: Set up user for crates.io downloads
+  user:
+    name: crates-io-downloader
+    state: present
+
+- name: Install Rust for crates-io-downloader
+  shell: "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
+  become_user: crates-io-downloader
+
+- name: Install get-all-crates
+  shell: "PATH=$PATH:$HOME/.cargo/bin cargo install get-all-crates --version 0.1.22 --locked"
+  become_user: crates-io-downloader
+
+- name: Set up get-all-crates systemd service
+  template:
+    src: get-all-crates.service.j2
+    dest: /etc/systemd/system/get-all-crates.service
+    mode: 0644
+  register: get_all_crates_service
+
+- name: Set up get-all-crates systemd timer
+  template:
+    src: get-all-crates.timer.j2
+    dest: /etc/systemd/system/get-all-crates.timer
+    mode: 0644
+  register: get_all_crates_timer
+
+- name: reload systemd
+  systemd:
+    daemon_reload: true
+  when: get_all_crates_timer is changed or get_all_crates_service is changed
+
+- name: setup all-crates directory
+  file:
+    path: /var/cache/all-crates
+    state: directory
+    owner: crates-io-downloader
+    group: crates-io-downloader
+    mode: 0755
+
+- name: Set up get-all-crates script
+  copy:
+    src: files/refresh-crates.sh
+    dest: /home/crates-io-downloader/refresh-crates.sh
+    owner: crates-io-downloader
+    mode: u+x

--- a/ansible/roles/dev-desktop/tasks/main.yml
+++ b/ansible/roles/dev-desktop/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 
+- include_tasks: crates-io.yml
 - include_tasks: cloud_provider.yml
 - include_tasks: oom.yml
 - include_tasks: dependencies.yml

--- a/ansible/roles/dev-desktop/templates/get-all-crates.service.j2
+++ b/ansible/roles/dev-desktop/templates/get-all-crates.service.j2
@@ -1,0 +1,8 @@
+[Unit]
+Description=Refresh crates.io export
+
+[Service]
+Type=oneshot
+User=crates-io-downloader
+ExecStart=/home/crates-io-downloader/refresh-crates.sh
+MemoryMax=80%

--- a/ansible/roles/dev-desktop/templates/get-all-crates.timer.j2
+++ b/ansible/roles/dev-desktop/templates/get-all-crates.timer.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=Refresh crates.io export timer
+
+[Timer]
+OnCalendar=daily
+RandomizedDelaySec=3600
+
+[Install]
+#WantedBy=timers.target


### PR DESCRIPTION
This is disabled, but has run successfully (ish, see below) on dev-desktop-us-2.

```text
$ sudo du -h -d 1 /home/crates-io-downloader
1.4G    /home/crates-io-downloader/.rustup
267M    /home/crates-io-downloader/.cargo
20K     /home/crates-io-downloader/.config
8.0K    /home/crates-io-downloader/.ansible
4.8G    /home/crates-io-downloader/crates.io-index
6.3G    /home/crates-io-downloader
$ sudo du -h -d 0 /var/cache/all-crates
385G    /var/cache/all-crates
```

Running the systemd unit repeatedly exited early due to memory limits -- I think if we want to enable the timer to run this unit on a periodic basis, we'll want to work to either update or replace get-all-crates to not use meaningful memory before we enable this on a continuous basis. It runs incrementally, so I don't think there's actually a hard blocker there, but it feels like there's an opportunity for improvement that should be driven to conclusion.

In the meantime us-2 has a copy in /var/cache/all-crates that is probably useful for folks and we can manually run the unit on an as-needed basis on that host (sudo systemctl start get-all-crates).

cc [#t-infra > Put all crates on dev desktops](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Put.20all.20crates.20on.20dev.20desktops/with/583617856)