### PR TITLE
provision docs-rs-event-queue

### DIFF
--- a/terragrunt/accounts/crates-io-prod/docs-rs-event-queue/.terraform.lock.hcl
+++ b/terragrunt/accounts/crates-io-prod/docs-rs-event-queue/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.54.0"
+  constraints = "~> 6.27"
+  hashes = [
+    "h1:i89hWLGo3bPwJKYBv3+S67qbfr0tydFqs70Hq5VcoYs=",
+    "h1:pdl5u/cxTU5ctqlHFr/Z4IPPVIDX9Gt+wBQbzZjLWlM=",
+    "zh:0557777baa82faa7907adce61a2a3f9b2a487070bb03f29df20a7502edfe966f",
+    "zh:0767256c36b9c4d4b66d4af882de480c6535ff9eac26410fca253e87b89cb478",
+    "zh:0be7595ef70273af5eb72d850d45eb264d39796d0578c7f3eda9988d7f0781e5",
+    "zh:0fd81edad00c8da35b37aa310c7466f7a8d61056b95b37b349c510d21a8a52f6",
+    "zh:11a976648c864d126a70eb2d40182a17ecfeb3c6c3bf790c4f7eafa5e4c204ba",
+    "zh:14065875294ea597303ae8e462189041067de3b1f5d97c9f2b04b5d14aeb4f7c",
+    "zh:55a76258b109f8394cad20c9e07f376fe3051920931bf43d1b62f4d7242f20c8",
+    "zh:69b04cc363dda4df3d703c3954ae87ef36b0fea8fe45a236db89f8647a879274",
+    "zh:79e3425219f59e285f128e88a7c294a6d33c7bfa73c57a42e31ac0d8daa2f20a",
+    "zh:8d6c46c8a215f73c3c1109695a9bfd8894852d0b1c592516f09efb8a84e08b0c",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9db8f8fac77d6e999a2886df52bebb106b93ba8dfc4fea1e04decc8fda8070cd",
+    "zh:b4fc365f093b232531905547a50d4f62dbd9d5a843707867520b8b04e8b36e4f",
+    "zh:c9135045fbc561d30ec72f0b9335fcfe7590eed7e6b4eb8988455e6c8b4d348a",
+    "zh:db5f51f9f7037428cb7e8f8d43a63e0d3de498c9730fe98a3c539a75cc49208e",
+    "zh:f807b2a66174b20749c11d58cf7b2ffa8e89b4ec60dd70382959074f8490c387",
+  ]
+}

--- a/terragrunt/accounts/crates-io-prod/docs-rs-event-queue/terragrunt.hcl
+++ b/terragrunt/accounts/crates-io-prod/docs-rs-event-queue/terragrunt.hcl
@@ -1,0 +1,8 @@
+terraform {
+  source = "../../../..//terragrunt/modules/docs-rs-event-queue"
+}
+
+include {
+  path           = find_in_parent_folders()
+  merge_strategy = "deep"
+}

--- a/terragrunt/accounts/crates-io-staging/docs-rs-event-queue/.terraform.lock.hcl
+++ b/terragrunt/accounts/crates-io-staging/docs-rs-event-queue/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.54.0"
+  constraints = "~> 6.27"
+  hashes = [
+    "h1:i89hWLGo3bPwJKYBv3+S67qbfr0tydFqs70Hq5VcoYs=",
+    "h1:pdl5u/cxTU5ctqlHFr/Z4IPPVIDX9Gt+wBQbzZjLWlM=",
+    "zh:0557777baa82faa7907adce61a2a3f9b2a487070bb03f29df20a7502edfe966f",
+    "zh:0767256c36b9c4d4b66d4af882de480c6535ff9eac26410fca253e87b89cb478",
+    "zh:0be7595ef70273af5eb72d850d45eb264d39796d0578c7f3eda9988d7f0781e5",
+    "zh:0fd81edad00c8da35b37aa310c7466f7a8d61056b95b37b349c510d21a8a52f6",
+    "zh:11a976648c864d126a70eb2d40182a17ecfeb3c6c3bf790c4f7eafa5e4c204ba",
+    "zh:14065875294ea597303ae8e462189041067de3b1f5d97c9f2b04b5d14aeb4f7c",
+    "zh:55a76258b109f8394cad20c9e07f376fe3051920931bf43d1b62f4d7242f20c8",
+    "zh:69b04cc363dda4df3d703c3954ae87ef36b0fea8fe45a236db89f8647a879274",
+    "zh:79e3425219f59e285f128e88a7c294a6d33c7bfa73c57a42e31ac0d8daa2f20a",
+    "zh:8d6c46c8a215f73c3c1109695a9bfd8894852d0b1c592516f09efb8a84e08b0c",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9db8f8fac77d6e999a2886df52bebb106b93ba8dfc4fea1e04decc8fda8070cd",
+    "zh:b4fc365f093b232531905547a50d4f62dbd9d5a843707867520b8b04e8b36e4f",
+    "zh:c9135045fbc561d30ec72f0b9335fcfe7590eed7e6b4eb8988455e6c8b4d348a",
+    "zh:db5f51f9f7037428cb7e8f8d43a63e0d3de498c9730fe98a3c539a75cc49208e",
+    "zh:f807b2a66174b20749c11d58cf7b2ffa8e89b4ec60dd70382959074f8490c387",
+  ]
+}

--- a/terragrunt/accounts/crates-io-staging/docs-rs-event-queue/terragrunt.hcl
+++ b/terragrunt/accounts/crates-io-staging/docs-rs-event-queue/terragrunt.hcl
@@ -1,0 +1,8 @@
+terraform {
+  source = "../../../..//terragrunt/modules/docs-rs-event-queue"
+}
+
+include {
+  path           = find_in_parent_folders()
+  merge_strategy = "deep"
+}

--- a/terragrunt/modules/docs-rs-event-queue/README.md
+++ b/terragrunt/modules/docs-rs-event-queue/README.md
@@ -1,0 +1,8 @@
+# `docs-rs-event-queue`
+
+This module provisions the FIFO SQS queue that carries crates.io index changes
+from crates.io to docs.rs.
+The queue is deployed in the `us-east-1` region.
+
+- Producer: crates.io
+- Consumer: docs.rs

--- a/terragrunt/modules/docs-rs-event-queue/_terraform.tf
+++ b/terragrunt/modules/docs-rs-event-queue/_terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.27"
+    }
+  }
+}

--- a/terragrunt/modules/docs-rs-event-queue/main.tf
+++ b/terragrunt/modules/docs-rs-event-queue/main.tf
@@ -1,0 +1,71 @@
+data "aws_iam_user" "producer" {
+  # Same IAM user used in the crates-io-logs module.
+  user_name = "crates-io-heroku-access"
+  provider  = aws.us-east-1
+}
+
+resource "aws_sqs_queue" "index_changes" {
+  provider = aws.us-east-1
+  name     = "crates-io-index-events.fifo"
+
+  # Preserve the ordering of registry events, including deletes, recreations,
+  # yanks, and unyanks. The producer should use one MessageGroupId for all
+  # events to retain total ordering.
+  fifo_queue = true
+
+  # Let crates.io assign a stable event ID as MessageDeduplicationId instead of
+  # deriving it from the message body. SendMessage fails if the ID is omitted.
+  # If set to true, the queue silently discards distinct events with identical bodies.
+  # This is not acceptable because crates.io may send the same event multiple times.
+  # E.g. if someone yanks, unyank, and yanks again, the second yank is a distinct event
+  # that must be delivered to docs.rs.
+  content_based_deduplication = false
+
+  # Keep events for seven days so docs.rs can recover from a prolonged outage.
+  # Default: 4 days.
+  message_retention_seconds = 7 * 24 * 60 * 60
+
+  # Use the maximum long-poll duration to reduce empty ReceiveMessage calls.
+  # The default is 0 seconds, which means that HTTP calls return immediately if the queue is empty.
+  # This can cause a lot of empty calls and wasted resources.
+  # By setting this value, HTTP calls wait up to 20 seconds for a message to arrive before returning.
+  # The consumer can override this queue-level value by supplying
+  # WaitTimeSeconds in each ReceiveMessage call.
+  # Note: ensure the client’s HTTP timeout is longer than 20 seconds.
+  receive_wait_time_seconds = 20
+
+  # Give the consumer (docs-rs in this case) five minutes to handle an event.
+  # After the consumer receives an event, SQS hides it for five minutes.
+  # If the consumer deletes it, processing is complete. Otherwise, it becomes visible for retry.
+  # Messages are idempotent, so it's safe to retry.
+  # The consumer must extend this with ChangeMessageVisibility when processing takes longer.
+  # Default: 30 seconds.
+  visibility_timeout_seconds = 300
+
+  # Encrypt messages at rest without requiring a customer-managed KMS key.
+  # This is the default, and it is set to true to detect drifts.
+  sqs_managed_sse_enabled = true
+}
+
+data "aws_iam_policy_document" "producer" {
+  provider = aws.us-east-1
+
+  statement {
+    sid    = "SendCratesIoIndexEvents"
+    effect = "Allow"
+
+    actions = [
+      "sqs:GetQueueAttributes",
+      "sqs:GetQueueUrl",
+      "sqs:SendMessage",
+    ]
+    resources = [aws_sqs_queue.index_changes.arn]
+  }
+}
+
+resource "aws_iam_user_policy" "producer" {
+  provider = aws.us-east-1
+  name     = "crates-io-index-events-producer"
+  user     = data.aws_iam_user.producer.user_name
+  policy   = data.aws_iam_policy_document.producer.json
+}

--- a/terragrunt/modules/docs-rs-event-queue/outputs.tf
+++ b/terragrunt/modules/docs-rs-event-queue/outputs.tf
@@ -1,0 +1,14 @@
+output "queue_arn" {
+  description = "ARN of the queue carrying crates.io index changes for docs.rs."
+  value       = aws_sqs_queue.index_changes.arn
+}
+
+output "queue_name" {
+  description = "Name of the queue carrying crates.io index changes for docs.rs."
+  value       = aws_sqs_queue.index_changes.name
+}
+
+output "queue_url" {
+  description = "URL applications use to send or receive docs.rs index changes."
+  value       = aws_sqs_queue.index_changes.url
+}


### PR DESCRIPTION
Related to https://github.com/rust-lang/simpleinfra/issues/1075

This just provisions the queue and the permissions for the producer (crates-io).
I will do more PRs later.

## For crates-io and docs-rs team

Please check the comments in the aws_sqs_queue. In particular:

* For crates-io:
  * MessageGroupId
  * MessageDeduplicationId
* For docs-rs:
  * HTTP client timeout of 20 seconds

## AI disclosure

I used GPT5.6 with the codex harness to generate this change. I reviewed its output and changed it where necessary.