### PR TITLE
fix: include Content-Length in fastly HEAD responses

### DIFF
--- a/terragrunt/modules/crates-io/compute-static/src/main.rs
+++ b/terragrunt/modules/crates-io/compute-static/src/main.rs
@@ -298,6 +298,16 @@ fn send_request_to_s3(config: &Config, request: &Request) -> Result<Response, Er
 
     enable_dynamic_compression(request, &mut response);
 
+    // Without this, HEAD requests throw away the content length from the upstream S3.
+    // The default Automatic mode will re-frame the response depending on
+    // client preferences, which may differ from the way content is fetched
+    // from the origin. HEAD doesn't *do* framing since it has no body, and for
+    // some reason, the automatic mode doesn't attach any content-length to the
+    // response.
+    if request.get_method() == Method::HEAD {
+        response.set_framing_headers_mode(fastly::http::FramingHeadersMode::ManuallyFromHeaders);
+    }
+
     Ok(response)
 }
 

--- a/terragrunt/modules/crates-io/compute-static/src/main.rs
+++ b/terragrunt/modules/crates-io/compute-static/src/main.rs
@@ -302,7 +302,7 @@ fn send_request_to_s3(config: &Config, request: &Request) -> Result<Response, Er
     // discards S3's Content-Length. This is normally necessary because downstream
     // transformations such as client-negotiated compression can change the
     // representation. For HEAD, preserve the origin length only when the
-    // equivalent GET cannot be dynamically compressed.
+    // equivalent GET is ineligible for dynamic compression.
     if should_preserve_framing_headers(request, &response) {
         response.set_framing_headers_mode(fastly::http::FramingHeadersMode::ManuallyFromHeaders);
     }
@@ -333,6 +333,12 @@ fn enable_dynamic_compression(request: &Request, response: &mut Response) {
     response.append_header(header::VARY, "Accept-Encoding");
 }
 
+/// Whether a HEAD response can preserve the origin's framing headers.
+///
+/// Preserve S3's `Content-Length` only when the equivalent GET is structurally ineligible for
+/// dynamic compression. Intentionally do not inspect `Accept-Encoding`: Fastly owns that automatic
+/// negotiation. Omitting `Content-Length` for eligible HEAD responses is valid and safer
+/// than forwarding a potentially stale value.
 fn should_preserve_framing_headers(request: &Request, response: &Response) -> bool {
     request.get_method() == Method::HEAD && !is_eligible_for_dynamic_compression(request, response)
 }

--- a/terragrunt/modules/crates-io/compute-static/src/main.rs
+++ b/terragrunt/modules/crates-io/compute-static/src/main.rs
@@ -298,13 +298,12 @@ fn send_request_to_s3(config: &Config, request: &Request) -> Result<Response, Er
 
     enable_dynamic_compression(request, &mut response);
 
-    // Without this, HEAD requests throw away the content length from the upstream S3.
-    // The default Automatic mode will re-frame the response depending on
-    // client preferences, which may differ from the way content is fetched
-    // from the origin. HEAD doesn't *do* framing since it has no body, and for
-    // some reason, the automatic mode doesn't attach any content-length to the
-    // response.
-    if request.get_method() == Method::HEAD {
+    // Automatic framing derives downstream framing from the response body and
+    // discards S3's Content-Length. This is normally necessary because downstream
+    // transformations such as client-negotiated compression can change the
+    // representation. For HEAD, preserve the origin length only when the
+    // equivalent GET cannot be dynamically compressed.
+    if should_preserve_framing_headers(request, &response) {
         response.set_framing_headers_mode(fastly::http::FramingHeadersMode::ManuallyFromHeaders);
     }
 
@@ -332,6 +331,10 @@ fn enable_dynamic_compression(request: &Request, response: &mut Response) {
 
     response.set_header(X_COMPRESS_HINT, "on");
     response.append_header(header::VARY, "Accept-Encoding");
+}
+
+fn should_preserve_framing_headers(request: &Request, response: &Response) -> bool {
+    request.get_method() == Method::HEAD && !is_eligible_for_dynamic_compression(request, response)
 }
 
 fn is_eligible_for_dynamic_compression(request: &Request, response: &Response) -> bool {

--- a/terragrunt/modules/crates-io/compute-static/src/main.rs
+++ b/terragrunt/modules/crates-io/compute-static/src/main.rs
@@ -325,21 +325,28 @@ fn add_cors_headers(response: &mut Result<Response, Error>) {
 
 fn enable_dynamic_compression(request: &Request, response: &mut Response) {
     if request.get_method() != Method::GET
-        || request.contains_header(header::RANGE)
-        || response.get_status() != StatusCode::OK
-        || response.contains_header(header::CONTENT_ENCODING)
+        || !is_eligible_for_dynamic_compression(request, response)
     {
         return;
     }
 
+    response.set_header(X_COMPRESS_HINT, "on");
+    response.append_header(header::VARY, "Accept-Encoding");
+}
+
+fn is_eligible_for_dynamic_compression(request: &Request, response: &Response) -> bool {
+    if request.contains_header(header::RANGE)
+        || response.get_status() != StatusCode::OK
+        || response.contains_header(header::CONTENT_ENCODING)
+    {
+        return false;
+    }
+
     let Some(content_type) = response.get_content_type() else {
-        return;
+        return false;
     };
 
-    if is_compressible_content_type(&content_type) {
-        response.set_header(X_COMPRESS_HINT, "on");
-        response.append_header(header::VARY, "Accept-Encoding");
-    }
+    is_compressible_content_type(&content_type)
 }
 
 /// Collect data for the logs from the response


### PR DESCRIPTION
I hit an extremely strange issue while working on buck2: I got an error implying I needed to explicitly specify a content length while downloading crates at content-addressed paths. I dug through the code, realized there was a fallback path of making a HEAD request to get the length, then pulled out `curl` and went "wtf".

This only happens on fastly:

```
$ curl --head 'https://fastly-static.crates.io/crates/adler2/2.0.1/download' | grep -i content-
content-type: application/gzip

$ curl --head 'https://cloudfront-static.crates.io/crates/adler2/adler2-2.0.1.crate' | grep -i content-
content-type: application/gzip
content-length: 13366
```

With a GET request of an empty range, the content length is correct:

```
$ curl -sS -D - -o /dev/null --http1.1 -H 'Range: bytes=0-0' 'https://static.crates.io/crates/adler2/2.0.1/download' | grep -i content-
Content-Length: 13366
content-type: application/gzip
```

Validation: I'm terribly sorry; I don't know how to add automated tests to this project that would actually test this. It seems like it's not compatible with viceroy, due to `Request::set_after_send` not being supported; this implies to me that the test infra necessary to write an automated test doesn't exist.

For what it's worth, I have thrown an agent at making throwaway garbage LLM harness code that seems to validate this change *does* cause it to start sending Content-Length on HEAD requests where it did not before (I will spare you that code. it's not good). It cfg'd out calling `set_surrogate_keys` which apparently was pretty much all that was needed to get this crate to work on Viceroy, fyi, in case you *do* want to build a test suite.