### PR TITLE
crates.io: Enable dynamic compression for text responses

### DIFF
--- a/terragrunt/modules/crates-io/compute-static/src/compression.rs
+++ b/terragrunt/modules/crates-io/compute-static/src/compression.rs
@@ -1,0 +1,46 @@
+use fastly::mime::{self, Mime};
+
+pub fn is_compressible_content_type(content_type: &Mime) -> bool {
+    content_type.type_() == mime::TEXT
+        || content_type.subtype() == mime::JSON
+        || content_type.subtype() == mime::XML
+        || content_type.suffix() == Some(mime::JSON)
+        || content_type.suffix() == Some(mime::XML)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_compressible_content_type;
+    use fastly::mime::Mime;
+
+    fn mime(value: &str) -> Mime {
+        value.parse().unwrap()
+    }
+
+    #[test]
+    fn text_and_structured_content_types_are_compressible() {
+        for content_type in [
+            "text/html; charset=utf-8",
+            "text/xml;charset=utf-8",
+            "application/json",
+            "application/xml",
+            "application/rss+xml",
+            "application/vnd.api+json",
+        ] {
+            assert!(
+                is_compressible_content_type(&mime(content_type)),
+                "expected {content_type} to be compressible"
+            );
+        }
+    }
+
+    #[test]
+    fn binary_content_types_are_not_compressible() {
+        for content_type in ["application/gzip", "application/zip", "image/png"] {
+            assert!(
+                !is_compressible_content_type(&mime(content_type)),
+                "expected {content_type} not to be compressible"
+            );
+        }
+    }
+}

--- a/terragrunt/modules/crates-io/compute-static/src/compression.rs
+++ b/terragrunt/modules/crates-io/compute-static/src/compression.rs
@@ -2,10 +2,8 @@ use fastly::mime::{self, Mime};
 
 pub fn is_compressible_content_type(content_type: &Mime) -> bool {
     content_type.type_() == mime::TEXT
-        || content_type.subtype() == mime::JSON
-        || content_type.subtype() == mime::XML
-        || content_type.suffix() == Some(mime::JSON)
-        || content_type.suffix() == Some(mime::XML)
+        || matches!(content_type.subtype(), mime::JSON | mime::XML)
+        || matches!(content_type.suffix(), Some(mime::JSON | mime::XML))
 }
 
 #[cfg(test)]

--- a/terragrunt/modules/crates-io/compute-static/src/lib.rs
+++ b/terragrunt/modules/crates-io/compute-static/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod compression;

--- a/terragrunt/modules/crates-io/compute-static/src/main.rs
+++ b/terragrunt/modules/crates-io/compute-static/src/main.rs
@@ -1,3 +1,4 @@
+use compute_static::compression::is_compressible_content_type;
 use fastly::convert::ToHeaderValue;
 use fastly::http::{header, Method, StatusCode, Version};
 use fastly::{Error, Request, Response};
@@ -16,6 +17,7 @@ const DATADOG_APP: &str = "crates.io";
 const DATADOG_SERVICE: &str = "static.crates.io";
 const VERSION_DOWNLOADS: &str = "/archive/version-downloads/";
 const VERSION_DOWNLOADS_INDEX: &str = "/archive/version-downloads/index.html";
+const X_COMPRESS_HINT: &str = "X-Compress-Hint";
 
 #[fastly::main]
 fn main(request: Request) -> Result<Response, Error> {
@@ -294,6 +296,8 @@ fn send_request_to_s3(config: &Config, request: &Request) -> Result<Response, Er
         response = fallback_request.send(&config.fallback_host)?;
     }
 
+    enable_dynamic_compression(request, &mut response);
+
     Ok(response)
 }
 
@@ -306,6 +310,25 @@ fn add_cors_headers(response: &mut Result<Response, Error>) {
         response.set_header("Access-Control-Allow-Origin", "*");
         response.set_header("Access-Control-Allow-Methods", "GET");
         response.set_header("Access-Control-Max-Age", "3000");
+    }
+}
+
+fn enable_dynamic_compression(request: &Request, response: &mut Response) {
+    if request.get_method() != Method::GET
+        || request.contains_header(header::RANGE)
+        || response.get_status() != StatusCode::OK
+        || response.contains_header(header::CONTENT_ENCODING)
+    {
+        return;
+    }
+
+    let Some(content_type) = response.get_content_type() else {
+        return;
+    };
+
+    if is_compressible_content_type(&content_type) {
+        response.set_header(X_COMPRESS_HINT, "on");
+        response.append_header(header::VARY, "Accept-Encoding");
     }
 }
 


### PR DESCRIPTION
This sets [`X-Compress-Hint`](https://www.fastly.com/documentation/reference/http/http-headers/X-Compress-Hint/) and `Vary: Accept-Encoding` on eligible text, JSON, and XML responses to enable response compression for these files.