### PR TITLE
dev-desktop: set vim alternative

### DIFF
--- a/ansible/roles/dev-desktop/tasks/dependencies.yml
+++ b/ansible/roles/dev-desktop/tasks/dependencies.yml
@@ -85,6 +85,10 @@
       - libxcb-xfixes0-dev
     state: present
 
+# neovim is installed, and a good default for people without a specific preference for classic vim
+- name: Set vim alternative
+  shell: update-alternatives --set vim /usr/bin/nvim
+
 # we don't need it because we don't need to send emails
 - name: Uninstall postfix
   apt:


### PR DESCRIPTION
The dev desktops install neovim, which accurately has a reputation for
having friendlier defaults. It's a good default for people who don't
have a specific preference for classic vim. So, use
`update-alternatives` to set `vim` to refer to neovim.
