### PR TITLE
redirect `prev.rust-lang.org` website to `rust-lang.org`

### DIFF
--- a/terraform/prev-rust-lang-org/.terraform.lock.hcl
+++ b/terraform/prev-rust-lang-org/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.41.0"
+  constraints = "6.41.0"
+  hashes = [
+    "h1:P5G2OYd40P7QUS0dM2uw3WJ0y+VzOoIO7RvRRqA62D0=",
+    "zh:01835476adda6d93095e37fdf782f14e6709f6922dc62e88994f9684627deb69",
+    "zh:0b9bc5eda9def53df19e1a37562dcb67c1fba8452803e1b5601e75653c986255",
+    "zh:196f81d97ea2951d2c6667709445d7c36b5fd8603890c774495806b4da0743aa",
+    "zh:1ba36118b0146e5c3603020509b34d09e693db50ec29f9be5badc9f2a4fd95b8",
+    "zh:4253c2f6066ce279e5ce48849c78fc193f222dc42a929e6876b9563ed5c23fcf",
+    "zh:457ed8609680338dbcb9809e263638a530c06ba43208af9e660803133dc5e1e6",
+    "zh:4e8de5f3fcc3e3f41b6703ad4c0fa62175d0c29afcf56ac82eb16c604bb6dafa",
+    "zh:583ae622cfe4633fabca071ded738e9ef3398d9e9916cb26350aad28068462c5",
+    "zh:5b8bf11070c13e21a0fef05713a25be0392c7d064bd2199c2f99939cc345e8c5",
+    "zh:6aa7ae41d4fff4e95cedcbeaa143b2af9ad3e3a4b40208801b701d77a738b2c7",
+    "zh:8143670bca48af3b873b0db83443dbdcb868442f1e789ffba356d6adf4dbd7b9",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:c22951cf0a4b169607ea066717dd499f46221af035903497b97f24590fb79d2c",
+    "zh:dbd9cd975206a41a9c12006d3a30c77b95c0e660fcba2cc3bb0ee5779431c107",
+    "zh:e6ea2e0f142001b7f2229e8d39eb7f8037084723861be9d53478005196cd7f9e",
+  ]
+}

--- a/terraform/prev-rust-lang-org/README.md
+++ b/terraform/prev-rust-lang-org/README.md
@@ -1,0 +1,6 @@
+# prev.rust-lang.org
+
+This directory contains the Terraform configuration for `prev.rust-lang.org`.
+
+The CloudFront Function redirects traffic to `https://rust-lang.org`, preserving
+the incoming request path.

--- a/terraform/prev-rust-lang-org/_terraform.tf
+++ b/terraform/prev-rust-lang-org/_terraform.tf
@@ -1,0 +1,24 @@
+// Configuration for Terraform itself.
+
+terraform {
+  required_version = "~> 1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "= 6.41.0"
+    }
+  }
+
+  backend "s3" {
+    bucket         = "rust-terraform"
+    key            = "simpleinfra/prev-rust-lang-org.tfstate"
+    region         = "us-west-1"
+    dynamodb_table = "terraform-state-lock"
+    encrypt        = true
+  }
+}
+
+provider "aws" {
+  region = "us-west-1"
+}

--- a/terraform/prev-rust-lang-org/main.tf
+++ b/terraform/prev-rust-lang-org/main.tf
@@ -1,0 +1,76 @@
+data "aws_route53_zone" "rust_lang_org" {
+  name = "rust-lang.org"
+}
+
+resource "aws_cloudfront_function" "prev_rust_lang_org_redirect" {
+  name    = "prev-rust-lang-org-redirect"
+  comment = "Redirect prev.rust-lang.org to rust-lang.org"
+  runtime = "cloudfront-js-2.0"
+  publish = true
+  code    = file("${path.module}/prev_rust_lang_org_redirect.js")
+}
+
+resource "aws_cloudfront_distribution" "prev_rust_lang_org" {
+  comment = "prev.rust-lang.org"
+
+  enabled             = true
+  wait_for_deployment = true
+  is_ipv6_enabled     = true
+  price_class         = "PriceClass_All"
+  http_version        = "http2"
+  default_root_object = ""
+
+  aliases = [
+    "prev.rust-lang.org",
+  ]
+
+  viewer_certificate {
+    acm_certificate_arn      = "arn:aws:acm:us-east-1:890664054962:certificate/0633f4b2-8a1f-46f8-a2d3-184c461a2eb8"
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  default_cache_behavior {
+    target_origin_id       = "placeholder"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+
+    cache_policy_id            = "658327ea-f89d-4fab-a63d-7e88639e58f6"
+    response_headers_policy_id = "67f7725c-6f97-4210-82d7-5512b31e9d03"
+
+    function_association {
+      event_type   = "viewer-request"
+      function_arn = aws_cloudfront_function.prev_rust_lang_org_redirect.arn
+    }
+  }
+
+  # CloudFront still requires a default origin, even though the viewer-request
+  # function returns the redirect response before any origin fetch occurs.
+  origin {
+    origin_id   = "placeholder"
+    domain_name = "example.com"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+}
+
+resource "aws_route53_record" "prev_rust_lang_org" {
+  zone_id = data.aws_route53_zone.rust_lang_org.zone_id
+  name    = "prev.rust-lang.org"
+  type    = "CNAME"
+  ttl     = 10800
+  records = [aws_cloudfront_distribution.prev_rust_lang_org.domain_name]
+}

--- a/terraform/prev-rust-lang-org/prev_rust_lang_org_redirect.js
+++ b/terraform/prev-rust-lang-org/prev_rust_lang_org_redirect.js
@@ -1,0 +1,16 @@
+function handler(event) {
+    var request = event.request;
+
+    return {
+        statusCode: 301,
+        statusDescription: "Moved Permanently",
+        headers: {
+            location: {
+                value: "https://rust-lang.org" + request.uri,
+            },
+            "cache-control": {
+                value: "public, max-age=3600",
+            },
+        },
+    };
+}


### PR DESCRIPTION
The route 53 and cloudfront resources already exist outside Terraform, so I import them before the apply:

```sh
terraform import aws_route53_record.prev_rust_lang_org Z237AC8WS9NFCS_prev.rust-lang.org_CNAME
terraform import aws_cloudfront_distribution.prev_rust_lang_org E3FXMWVQPNRDC2
```

Related to https://github.com/rust-lang/www.rust-lang.org/issues/2102

Query strings are not preserved for simplicity because I don't think they were used in the old website. But we can always change this if needed.