### PR TITLE
increase docs-rs volume speed

### DIFF
--- a/terragrunt/accounts/docs-rs-prod/docs-rs/terragrunt.hcl
+++ b/terragrunt/accounts/docs-rs-prod/docs-rs/terragrunt.hcl
@@ -27,6 +27,8 @@ inputs = {
   domain                    = "docs-rs-prod.rust-lang.net"
   bastion_security_group_id = dependency.vpc.outputs.bastion_security_group_id
   builder_instance_type     = "c6a.8xlarge" # 32 vCPU. 64 GiB RAM.
+  builder_volume_iops       = 8000
+  builder_volume_throughput = 500
   db_instance_class         = "db.m6i.large" # 2 vCPUs. 8 GiB RAM.
 
   # One-time ~10TB migration from the legacy bucket managed in terraform/docs-rs.

--- a/terragrunt/modules/docs-rs/builder.tf
+++ b/terragrunt/modules/docs-rs/builder.tf
@@ -17,6 +17,9 @@ resource "aws_instance" "builder" {
   root_block_device {
     # Size of the volume in GiB.
     volume_size           = 64
+    volume_type           = "gp3"
+    iops                  = var.builder_volume_iops
+    throughput            = var.builder_volume_throughput
     delete_on_termination = true
   }
 

--- a/terragrunt/modules/docs-rs/variables.tf
+++ b/terragrunt/modules/docs-rs/variables.tf
@@ -35,6 +35,18 @@ variable "builder_instance_type" {
   description = "The EC2 instance type for the docs-rs builder"
 }
 
+variable "builder_volume_iops" {
+  type        = number
+  description = "The provisioned IOPS for the docs-rs builder gp3 root volume."
+  default     = 3000
+}
+
+variable "builder_volume_throughput" {
+  type        = number
+  description = "The provisioned throughput in MiB/s for the docs-rs builder gp3 root volume."
+  default     = 125
+}
+
 variable "github_environment" {
   type        = string
   description = "The GitHub deployment environment used for GitHub Actions OIDC."


### PR DESCRIPTION
Note that this is for the next infrastructure environment. I already increased the speed of the volume of the EC2 used currently in production (that is not in IaC).

Discussed in [#t-docs-rs > New docs.rs infrastructure @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/356853-t-docs-rs/topic/New.20docs.2Ers.20infrastructure/near/595329915)

## Plan

staging: no changes detected

prod:


```
  ~ resource "aws_instance" "builder" {
        id                                   = "i-070b829bb64d5089f"
        tags                                 = {
            "Name" = "docs-rs-builder"
        }
        # (41 unchanged attributes hidden)

      ~ root_block_device {
          ~ iops                  = 3000 -> 8000
            tags                  = {}
          ~ throughput            = 125 -> 500
            # (8 unchanged attributes hidden)
        }

        # (7 unchanged blocks hidden)
    }
```

## AI disclosure

I used GPT5.5 with the codex harness to generate this change. I reviewed its output and no changes where necessary