### PR TITLE
fastly: return 429 when rate limiting with ngwaf

### DIFF
--- a/terragrunt/modules/crates-io/fastly-webapp-ngwaf.tf
+++ b/terragrunt/modules/crates-io/fastly-webapp-ngwaf.tf
@@ -97,8 +97,9 @@ resource "fastly_ngwaf_workspace_rule" "webapp_per_ip_rate_limit" {
 
   # If the workspace mode isn't "block", then this rule is not enforced.
   action {
-    signal = "site.webapp-rate-limit"
-    type   = "block_signal"
+    signal        = "site.webapp-rate-limit"
+    type          = "block_signal"
+    response_code = 429
   }
 
   # If an IP sends 600 req in 10 minutes, block them for 5 minutes.


### PR DESCRIPTION
It seems that we should configure the status code returned by this waf rule. Since we are rate-limiting, clients will expect HTTP 429 instead of HTTP 406, which is the default for ngwaf workspace rules.

<img width="1252" height="690" alt="screenshot-2026-04-27 at 18 28 29" src="https://github.com/user-attachments/assets/ab430730-dcc1-404f-901a-9dec94ece27f" />

Also worths checking :

<details>
<summary>terragrunt plan</summary>

```
Terraform will perform the following actions:
  # fastly_ngwaf_workspace_rule.webapp_per_ip_rate_limit will be updated in-place
  ~ resource "fastly_ngwaf_workspace_rule" "webapp_per_ip_rate_limit" {
        id              = "69981dbcaab0692d53dedd17"
        # (6 unchanged attributes hidden)
      ~ action {
          ~ response_code     = 0 -> 429
            # (5 unchanged attributes hidden)
        }
        # (2 unchanged blocks hidden)
    }
```

</details>