### PR TITLE
Tag `manifests.txt` with surrogate key for purging

### DIFF
--- a/terragrunt/modules/release-distribution/fastly-static.tf
+++ b/terragrunt/modules/release-distribution/fastly-static.tf
@@ -104,6 +104,19 @@ resource "fastly_service_vcl" "static" {
     VCL
   }
 
+  # When a new release is published, promote-release purges the `manifeststxt`
+  # surrogate key so that `manifests.txt` updates promptly instead of lagging
+  # until TTL. This snippet tags the response with that key at request time.
+  snippet {
+    name    = "set cache key for manifests.txt"
+    type    = "fetch"
+    content = <<-VCL
+      if (req.url ~ "^\/manifests\.txt$") {
+        set beresp.http.Surrogate-Key = "manifeststxt";
+      }
+    VCL
+  }
+
   snippet {
     name    = "redirect rustup.sh to rustup.rs"
     type    = "error"


### PR DESCRIPTION
`promote-release` purges the `manifeststxt` surrogate key on every release, but nothing in the Fastly VCL tagged the https://static.rust-lang.org/manifests.txt response with that key, so the purge matched zero objects and the cached copy survived until TTL.

This adds a fetch snippet that tags `/manifests.txt` responses with the `manifeststxt` key so the existing purge takes effect.

/cc @Mark-Simulacrum @rust-lang/infra 

### Related

- Resolves https://github.com/rust-lang/simpleinfra/issues/828
- https://github.com/dependabot/dependabot-core/issues/13583
- https://github.com/dependabot/dependabot-core/pull/13604
- https://github.com/renovatebot/renovate/pull/43672