### PR TITLE
fastly: allow temp ngwaf bypass for some users

### DIFF
--- a/terragrunt/modules/crates-io/fastly-webapp-ngwaf.tf
+++ b/terragrunt/modules/crates-io/fastly-webapp-ngwaf.tf
@@ -119,3 +119,24 @@ resource "fastly_ngwaf_workspace_rule" "webapp_per_ip_rate_limit" {
     }
   }
 }
+
+# Temporary allow IN users bypass ngwaf rules
+# See :
+# https://github.com/rust-lang/crates.io/issues/13825
+# https://github.com/rust-lang/crates.io/issues/13695
+resource "fastly_ngwaf_workspace_rule" "webapp_in_temp_bypass" {
+  workspace_id = fastly_ngwaf_workspace.webapp.id
+  type         = "request"
+  description  = "Temporary allow IN users bypass ngwaf rules"
+  enabled      = true
+
+  condition {
+    field    = "country"
+    operator = "equals"
+    value    = "IN"
+  }
+
+  action {
+    type = "allow"
+  }
+}


### PR DESCRIPTION
Work around for https://github.com/rust-lang/crates.io/issues/13695 and related issues