### PR TITLE
crates.io: Enable compression for index.crates.io responses

### DIFF
--- a/terragrunt/modules/crates-io/fastly-index.tf
+++ b/terragrunt/modules/crates-io/fastly-index.tf
@@ -139,6 +139,24 @@ resource "fastly_service_vcl" "index" {
       set segmented_caching.block_size = 10000000;
     VCL
   }
+
+  snippet {
+    name    = "enable dynamic compression"
+    type    = "deliver"
+    content = <<-VCL
+      if (
+        req.method == "GET" &&
+        !req.http.Range &&
+        resp.status == 200 &&
+        !resp.http.Content-Encoding
+      ) {
+        set resp.http.X-Compress-Hint = "on";
+
+        # The cached object remains uncompressed, so only downstream caches vary.
+        set resp.http.Vary:Accept-Encoding = "";
+      }
+    VCL
+  }
 }
 
 module "fastly_tls_subscription_index" {


### PR DESCRIPTION
This marks complete successful GET responses for Fastly dynamic compression while keeping cached objects uncompressed.

It adds `Accept-Encoding` to `Vary` for downstream caches.

### Related

- #1120 