### PR TITLE
crates.io: Test the static.crates.io Fastly worker

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>rust-lang/renovate"],
+  "extends": [
+    "github>rust-lang/renovate",
+    "customManagers:githubActionsVersions",
+  ],
    // Require manual approval from the Dependency Dashboard before opening PRs
   "dependencyDashboardApproval": true,
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>rust-lang/renovate",
+    // Update `_VERSION` environment variables in GitHub Action files.
     "customManagers:githubActionsVersions",
   ],
    // Require manual approval from the Dependency Dashboard before opening PRs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,31 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all -- -Dwarnings
 
+  static-crates-io:
+    name: static.crates.io Fastly worker
+    runs-on: ubuntu-24.04
+    env:
+      # renovate: datasource=crate depName=viceroy
+      VICEROY_VERSION: "0.20.0"
+      # renovate: datasource=crate depName=cargo-nextest
+      NEXTEST_VERSION: "0.9.140"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          env-vars: VICEROY_VERSION NEXTEST_VERSION
+          workspaces: terragrunt/modules/crates-io/compute-static
+
+      - name: Install test tools
+        run: |
+          cargo install viceroy --locked --version "$VICEROY_VERSION"
+          cargo install cargo-nextest --locked --version "$NEXTEST_VERSION"
+
+      - name: Run the test suite
+        working-directory: terragrunt/modules/crates-io/compute-static
+        run: cargo nextest run
+
   terraform:
     name: Terraform configuration
     runs-on: ubuntu-24.04

--- a/terragrunt/modules/crates-io/compute-static/.cargo/config.toml
+++ b/terragrunt/modules/crates-io/compute-static/.cargo/config.toml
@@ -1,2 +1,5 @@
 [build]
 target = "wasm32-wasip1"
+
+[target.wasm32-wasip1]
+runner = "viceroy run -C fastly.toml -- "

--- a/terragrunt/modules/crates-io/compute-static/README.md
+++ b/terragrunt/modules/crates-io/compute-static/README.md
@@ -15,6 +15,19 @@ cd compute-static
 fastly compute build
 ```
 
+## Testing
+
+Install [Viceroy] and [cargo-nextest], then run:
+
+```shell
+cargo nextest run
+```
+
+The tests compile to WebAssembly. Viceroy provides the Fastly hostcalls that a
+regular WASI runtime does not implement, and Cargo invokes it through the
+configured target runner. Cargo-nextest runs each test in a separate WebAssembly
+instance because a panic stops the current instance.
+
 ## Deployment
 
 Terraform uses an [external data source] to build the function as part of its
@@ -28,4 +41,6 @@ export FASTLY_API_KEY=""
 terraform plan
 ```
 
+[cargo-nextest]: https://nexte.st/
 [external data source]: https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/data_source
+[viceroy]: https://github.com/fastly/Viceroy


### PR DESCRIPTION
Cargo now runs the `static.crates.io` worker’s `wasm32-wasip1` test binaries through Viceroy, which supplies Fastly hostcalls unavailable in a regular WASI runtime. 

The worker README documents the local `cargo nextest run` workflow and explains why each test runs in an isolated WebAssembly instance. 

CI exercises the same test suite in a dedicated job with pinned Viceroy and cargo-nextest versions backed by job-local Rust caching. Renovate’s GitHub Actions versions preset keeps both tool pins current.