### PR TITLE
crates-io: Forward index.crates.io request logs to Datadog

### DIFF
--- a/terragrunt/modules/crates-io/fastly-index.tf
+++ b/terragrunt/modules/crates-io/fastly-index.tf
@@ -26,6 +26,11 @@ resource "fastly_service_vcl" "index" {
 
   default_ttl = local.index_default_ttl
 
+  logging_datadog {
+    name  = "datadog-index-${var.index_domain_name}"
+    token = data.aws_ssm_parameter.datadog_token.value
+  }
+
   logging_s3 {
     name        = "s3-request-logs"
     bucket_name = aws_s3_bucket.logs.bucket


### PR DESCRIPTION
Adds a `logging_datadog` block to the `index.crates.io` Fastly service so its request logs reach Datadog, the same way the webapp and static services already do.

The block reuses the existing module-scoped `datadog-token` SSM parameter, so I think no new credentials should be needed. The existing S3 request logging (`/fastly-requests/index.crates.io/`) is left untouched and keeps flowing alongside the new Datadog stream.

/cc @rust-lang/infra 