### PR TITLE
create new cert for prev and beta

### DIFF
--- a/terraform/prev-rust-lang-org/_terraform.tf
+++ b/terraform/prev-rust-lang-org/_terraform.tf
@@ -22,3 +22,8 @@ terraform {
 provider "aws" {
   region = "us-west-1"
 }
+
+provider "aws" {
+  alias  = "us-east-1"
+  region = "us-east-1"
+}

--- a/terraform/prev-rust-lang-org/beta_rust_lang_org.tf
+++ b/terraform/prev-rust-lang-org/beta_rust_lang_org.tf
@@ -21,7 +21,7 @@ resource "aws_cloudfront_distribution" "beta_rust_lang_org" {
   ]
 
   viewer_certificate {
-    acm_certificate_arn      = "arn:aws:acm:us-east-1:890664054962:certificate/0633f4b2-8a1f-46f8-a2d3-184c461a2eb8"
+    acm_certificate_arn      = module.certificate.arn
     ssl_support_method       = "sni-only"
     minimum_protocol_version = "TLSv1.1_2016"
   }

--- a/terraform/prev-rust-lang-org/main.tf
+++ b/terraform/prev-rust-lang-org/main.tf
@@ -2,6 +2,20 @@ data "aws_route53_zone" "rust_lang_org" {
   name = "rust-lang.org"
 }
 
+module "certificate" {
+  source = "../shared/modules/acm-certificate"
+
+  providers = {
+    aws = aws.us-east-1
+  }
+
+  # Exclude www.rust-lang.org because it's managed by GitHub Pages
+  domains = [
+    "prev.rust-lang.org",
+    "beta.rust-lang.org",
+  ]
+}
+
 resource "aws_cloudfront_function" "prev_rust_lang_org_redirect" {
   name    = "prev-rust-lang-org-redirect"
   comment = "Redirect prev.rust-lang.org to rust-lang.org"
@@ -25,7 +39,7 @@ resource "aws_cloudfront_distribution" "prev_rust_lang_org" {
   ]
 
   viewer_certificate {
-    acm_certificate_arn      = "arn:aws:acm:us-east-1:890664054962:certificate/0633f4b2-8a1f-46f8-a2d3-184c461a2eb8"
+    acm_certificate_arn      = module.certificate.arn
     ssl_support_method       = "sni-only"
     minimum_protocol_version = "TLSv1.2_2021"
   }

--- a/terraform/prev-rust-lang-org/outputs.tf
+++ b/terraform/prev-rust-lang-org/outputs.tf
@@ -1,0 +1,4 @@
+output "certificate_arn" {
+  value       = module.certificate.arn
+  description = "ARN of the ACM certificate for prev.rust-lang.org and beta.rust-lang.org."
+}


### PR DESCRIPTION
The old certificate also had `www.rust-lang.org` which is now in github actions.
So I create a new certificate just for these two. This PR solves an error that AWS sent via email to us.

## AI disclosure

I used GPT5.5 with the codex harness to generate this change. I reviewed its output and changed it where necessary.