### PR TITLE
ansible: configure ubuntu pro

### DIFF
--- a/ansible/envs/prod/group_vars/all.yml
+++ b/ansible/envs/prod/group_vars/all.yml
@@ -7,4 +7,6 @@ vars_datadog_api_key: "{{ ssm_all['datadog-api-key'] }}"
 
 vars_papertrail_url: "{{ ssm_all['papertrail-url'] }}"
 
+vars_ubuntu_pro_token: "{{ ssm_all['ubuntu-pro-token'] }}"
+
 vars_letsencrypt_dummy_certs: false

--- a/ansible/envs/staging/group_vars/all.yml
+++ b/ansible/envs/staging/group_vars/all.yml
@@ -5,6 +5,8 @@ ssm_all: "{{ lookup('aws_ssm', '/staging/ansible/all/', region='us-west-1', shor
 
 vars_datadog_api_key: "{{ ssm_all['datadog-api-key'] }}"
 
+vars_ubuntu_pro_token: "{{ ssm_all['ubuntu-pro-token'] }}"
+
 # Do not log to Papertrail in the staging environment.
 vars_papertrail_url: null
 

--- a/ansible/roles/common/README.md
+++ b/ansible/roles/common/README.md
@@ -11,6 +11,7 @@ Currently it does these things:
 * Remove the default `ubuntu` user
 * Configure backup manifests
 * Setup [Prometheus]'s [node-exporter] to expose system metrics
+* Attach Ubuntu hosts to Ubuntu Pro
 
 [Prometheus]: https://prometheus.io
 [node-exporter]: https://github.com/prometheus/node_exporter
@@ -57,6 +58,11 @@ want to preserve.
   # Papertrail logs collection URL. [optional]
   # If the URL is missing logs will not be shipped to Papertrail.
   papertrail_url: logsN.papertrailapp.com:NNNNN
+
+  # Ubuntu Pro token used to attach Ubuntu hosts. [required for Ubuntu hosts]
+  # Production and staging load this from the `ubuntu-pro-token` SSM key under
+  # their `/ansible/all/` path.
+  ubuntu_pro_token: "{{ vars_ubuntu_pro_token }}"
 ```
 
 ## Unattended Upgrades

--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -7,3 +7,4 @@ collect_metrics_from: []
 avoid_removing_docker_users: []
 papertrail_url: null
 allow_ssh_extra_groups: ""
+ubuntu_pro_token: "{{ vars_ubuntu_pro_token }}"

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -1,6 +1,9 @@
 ---
 
 - include_tasks: apt.yml
+- include_tasks: ubuntu-pro.yml
+  when:
+    - ansible_distribution | default("") == "Ubuntu"
 - include_tasks: kernel.yml
 - include_tasks: users.yml
 - include_tasks: ssh.yml

--- a/ansible/roles/common/tasks/ubuntu-pro.yml
+++ b/ansible/roles/common/tasks/ubuntu-pro.yml
@@ -1,0 +1,69 @@
+---
+
+- name: ensure Ubuntu Pro token is configured
+  assert:
+    that:
+      - ubuntu_pro_token | default("", true) | trim | length > 0
+    fail_msg: >-
+      ubuntu_pro_token must be configured for Ubuntu host {{ inventory_hostname }}.
+
+- name: check Ubuntu Pro attachment status
+  command:
+    argv:
+      - pro
+      - status
+      - --format
+      - json
+  register: ubuntu_pro_status
+  changed_when: false
+  check_mode: false
+  no_log: true
+
+- name: record Ubuntu Pro attachment status
+  set_fact:
+    ubuntu_pro_is_attached: >-
+      {{ ((ubuntu_pro_status.stdout | from_json).attached | default(false)) | bool }}
+  no_log: true
+
+- name: attach Ubuntu Pro subscription
+  when:
+    - not ansible_check_mode
+    - not ubuntu_pro_is_attached
+  no_log: true
+  block:
+    # Keep the token out of the process arguments: `pro attach <token>` can be
+    # exposed through process listings while the command is running.
+    # Instead, write the token to a temporary config file.
+    # Writing to a file should be allowed to users with sudo permission.
+    - name: write temporary Ubuntu Pro attach config
+      copy:
+        dest: /root/.ubuntu-pro-attach.yml
+        content: "token: {{ ubuntu_pro_token | trim | to_json }}\n"
+        owner: root
+        group: root
+        mode: "0600"
+
+    - name: attach Ubuntu Pro subscription
+      command:
+        argv:
+          - pro
+          - attach
+          - --attach-config
+          - /root/.ubuntu-pro-attach.yml
+      register: ubuntu_pro_attach
+      changed_when: ubuntu_pro_attach.rc == 0
+      failed_when: ubuntu_pro_attach.rc not in [0, 2]
+  always:
+    - name: remove temporary Ubuntu Pro attach config
+      file:
+        path: /root/.ubuntu-pro-attach.yml
+        state: absent
+
+# `pro attach` can enable Ubuntu Pro apt sources such as ESM. Refresh the
+# package index so later apt tasks see the newly available repositories.
+- name: update apt cache after Ubuntu Pro attachment
+  apt:
+    update_cache: true
+  when:
+    - ubuntu_pro_attach is defined
+    - ubuntu_pro_attach is changed


### PR DESCRIPTION
This makes ubuntu pro mandatory for ubuntu VMs managed in ansible. I'm fine removing this requirement if there's a good reason for it 👍
But generally, ansible is for long running VMs so I guess it makes sense.
Also we have more than double the licenses we need, so lack of licenses shouldn't be an issue.

I added the token as a secure string in AWS Parameter Store at the following paths:

- `/prod/ansible/all/ubuntu-pro-token`
- `/staging/ansible/all/ubuntu-pro-token`

## AI disclosure

I used GPT5.5 with the codex harness to generate this change. I reviewed its output and changed it where necessary.