### PR TITLE
crater: disable more kernel modules

### DIFF
--- a/terraform/crater/startup-script.sh
+++ b/terraform/crater/startup-script.sh
@@ -6,6 +6,17 @@ set -euo pipefail
 echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif.conf
 sudo rmmod algif_aead 2>/dev/null || true
 
+# Workaroud for dirtyfrag
+# https://github.com/V4bel/dirtyfrag/blob/master/README.md#mitigation
+# https://ubuntu.com/blog/dirty-frag-linux-vulnerability-fixes-available
+sudo tee /etc/modprobe.d/dirtyfrag.conf > /dev/null <<'EOF'
+install esp4 /bin/false
+install esp6 /bin/false
+install rxrpc /bin/false
+EOF
+sudo rmmod esp4 esp6 rxrpc 2>/dev/null || true
+sudo echo 3 > /proc/sys/vm/drop_caches || true
+
 mkdir -p /opt
 cd /opt
 sudo apt update


### PR DESCRIPTION
Mitigation for [dirtyfrag](https://github.com/V4bel/dirtyfrag/blob/master/README.md#mitigation). I took the one-liner and made it more readable, hopefully

Terraform plan will run with

<details>
<summary>terraform plan</summary>

```text
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place
+/- create replacement and then destroy

Terraform will perform the following actions:

  # google_compute_instance_template.agent["c2d-highcpu-8"] must be replaced
+/- resource "google_compute_instance_template" "agent" {
      ~ id                   = "projects/rust-crater/global/instanceTemplates/crater-agent-20260429215204591300000001" -> (known after apply)
      - labels               = {} -> null
      ~ metadata             = { # forces replacement
          ~ "startup-script" = <<-EOT
                #!/bin/bash

                set -euo pipefail

                # Disable the algif_aead kernel module to mitigate CVE-2026-31431
                echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif.conf
                sudo rmmod algif_aead 2>/dev/null || true

              + # Workaroud for dirtyfrag
              + # https://github.com/V4bel/dirtyfrag/blob/master/README.md#mitigation
              + sudo tee /etc/modprobe.d/dirtyfrag.conf > /dev/null <<'EOF'
              + install esp4 /bin/false
              + install esp6 /bin/false
              + install rxrpc /bin/false
              + EOF
              + sudo rmmod esp4 esp6 rxrpc 2>/dev/null || true
              + sudo echo 3 > /proc/sys/vm/drop_caches || true
              +
                mkdir -p /opt
                cd /opt
                sudo apt update
                sudo apt install -y vim jq docker.io unzip

                # Install aws cli per instructions (https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
                curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
                unzip awscliv2.zip
                sudo ./aws/install

                sudo systemctl unmask docker.service
                sudo systemctl start docker.service

                aws sts assume-role-with-web-identity \
                    --role-arn arn:aws:iam::890664054962:role/crater-agent \
                    --role-session-name $(hostname) \
                    --duration-seconds 900 \
                    --web-identity-token $(curl \
                        -H "Metadata-Flavor: Google" \
                        'http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?audience=aws') \
                > credentials

                export AWS_ACCESS_KEY_ID="$(jq -r .Credentials.AccessKeyId credentials)"
                export AWS_SECRET_ACCESS_KEY="$(jq -r .Credentials.SecretAccessKey credentials)"
                export AWS_SESSION_TOKEN="$(jq -r .Credentials.SessionToken credentials)"

                rm credentials # Remove the raw file on disk, no need for that to exist

                AGENT_TOKEN=$(aws --region us-west-1 \
                    --output text --query Parameter.Value \
                    ssm get-parameter \
                    --name /prod/ansible/crater-gcp-2/crater-token \
                    --with-decryption)

                aws ecr get-login-password --region us-west-1 | docker login --username AWS --password-stdin 890664054962.dkr.ecr.us-west-1.amazonaws.com/crater

                docker pull 890664054962.dkr.ecr.us-west-1.amazonaws.com/crater

                mkdir -p /var/lib/crater-agent-workspace

                # Mount the local SSD as the Crater workspace
                sudo mkfs.ext4 -F /dev/disk/by-id/google-local-nvme-ssd-0
                sudo mount /dev/disk/by-id/google-local-nvme-ssd-0 /var/lib/crater-agent-workspace
                sudo chmod a+rwx /var/lib/crater-agent-workspace

                curl http://metadata.google.internal/computeMetadata/v1/instance/attributes/update-script \
                    -o /opt/update.sh \
                    -H "Metadata-Flavor: Google"

                chmod +x /opt/update.sh

                # Run update task every 5 minutes
                sudo systemd-run --unit crater-agent-update --on-calendar='*:0/5' /opt/update.sh

                systemd-run \
                    --unit crater-agent \
                    docker run --init --rm --name crater-agent \
                        -v /var/lib/crater-agent-workspace:/workspace \
                        -v /var/run/docker.sock:/var/run/docker.sock \
                        -e RUST_LOG=crater=trace,rustwide=info \
                        -p 4343:4343 \
                        890664054962.dkr.ecr.us-west-1.amazonaws.com/crater \
                        agent https://crater.rust-lang.org \
                        $AGENT_TOKEN \
                        --threads 8
            EOT
            # (1 unchanged element hidden)
        }
      ~ metadata_fingerprint = "iVPD6UYxCpQ=" -> (known after apply)
      ~ name                 = "crater-agent-20260429215204591300000001" -> (known after apply)
      + region               = (known after apply)
      ~ self_link            = "https://www.googleapis.com/compute/v1/projects/rust-crater/global/instanceTemplates/crater-agent-20260429215204591300000001" -> (known after apply)
      ~ self_link_unique     = "https://www.googleapis.com/compute/v1/projects/rust-crater/global/instanceTemplates/crater-agent-20260429215204591300000001?uniqueId=1059478644413416299" -> (known after apply)
      - tags                 = [] -> null
      + tags_fingerprint     = (known after apply)
        # (9 unchanged attributes hidden)

      ~ confidential_instance_config (known after apply)

      ~ disk {
          ~ device_name           = "persistent-disk-0" -> (known after apply)
          ~ interface             = "SCSI" -> (known after apply)
          - labels                = {} -> null
          ~ mode                  = "READ_WRITE" -> (known after apply)
          ~ provisioned_iops      = 0 -> (known after apply)
          - resource_manager_tags = {} -> null
          - resource_policies     = [] -> null
          ~ source_image          = "projects/ubuntu-os-cloud/global/images/ubuntu-minimal-2404-noble-amd64-v20260429" -> "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-2404-noble-amd64-v20260507" # forces replacement
          ~ type                  = "PERSISTENT" -> (known after apply)
            # (7 unchanged attributes hidden)
        }
      ~ disk {
          ~ device_name           = "local-ssd-0" -> (known after apply)
          - labels                = {} -> null
          ~ mode                  = "READ_WRITE" -> (known after apply)
          ~ provisioned_iops      = 0 -> (known after apply)
          - resource_manager_tags = {} -> null
          - resource_policies     = [] -> null
          + source_image          = (known after apply)
            # (9 unchanged attributes hidden)
        }

      ~ network_interface {
          ~ internal_ipv6_prefix_length = 0 -> (known after apply)
          + ipv6_access_type            = (known after apply)
          + ipv6_address                = (known after apply)
          ~ name                        = "nic0" -> (known after apply)
          ~ network                     = "https://www.googleapis.com/compute/v1/projects/rust-crater/global/networks/crater" -> "crater"
          - queue_count                 = 0 -> null
          + stack_type                  = (known after apply)
          + subnetwork                  = (known after apply)
          + subnetwork_project          = (known after apply)
            # (2 unchanged attributes hidden)

          ~ access_config {
              + nat_ip                 = (known after apply)
              ~ network_tier           = "PREMIUM" -> (known after apply)
              + public_ptr_domain_name = (known after apply)
            }
        }

      ~ scheduling {
          - instance_termination_action = "STOP" -> null # forces replacement
          - min_node_cpus               = 0 -> null
          ~ on_host_maintenance         = "TERMINATE" -> (known after apply)
            # (3 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }

  # google_compute_instance_template.agent["n2d-highcpu-16"] must be replaced
+/- resource "google_compute_instance_template" "agent" {
      ~ id                   = "projects/rust-crater/global/instanceTemplates/crater-agent-20260429215204591400000002" -> (known after apply)
      - labels               = {} -> null
      ~ metadata             = { # forces replacement
          ~ "startup-script" = <<-EOT
                #!/bin/bash

                set -euo pipefail

                # Disable the algif_aead kernel module to mitigate CVE-2026-31431
                echo "install algif_aead /bin/false" | sudo tee /etc/modprobe.d/disable-algif.conf
                sudo rmmod algif_aead 2>/dev/null || true

              + # Workaroud for dirtyfrag
              + # https://github.com/V4bel/dirtyfrag/blob/master/README.md#mitigation
              + sudo tee /etc/modprobe.d/dirtyfrag.conf > /dev/null <<'EOF'
              + install esp4 /bin/false
              + install esp6 /bin/false
              + install rxrpc /bin/false
              + EOF
              + sudo rmmod esp4 esp6 rxrpc 2>/dev/null || true
              + sudo echo 3 > /proc/sys/vm/drop_caches || true
              +
                mkdir -p /opt
                cd /opt
                sudo apt update
                sudo apt install -y vim jq docker.io unzip

                # Install aws cli per instructions (https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
                curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
                unzip awscliv2.zip
                sudo ./aws/install

                sudo systemctl unmask docker.service
                sudo systemctl start docker.service

                aws sts assume-role-with-web-identity \
                    --role-arn arn:aws:iam::890664054962:role/crater-agent \
                    --role-session-name $(hostname) \
                    --duration-seconds 900 \
                    --web-identity-token $(curl \
                        -H "Metadata-Flavor: Google" \
                        'http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?audience=aws') \
                > credentials

                export AWS_ACCESS_KEY_ID="$(jq -r .Credentials.AccessKeyId credentials)"
                export AWS_SECRET_ACCESS_KEY="$(jq -r .Credentials.SecretAccessKey credentials)"
                export AWS_SESSION_TOKEN="$(jq -r .Credentials.SessionToken credentials)"

                rm credentials # Remove the raw file on disk, no need for that to exist

                AGENT_TOKEN=$(aws --region us-west-1 \
                    --output text --query Parameter.Value \
                    ssm get-parameter \
                    --name /prod/ansible/crater-gcp-2/crater-token \
                    --with-decryption)

                aws ecr get-login-password --region us-west-1 | docker login --username AWS --password-stdin 890664054962.dkr.ecr.us-west-1.amazonaws.com/crater

                docker pull 890664054962.dkr.ecr.us-west-1.amazonaws.com/crater

                mkdir -p /var/lib/crater-agent-workspace

                # Mount the local SSD as the Crater workspace
                sudo mkfs.ext4 -F /dev/disk/by-id/google-local-nvme-ssd-0
                sudo mount /dev/disk/by-id/google-local-nvme-ssd-0 /var/lib/crater-agent-workspace
                sudo chmod a+rwx /var/lib/crater-agent-workspace

                curl http://metadata.google.internal/computeMetadata/v1/instance/attributes/update-script \
                    -o /opt/update.sh \
                    -H "Metadata-Flavor: Google"

                chmod +x /opt/update.sh

                # Run update task every 5 minutes
                sudo systemd-run --unit crater-agent-update --on-calendar='*:0/5' /opt/update.sh

                systemd-run \
                    --unit crater-agent \
                    docker run --init --rm --name crater-agent \
                        -v /var/lib/crater-agent-workspace:/workspace \
                        -v /var/run/docker.sock:/var/run/docker.sock \
                        -e RUST_LOG=crater=trace,rustwide=info \
                        -p 4343:4343 \
                        890664054962.dkr.ecr.us-west-1.amazonaws.com/crater \
                        agent https://crater.rust-lang.org \
                        $AGENT_TOKEN \
                        --threads 8
            EOT
            # (1 unchanged element hidden)
        }
      ~ metadata_fingerprint = "iVPD6UYxCpQ=" -> (known after apply)
      ~ name                 = "crater-agent-20260429215204591400000002" -> (known after apply)
      + region               = (known after apply)
      ~ self_link            = "https://www.googleapis.com/compute/v1/projects/rust-crater/global/instanceTemplates/crater-agent-20260429215204591400000002" -> (known after apply)
      ~ self_link_unique     = "https://www.googleapis.com/compute/v1/projects/rust-crater/global/instanceTemplates/crater-agent-20260429215204591400000002?uniqueId=5272572688246752107" -> (known after apply)
      - tags                 = [] -> null
      + tags_fingerprint     = (known after apply)
        # (9 unchanged attributes hidden)

      ~ confidential_instance_config (known after apply)

      ~ disk {
          ~ device_name           = "persistent-disk-0" -> (known after apply)
          ~ interface             = "SCSI" -> (known after apply)
          - labels                = {} -> null
          ~ mode                  = "READ_WRITE" -> (known after apply)
          ~ provisioned_iops      = 0 -> (known after apply)
          - resource_manager_tags = {} -> null
          - resource_policies     = [] -> null
          ~ source_image          = "projects/ubuntu-os-cloud/global/images/ubuntu-minimal-2404-noble-amd64-v20260429" -> "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-2404-noble-amd64-v20260507" # forces replacement
          ~ type                  = "PERSISTENT" -> (known after apply)
            # (7 unchanged attributes hidden)
        }
      ~ disk {
          ~ device_name           = "local-ssd-0" -> (known after apply)
          - labels                = {} -> null
          ~ mode                  = "READ_WRITE" -> (known after apply)
          ~ provisioned_iops      = 0 -> (known after apply)
          - resource_manager_tags = {} -> null
          - resource_policies     = [] -> null
          + source_image          = (known after apply)
            # (9 unchanged attributes hidden)
        }

      ~ network_interface {
          ~ internal_ipv6_prefix_length = 0 -> (known after apply)
          + ipv6_access_type            = (known after apply)
          + ipv6_address                = (known after apply)
          ~ name                        = "nic0" -> (known after apply)
          ~ network                     = "https://www.googleapis.com/compute/v1/projects/rust-crater/global/networks/crater" -> "crater"
          - queue_count                 = 0 -> null
          + stack_type                  = (known after apply)
          + subnetwork                  = (known after apply)
          + subnetwork_project          = (known after apply)
            # (2 unchanged attributes hidden)

          ~ access_config {
              + nat_ip                 = (known after apply)
              ~ network_tier           = "PREMIUM" -> (known after apply)
              + public_ptr_domain_name = (known after apply)
            }
        }

      ~ scheduling {
          - instance_termination_action = "STOP" -> null # forces replacement
          - min_node_cpus               = 0 -> null
          ~ on_host_maintenance         = "TERMINATE" -> (known after apply)
            # (3 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }

  # google_compute_region_instance_group_manager.agents["us-central1-c2d"] will be updated in-place
  ~ resource "google_compute_region_instance_group_manager" "agents" {
        id                               = "projects/rust-crater/regions/us-central1/instanceGroupManagers/crater-agents-v2-us-central1-c2d"
        name                             = "crater-agents-v2-us-central1-c2d"
        # (16 unchanged attributes hidden)

      ~ version {
          ~ instance_template = "https://www.googleapis.com/compute/v1/projects/rust-crater/global/instanceTemplates/crater-agent-20260429215204591300000001" -> (known after apply)
            name              = null
        }

        # (3 unchanged blocks hidden)
    }

  # google_compute_region_instance_group_manager.agents["us-central1-n2d"] will be updated in-place
  ~ resource "google_compute_region_instance_group_manager" "agents" {
        id                               = "projects/rust-crater/regions/us-central1/instanceGroupManagers/crater-agents-v2-us-central1-n2d"
        name                             = "crater-agents-v2-us-central1-n2d"
        # (16 unchanged attributes hidden)

      ~ version {
          ~ instance_template = "https://www.googleapis.com/compute/v1/projects/rust-crater/global/instanceTemplates/crater-agent-20260429215204591400000002" -> (known after apply)
            name              = null
        }

        # (3 unchanged blocks hidden)
    }

  # google_compute_region_instance_group_manager.agents["us-east1-n2d"] will be updated in-place
  ~ resource "google_compute_region_instance_group_manager" "agents" {
        id                               = "projects/rust-crater/regions/us-east5/instanceGroupManagers/crater-agents-v2-us-east1-n2d"
        name                             = "crater-agents-v2-us-east1-n2d"
        # (16 unchanged attributes hidden)

      ~ version {
          ~ instance_template = "https://www.googleapis.com/compute/v1/projects/rust-crater/global/instanceTemplates/crater-agent-20260429215204591400000002" -> (known after apply)
            name              = null
        }

        # (3 unchanged blocks hidden)
    }

Plan: 2 to add, 3 to change, 2 to destroy.
╷
│ Warning: Argument is deprecated
│
│   with aws_eip.crater,
│   on instance.tf line 48, in resource "aws_eip" "crater":
│   48:   vpc = true
│
│ vpc is deprecated. Use domain instead.
╵

```
<details>