### PR TITLE
dev-desktops: add a few additional packages

### DIFF
--- a/ansible/roles/dev-desktop/tasks/dependencies.yml
+++ b/ansible/roles/dev-desktop/tasks/dependencies.yml
@@ -20,12 +20,16 @@
       - g++-14-aarch64-linux-gnu # Required for functional clang++ when libgcc-14-dev is installed
       - gcc-mingw-w64-x86-64 # Allows running `x check --target x86_64-pc-windows-gnu`
       - gh
+      - git-delta
       - jq
       - tidy # Format and diff html for rustdoc
       - cvise
       - libssl-dev
       - llvm
+      - moreutils
+      - musl-tools
       - ninja-build
+      - patchutils
       - pkg-config
       - python-is-python3
       - python3
@@ -35,6 +39,10 @@
       - quota
       - ripgrep
       - rustfilt
+      - tree
+      - valgrind
+      - vim-fugitive
+      - vim-scripts
       - "linux-tools-{{ kernel.stdout }}"
       - "linux-tools-{{ kernel_flavor.stdout }}"
       - libatk1.0-0 # Allows running `x test rustdoc-gui`


### PR DESCRIPTION
Several of these are in the category of "my standard dotfiles break if
they're not present".

- git-delta: the `delta` command for smarter git diffs. Commonly
  configured in people's `.gitconfig`s, including mine.
- moreutils: the `errno`, `sponge`, `vidir`, and `vipe` commands are
  particularly useful.
- pathutils: `filterdiff` and `lsdiff` are quite useful.
- tree: wildly and constantly useful.
- valgrind: useful for debugging
- vim-scripts: referenced by my `.vimrc` in ways it's not
  straightforward to make conditional.
