### PR TITLE
crates.io: Encode all `+` characters in static-router URI

### DIFF
--- a/terragrunt/modules/crates-io/cloudfront-functions/static-router.js
+++ b/terragrunt/modules/crates-io/cloudfront-functions/static-router.js
@@ -5,7 +5,7 @@ function handler(event) {
     // URL-encode the `+` character in the request URI
     // See more: https://github.com/rust-lang/crates.io/issues/4891
     if (request.uri.includes("+")) {
-        request.uri = request.uri.replace("+", "%2B");
+        request.uri = request.uri.replace(/\+/g, "%2B");
     } else if (request.uri === versionDownloads) {
         request.uri += 'index.html';
         return request;


### PR DESCRIPTION
`static-router.js` used `request.uri.replace("+", "%2B")`, which with a string argument only replaces the first `+`. The Fastly Compute service uses Rust `str::replace()`, which replaces all occurrences. This switches CloudFront to a global regex to match.

The `cloudfront-js-1.0` runtime is ES5.1-based and doesn't support `replaceAll()`, so the global regex form is used.

r? @rust-lang/infra 

### Related
- https://github.com/rust-lang/crates.io/issues/4891