### PR TITLE
import datadog roles changes

### DIFF
--- a/terraform/team-members-datadog/secrets-scanner.tf
+++ b/terraform/team-members-datadog/secrets-scanner.tf
@@ -1,0 +1,23 @@
+locals {
+  secrets_scanner_access = {
+    "tobias" = local.users.tobias
+  }
+}
+
+resource "datadog_role" "secrets_scanner_access" {
+  name = "Secrets Scanner Access"
+
+  dynamic "permission" {
+    for_each = toset([
+      data.datadog_permissions.all.permissions.data_scanner_read,
+      data.datadog_permissions.all.permissions.data_scanner_unmask,
+      data.datadog_permissions.all.permissions.data_scanner_write,
+
+    ])
+
+    content {
+      id = permission.value
+    }
+  }
+}
+

--- a/terraform/team-members-datadog/users.tf
+++ b/terraform/team-members-datadog/users.tf
@@ -100,6 +100,7 @@ locals {
     { for name, user in local.foundation_board : name => merge(user, { roles = [datadog_role.board_member.name] }) },
     { for name, user in local.infra : name => merge(user, { roles = [datadog_role.infra.name] }) },
     { for name, user in local.infra_admins : name => merge(user, { roles = ["Datadog Admin Role"] }) },
+    { for name, user in local.secrets_scanner_access : name => merge(user, { roles = [datadog_role.secrets_scanner_access.name] }) },
   ]
 
   # This is an intermediate list that contains a single entry per user, but only with the roles from the first team.


### PR DESCRIPTION
The role secrets_scanner_access was created manually and Tobi was added to it. This PR reflects this change in terraform. I ran `terraform import datadog_role.secrets_scanner_access 91261718-6043-11f1-a443-da7ad0900002`.

The plan is clean, so there's nothing to apply.