### PR TITLE
fastly: Cache crates.io webapp responses per origin headers

### DIFF
--- a/terragrunt/modules/crates-io/fastly-webapp.tf
+++ b/terragrunt/modules/crates-io/fastly-webapp.tf
@@ -86,16 +86,6 @@ resource "fastly_service_vcl" "webapp" {
     VCL
   }
 
-  # Pass all requests to origin (no caching for API)
-  snippet {
-    name    = "pass all requests"
-    type    = "recv"
-    content = <<-VCL
-      # Don't cache any requests - pass directly to origin
-      return(pass);
-    VCL
-  }
-
   # Handle HSTS headers if strict_security_headers is enabled
   dynamic "snippet" {
     for_each = var.strict_security_headers ? [1] : []


### PR DESCRIPTION
The webapp Fastly service ran `return(pass)` in `vcl_recv` for every request, so it never cached anything. The comment said this was to avoid caching the API, but the same origin (`crates-io.herokuapp.com`) also serves the SvelteKit frontend, including immutable static assets that set `Cache-Control: public, max-age=315360000`. Those assets were never cached on the Fastly path, while the CloudFront distribution for the same origin cached them normally.

This removes the blanket pass so Fastly honors the origin's `Cache-Control`, matching CloudFront. `default_ttl = 0` stays, so responses without caching headers and per-user `no-store` responses are still not cached.

---

Created with the help of Claude Code, which:
- traced the missing cache hits to the unconditional `return(pass)` by inspecting Fastly vs CloudFront headers,
- reviewed the git history to understand why the snippet was added, and
- made the VCL change.