### PR TITLE
crates-io: Wire up CDN cache tags for static.crates.io

### DIFF
--- a/terragrunt/modules/crates-io/cloudfront-static.tf
+++ b/terragrunt/modules/crates-io/cloudfront-static.tf
@@ -11,6 +11,19 @@ resource "aws_cloudfront_function" "static_router" {
   code    = file("${path.module}/cloudfront-functions/static-router.js")
 }
 
+resource "aws_cloudfront_response_headers_policy" "static" {
+  name = "${replace(var.static_domain_name, ".", "-")}--static"
+
+  // CloudFront reads the cache tags from the origin response at cache-fill time
+  // (see `cache_tag_config` below) and then forwards the header to viewers by
+  // default. Strip it here so the tags stay an origin-internal detail.
+  remove_headers_config {
+    items {
+      header = "x-amz-meta-cache-tags"
+    }
+  }
+}
+
 resource "aws_cloudfront_distribution" "static" {
   comment = var.static_domain_name
 
@@ -39,11 +52,12 @@ resource "aws_cloudfront_distribution" "static" {
   }
 
   default_cache_behavior {
-    target_origin_id       = "main-with-fallback"
-    allowed_methods        = ["GET", "HEAD"]
-    cached_methods         = ["GET", "HEAD"]
-    compress               = true
-    viewer_protocol_policy = "redirect-to-https"
+    target_origin_id           = "main-with-fallback"
+    allowed_methods            = ["GET", "HEAD"]
+    cached_methods             = ["GET", "HEAD"]
+    compress                   = true
+    viewer_protocol_policy     = "redirect-to-https"
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.static.id
 
     default_ttl = var.static_ttl
 

--- a/terragrunt/modules/crates-io/cloudfront-static.tf
+++ b/terragrunt/modules/crates-io/cloudfront-static.tf
@@ -30,6 +30,14 @@ resource "aws_cloudfront_distribution" "static" {
     ssl_support_method  = "sni-only"
   }
 
+  // At cache-fill time, CloudFront reads the comma-separated cache tags from
+  // the S3 object metadata and indexes the cached object against them. This
+  // enables tag-based invalidations (e.g. `#crate:serde`) in addition to
+  // path-based ones.
+  cache_tag_config {
+    header_name = "x-amz-meta-cache-tags"
+  }
+
   default_cache_behavior {
     target_origin_id       = "main-with-fallback"
     allowed_methods        = ["GET", "HEAD"]

--- a/terragrunt/modules/crates-io/compute-static/src/main.rs
+++ b/terragrunt/modules/crates-io/compute-static/src/main.rs
@@ -130,6 +130,7 @@ fn handle_request(config: &Config, mut request: Request) -> Result<Response, Err
     }
 
     set_ttl(config, &mut request);
+    set_surrogate_keys(&mut request);
     rewrite_urls_with_plus_character(&mut request);
     rewrite_download_urls(&mut request);
     rewrite_version_downloads_urls(&mut request);
@@ -175,6 +176,30 @@ fn limit_http_methods(request: &Request) -> Option<Response> {
 /// of time.
 fn set_ttl(config: &Config, request: &mut Request) {
     request.set_ttl(config.static_ttl);
+}
+
+/// Set the surrogate keys
+///
+/// The crates.io backend attaches a comma-separated list of cache tags (e.g.
+/// `crate:serde,release:serde@1.0.0`) to the S3 objects as `cache-tags` metadata, which S3
+/// surfaces as the `x-amz-meta-cache-tags` response header. A callback is registered to read the
+/// header before the response is cached and translate it into surrogate keys, so that e.g. all
+/// cached files of a crate can be purged with a single request. The header is removed from the
+/// response in the process, since it is an origin-internal detail.
+fn set_surrogate_keys(request: &mut Request) {
+    request.set_after_send(|candidate| {
+        if candidate.get_status().is_success() {
+            if let Some(tags) = candidate.remove_header_str("x-amz-meta-cache-tags") {
+                candidate.set_surrogate_keys(parse_cache_tags(&tags));
+            }
+        }
+        Ok(())
+    });
+}
+
+/// Split a comma-separated `cache-tags` metadata value into individual cache tags
+fn parse_cache_tags(tags: &str) -> impl Iterator<Item = &str> {
+    tags.split(',').map(str::trim).filter(|tag| !tag.is_empty())
 }
 
 /// Rewrite URLs with a plus character
@@ -335,6 +360,25 @@ fn http_version_to_string(version: Version) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_parse_cache_tags() {
+        fn test(input: &str, expected: &[&str]) {
+            assert_eq!(parse_cache_tags(input).collect::<Vec<_>>(), expected);
+        }
+
+        test(
+            "crate:serde,release:serde@1.0.0",
+            &["crate:serde", "release:serde@1.0.0"],
+        );
+        test("crate:serde", &["crate:serde"]);
+        test(
+            " crate:serde , release:serde@1.0.0 ",
+            &["crate:serde", "release:serde@1.0.0"],
+        );
+        test("", &[]);
+        test(" , ", &[]);
+    }
 
     #[test]
     fn test_rewrite_download_urls() {


### PR DESCRIPTION
The crates.io backend attaches cache tags to the S3 objects of `static.crates.io` as comma-separated `cache-tags` metadata (`crate:{name}` and `release:{name}@{version}`). This PR makes both CDNs read that metadata at cache-fill time so that grouped, tag-based purges become possible instead of enumerating URL paths on deletion.

- **CloudFront:** `cache_tag_config` on the static distribution reads the `x-amz-meta-cache-tags` header and indexes cached objects under the tags, enabling `#crate:{name}` style invalidations. The attribute requires AWS provider >= 6.46.0, the lock files already pin 6.52.0.
- **Fastly:** the `compute-static` worker registers a `set_after_send` callback that translates the same header into surrogate keys before the response enters the cache.

r? @rust-lang/infra 

Note that this PR was created with the help of Claude Code and I had no way of verifying that it works on staging/production yet. This should be applied to the staging environment and then tested manually with tag-based invalidations.