### PR TITLE
ngwaf: encode some values to remove plan diff

### DIFF
--- a/terragrunt/modules/crates-io/fastly-webapp-ngwaf.tf
+++ b/terragrunt/modules/crates-io/fastly-webapp-ngwaf.tf
@@ -125,10 +125,12 @@ resource "fastly_ngwaf_workspace_rule" "webapp_per_ip_rate_limit" {
 # https://github.com/rust-lang/crates.io/issues/13825
 # https://github.com/rust-lang/crates.io/issues/13695
 resource "fastly_ngwaf_workspace_rule" "webapp_in_temp_bypass" {
-  workspace_id = fastly_ngwaf_workspace.webapp.id
-  type         = "request"
-  description  = "Temporary allow IN users bypass ngwaf rules"
-  enabled      = true
+  workspace_id    = fastly_ngwaf_workspace.webapp.id
+  type            = "request"
+  description     = "Temporary allow IN users bypass ngwaf rules"
+  enabled         = true
+  group_operator  = "all"
+  request_logging = "sampled"
 
   condition {
     field    = "country"


### PR DESCRIPTION
no need to apply, as this change removes the terragrunt plan diff