### PR TITLE
give docs-rs consumer access to crates-io-index-events queue

### DIFF
--- a/terraform/docs-rs/sqs.tf
+++ b/terraform/docs-rs/sqs.tf
@@ -1,0 +1,31 @@
+locals {
+  crates_io_index_events_queue_arn = "arn:aws:sqs:us-east-1:365596307002:crates-io-index-events.fifo"
+}
+
+# This role is attached to the legacy EC2 instance currently running docs.rs:
+# i-0208c7ee11cc4e0db in us-west-1.
+data "aws_iam_role" "docs_rs_ec2" {
+  name = "docs-rs"
+}
+
+data "aws_iam_policy_document" "index_events_consumer" {
+  statement {
+    sid    = "ConsumeCratesIoIndexEvents"
+    effect = "Allow"
+
+    actions = [
+      "sqs:ChangeMessageVisibility",
+      "sqs:DeleteMessage",
+      "sqs:GetQueueAttributes",
+      "sqs:ReceiveMessage",
+      "sqs:GetQueueUrl",
+    ]
+    resources = [local.crates_io_index_events_queue_arn]
+  }
+}
+
+resource "aws_iam_role_policy" "index_events_consumer" {
+  name   = "crates-io-index-events-consumer"
+  role   = data.aws_iam_role.docs_rs_ec2.name
+  policy = data.aws_iam_policy_document.index_events_consumer.json
+}

--- a/terragrunt/accounts/crates-io-prod/docs-rs-event-queue/terragrunt.hcl
+++ b/terragrunt/accounts/crates-io-prod/docs-rs-event-queue/terragrunt.hcl
@@ -6,3 +6,8 @@ include {
   path           = find_in_parent_folders()
   merge_strategy = "deep"
 }
+
+inputs = {
+  # Role attached to the legacy EC2 instance currently running docs.rs.
+  consumer_principal_arns = ["arn:aws:iam::890664054962:role/docs-rs"]
+}

--- a/terragrunt/modules/docs-rs-event-queue/README.md
+++ b/terragrunt/modules/docs-rs-event-queue/README.md
@@ -6,3 +6,7 @@ The queue is deployed in the `us-east-1` region.
 
 - Producer: crates.io
 - Consumer: docs.rs
+
+Cross-account consumers can be granted access through the
+`consumer_principal_arns` input. The consumer also needs a matching
+identity-based IAM policy in its own account.

--- a/terragrunt/modules/docs-rs-event-queue/main.tf
+++ b/terragrunt/modules/docs-rs-event-queue/main.tf
@@ -69,3 +69,35 @@ resource "aws_iam_user_policy" "producer" {
   user     = data.aws_iam_user.producer.user_name
   policy   = data.aws_iam_policy_document.producer.json
 }
+
+data "aws_iam_policy_document" "consumer" {
+  count    = length(var.consumer_principal_arns) > 0 ? 1 : 0
+  provider = aws.us-east-1
+
+  statement {
+    sid    = "ConsumeCratesIoIndexEvents"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = var.consumer_principal_arns
+    }
+
+    actions = [
+      "sqs:ChangeMessageVisibility",
+      "sqs:DeleteMessage",
+      "sqs:GetQueueAttributes",
+      "sqs:ReceiveMessage",
+      "sqs:GetQueueUrl",
+    ]
+    resources = [aws_sqs_queue.index_changes.arn]
+  }
+}
+
+resource "aws_sqs_queue_policy" "consumer" {
+  count    = length(var.consumer_principal_arns) > 0 ? 1 : 0
+  provider = aws.us-east-1
+
+  queue_url = aws_sqs_queue.index_changes.url
+  policy    = data.aws_iam_policy_document.consumer[0].json
+}

--- a/terragrunt/modules/docs-rs-event-queue/variables.tf
+++ b/terragrunt/modules/docs-rs-event-queue/variables.tf
@@ -1,0 +1,5 @@
+variable "consumer_principal_arns" {
+  type        = list(string)
+  description = "IAM principals allowed to consume events from the queue."
+  default     = []
+}


### PR DESCRIPTION
Follow up to #1107. Related to https://github.com/rust-lang/simpleinfra/issues/1075.


## AI disclosure

I used GPT5.6 with the codex harness to generate this change. I reviewed its output and changed it where necessary.