### PR TITLE
google-workspace: create rustlang.org subdomain for legacy email path

### DIFF
--- a/terraform/dns-delegation/rust_lang_org.tf
+++ b/terraform/dns-delegation/rust_lang_org.tf
@@ -14,3 +14,21 @@ resource "aws_route53_record" "content" {
     "ns-1408.awsdns-48.org.",
   ]
 }
+
+# Plumbing subdomain used to enable email routing to
+# Google mail servers, at least while MX records
+# for rust-lang.org point to mailgun servers
+resource "aws_route53_record" "gws_mx_records" {
+  zone_id = data.aws_route53_zone.rust_lang_org.zone_id
+  name    = "mail.rust-lang.org"
+  type    = "MX"
+  ttl     = 3600
+
+  records = [
+    "1 aspmx.l.google.com",
+    "5 alt1.aspmx.l.google.com",
+    "5 alt2.aspmx.l.google.com",
+    "10 alt3.aspmx.l.google.com",
+    "10 alt4.aspmx.l.google.com",
+  ]
+}

--- a/terraform/dns-delegation/rust_lang_org.tf
+++ b/terraform/dns-delegation/rust_lang_org.tf
@@ -14,3 +14,20 @@ resource "aws_route53_record" "content" {
     "ns-1408.awsdns-48.org.",
   ]
 }
+
+# Temporary subdomain used to enable backwards compatibility
+# while we migrate legacy "mailing lists" powered by Mailgun
+# routing to Google Groups
+# Google Workspace will route unrecognized recipients to
+# this subdomain
+resource "aws_route53_record" "mailgun_legacy_lists" {
+  zone_id = data.aws_route53_zone.rust_lang_org.zone_id
+  name    = "legacy-lists.rust-lang.org"
+  type    = "MX"
+  ttl     = 3600
+
+  records = [
+    "10 mxa.mailgun.org",
+    "10 mxb.mailgun.org",
+  ]
+}


### PR DESCRIPTION
Towards https://github.com/rust-lang/infra-team/issues/297