### PR TITLE
crates-io/compute-static: Rename build target to `wasm32-wasip1`

### DIFF
--- a/terragrunt/modules/crates-io/compute-static/.cargo/config.toml
+++ b/terragrunt/modules/crates-io/compute-static/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"


### PR DESCRIPTION
The `wasm32-wasi` target was renamed to `wasm32-wasip1` upstream and removed in Rust 1.84. 349c667 migrated `fastly.toml` and `rust-toolchain.toml`, but missed `.cargo/config.toml`, which still pinned the old name and broke `cargo metadata` for the current toolchain.

r? @rust-lang/infra 