### PR TITLE
ubuntu pro: warn if livepatch is disabled

### DIFF
--- a/ansible/roles/common/tasks/ubuntu-pro-status.yml
+++ b/ansible/roles/common/tasks/ubuntu-pro-status.yml
@@ -1,0 +1,32 @@
+---
+
+- name: query Ubuntu Pro status
+  command:
+    argv:
+      - pro
+      - status
+      - --format
+      - json
+  register: ubuntu_pro_status
+  changed_when: false
+  check_mode: false
+  no_log: true
+
+- name: record current Ubuntu Pro status
+  set_fact:
+    ubuntu_pro_current_status: "{{ ubuntu_pro_status.stdout | from_json }}"
+  no_log: true
+
+- name: record current Ubuntu Pro attachment and livepatch status
+  set_fact:
+    ubuntu_pro_is_attached: >-
+      {{ (ubuntu_pro_current_status.attached | default(false)) | bool }}
+    ubuntu_pro_livepatch_status: >-
+      {{
+        ubuntu_pro_current_status.services | default([])
+        | selectattr("name", "equalto", "livepatch")
+        | map(attribute="status")
+        | first
+        | default("unknown", true)
+      }}
+  no_log: true

--- a/ansible/roles/common/tasks/ubuntu-pro.yml
+++ b/ansible/roles/common/tasks/ubuntu-pro.yml
@@ -7,23 +7,8 @@
     fail_msg: >-
       ubuntu_pro_token must be configured for Ubuntu host {{ inventory_hostname }}.
 
-- name: check Ubuntu Pro attachment status
-  command:
-    argv:
-      - pro
-      - status
-      - --format
-      - json
-  register: ubuntu_pro_status
-  changed_when: false
-  check_mode: false
-  no_log: true
-
-- name: record Ubuntu Pro attachment status
-  set_fact:
-    ubuntu_pro_is_attached: >-
-      {{ ((ubuntu_pro_status.stdout | from_json).attached | default(false)) | bool }}
-  no_log: true
+- name: check Ubuntu Pro status
+  include_tasks: ubuntu-pro-status.yml
 
 - name: attach Ubuntu Pro subscription
   when:
@@ -67,3 +52,21 @@
   when:
     - ubuntu_pro_attach is defined
     - ubuntu_pro_attach is changed
+
+- name: refresh Ubuntu Pro status after attachment
+  include_tasks: ubuntu-pro-status.yml
+  when:
+    - ubuntu_pro_attach is defined
+    - ubuntu_pro_attach is changed
+
+- name: warn when Ubuntu Pro livepatch is not enabled
+  debug:
+    msg: >-
+      WARNING: Ubuntu Pro livepatch is {{ ubuntu_pro_livepatch_status }} on
+      {{ inventory_hostname }}. Run `pro status` to troubleshoot.
+      If you need to update the kernel, run `sudo apt update && sudo apt full-upgrade`,
+      restart the machine, and check
+      `pro status` again to confirm livepatch is enabled.
+  when:
+    - ubuntu_pro_is_attached
+    - ubuntu_pro_livepatch_status != "enabled"


### PR DESCRIPTION
sometimes livepatch is disabled in ubuntu pro and I need to run `apt full-upgrade` and restart the machine to enable it.
When applying ansible it is easy to forget to run pro status to check if livepatch is enabled. 

This PR adds a step in ansible that warns the user if livepatch is disabled.

## AI disclosure

I used GPT5.5 with the codex harness to generate this change. I reviewed its output and changed it where necessary.