### PR TITLE
Define promote-release KMS keys

### DIFF
--- a/terragrunt/accounts/promote-release-prod/promote-release/.terraform.lock.hcl
+++ b/terragrunt/accounts/promote-release-prod/promote-release/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.54.0"
+  constraints = "~> 6.54"
+  hashes = [
+    "h1:i89hWLGo3bPwJKYBv3+S67qbfr0tydFqs70Hq5VcoYs=",
+    "zh:0557777baa82faa7907adce61a2a3f9b2a487070bb03f29df20a7502edfe966f",
+    "zh:0767256c36b9c4d4b66d4af882de480c6535ff9eac26410fca253e87b89cb478",
+    "zh:0be7595ef70273af5eb72d850d45eb264d39796d0578c7f3eda9988d7f0781e5",
+    "zh:0fd81edad00c8da35b37aa310c7466f7a8d61056b95b37b349c510d21a8a52f6",
+    "zh:11a976648c864d126a70eb2d40182a17ecfeb3c6c3bf790c4f7eafa5e4c204ba",
+    "zh:14065875294ea597303ae8e462189041067de3b1f5d97c9f2b04b5d14aeb4f7c",
+    "zh:55a76258b109f8394cad20c9e07f376fe3051920931bf43d1b62f4d7242f20c8",
+    "zh:69b04cc363dda4df3d703c3954ae87ef36b0fea8fe45a236db89f8647a879274",
+    "zh:79e3425219f59e285f128e88a7c294a6d33c7bfa73c57a42e31ac0d8daa2f20a",
+    "zh:8d6c46c8a215f73c3c1109695a9bfd8894852d0b1c592516f09efb8a84e08b0c",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9db8f8fac77d6e999a2886df52bebb106b93ba8dfc4fea1e04decc8fda8070cd",
+    "zh:b4fc365f093b232531905547a50d4f62dbd9d5a843707867520b8b04e8b36e4f",
+    "zh:c9135045fbc561d30ec72f0b9335fcfe7590eed7e6b4eb8988455e6c8b4d348a",
+    "zh:db5f51f9f7037428cb7e8f8d43a63e0d3de498c9730fe98a3c539a75cc49208e",
+    "zh:f807b2a66174b20749c11d58cf7b2ffa8e89b4ec60dd70382959074f8490c387",
+  ]
+}

--- a/terragrunt/accounts/promote-release-prod/promote-release/terragrunt.hcl
+++ b/terragrunt/accounts/promote-release-prod/promote-release/terragrunt.hcl
@@ -1,0 +1,12 @@
+terraform {
+  source = "../../../modules//promote-release"
+}
+
+include {
+  path           = find_in_parent_folders()
+  merge_strategy = "deep"
+}
+
+inputs = {
+  env = "prod"
+}

--- a/terragrunt/accounts/promote-release-staging/promote-release/.terraform.lock.hcl
+++ b/terragrunt/accounts/promote-release-staging/promote-release/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.54.0"
+  constraints = "~> 6.54"
+  hashes = [
+    "h1:i89hWLGo3bPwJKYBv3+S67qbfr0tydFqs70Hq5VcoYs=",
+    "zh:0557777baa82faa7907adce61a2a3f9b2a487070bb03f29df20a7502edfe966f",
+    "zh:0767256c36b9c4d4b66d4af882de480c6535ff9eac26410fca253e87b89cb478",
+    "zh:0be7595ef70273af5eb72d850d45eb264d39796d0578c7f3eda9988d7f0781e5",
+    "zh:0fd81edad00c8da35b37aa310c7466f7a8d61056b95b37b349c510d21a8a52f6",
+    "zh:11a976648c864d126a70eb2d40182a17ecfeb3c6c3bf790c4f7eafa5e4c204ba",
+    "zh:14065875294ea597303ae8e462189041067de3b1f5d97c9f2b04b5d14aeb4f7c",
+    "zh:55a76258b109f8394cad20c9e07f376fe3051920931bf43d1b62f4d7242f20c8",
+    "zh:69b04cc363dda4df3d703c3954ae87ef36b0fea8fe45a236db89f8647a879274",
+    "zh:79e3425219f59e285f128e88a7c294a6d33c7bfa73c57a42e31ac0d8daa2f20a",
+    "zh:8d6c46c8a215f73c3c1109695a9bfd8894852d0b1c592516f09efb8a84e08b0c",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9db8f8fac77d6e999a2886df52bebb106b93ba8dfc4fea1e04decc8fda8070cd",
+    "zh:b4fc365f093b232531905547a50d4f62dbd9d5a843707867520b8b04e8b36e4f",
+    "zh:c9135045fbc561d30ec72f0b9335fcfe7590eed7e6b4eb8988455e6c8b4d348a",
+    "zh:db5f51f9f7037428cb7e8f8d43a63e0d3de498c9730fe98a3c539a75cc49208e",
+    "zh:f807b2a66174b20749c11d58cf7b2ffa8e89b4ec60dd70382959074f8490c387",
+  ]
+}

--- a/terragrunt/accounts/promote-release-staging/promote-release/terragrunt.hcl
+++ b/terragrunt/accounts/promote-release-staging/promote-release/terragrunt.hcl
@@ -1,0 +1,12 @@
+terraform {
+  source = "../../../modules//promote-release"
+}
+
+include {
+  path           = find_in_parent_folders()
+  merge_strategy = "deep"
+}
+
+inputs = {
+  env = "staging"
+}

--- a/terragrunt/modules/promote-release/kms.tf
+++ b/terragrunt/modules/promote-release/kms.tf
@@ -1,0 +1,52 @@
+data "aws_caller_identity" "current" {}
+
+resource "aws_kms_key" "signing" {
+  description         = "Signing key"
+  enable_key_rotation = false
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id      = "tag-signing-1"
+    Statement = [
+      {
+        Sid    = "Enable IAM User Permissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        },
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      // Remove the ability to sign with this key from users authenticated via
+      // SSO (Identity Center) credentials.
+      //
+      // This prevents easy access (without modifying the key policy) for
+      // humans to being able to sign. This isn't hard enforcement (e.g., Admin
+      // credentials can create their own role or otherwise bypass this), but
+      // it does make it harder to sign without using our code to do so.
+      {
+        Sid = "Deny all signing operations to SSO users"
+        // Skip denying signing with the staging key.
+        // End-users shouldn't trust that key and it's convenient for local
+        // testing (and maybe CI?) of promote-release to be able to access it.
+        Effect   = var.env == "staging" ? "Allow" : "Deny"
+        Action   = "kms:Sign"
+        Resource = "*"
+        Principal = {
+          AWS = "*"
+        },
+        Condition = {
+          Null = {
+            "identitystore:UserId" = false
+          }
+        }
+      },
+    ]
+  })
+  key_usage                = "SIGN_VERIFY"
+  customer_master_key_spec = "RSA_4096"
+}
+
+resource "aws_kms_alias" "signing" {
+  name          = "alias/signing"
+  target_key_id = aws_kms_key.signing.key_id
+}

--- a/terragrunt/modules/promote-release/main.tf
+++ b/terragrunt/modules/promote-release/main.tf
@@ -1,9 +1,16 @@
 terraform {
   required_providers {
     aws = {
-      source                = "hashicorp/aws"
-      version               = "~> 6.54"
-      configuration_aliases = [aws.us-east-2]
+      source  = "hashicorp/aws"
+      version = "~> 6.54"
     }
+  }
+}
+
+variable "env" {
+  type = string
+  validation {
+    condition     = contains(["staging", "prod"], var.env)
+    error_message = "The environment must be 'staging' or 'prod'."
   }
 }

--- a/terragrunt/terragrunt.hcl
+++ b/terragrunt/terragrunt.hcl
@@ -15,6 +15,7 @@ remote_state {
     profile        = local.cmd.remote_state_profile
     bucket         = local.cmd.remote_state_bucket
     dynamodb_table = local.cmd.remote_state_dynamodb_table
+    use_lockfile = true
     region         = local.cmd.remote_state_region
     key            = local.cmd.remote_state_key
   }


### PR DESCRIPTION
The staging key is generated in AWS, and the production key is an imported form of our (pre-existing) primary GPG key.