### PR TITLE
configure datadog host

### DIFF
--- a/terragrunt/modules/crates-io/compute-static/src/main.rs
+++ b/terragrunt/modules/crates-io/compute-static/src/main.rs
@@ -101,7 +101,7 @@ fn collect_request(config: &Config, request: &Request) -> LogLineV1Builder {
         .service(DATADOG_SERVICE)
         .date_time(OffsetDateTime::now_utc())
         .edge_location(var("FASTLY_POP").ok())
-        .host(request.get_url().host().map(|s| s.to_string()))
+        .host(Some(config.datadog_host.clone()))
         .http(http_details)
         .ip(request.get_client_ip_addr())
         .method(Some(request.get_method().to_string()))


### PR DESCRIPTION
The datadog variable was unused. With this PR, I use it to configure logs correctly.
In another PR, I will change CI so that this project is checked. 

The datadog-host dictionary entry contains `static.crates.io`, which is the host that is present in our logs. So nothing should change in DataDog. This is just a code cleanup to remove the compiler warning. 