### PR TITLE
docs-rs queue: use default visibility_timeout_seconds

### DIFF
--- a/terragrunt/modules/docs-rs-event-queue/main.tf
+++ b/terragrunt/modules/docs-rs-event-queue/main.tf
@@ -34,14 +34,6 @@ resource "aws_sqs_queue" "index_changes" {
   # Note: ensure the client’s HTTP timeout is longer than 20 seconds.
   receive_wait_time_seconds = 20
 
-  # Give the consumer (docs-rs in this case) five minutes to handle an event.
-  # After the consumer receives an event, SQS hides it for five minutes.
-  # If the consumer deletes it, processing is complete. Otherwise, it becomes visible for retry.
-  # Messages are idempotent, so it's safe to retry.
-  # The consumer must extend this with ChangeMessageVisibility when processing takes longer.
-  # Default: 30 seconds.
-  visibility_timeout_seconds = 300
-
   # Encrypt messages at rest without requiring a customer-managed KMS key.
   # This is the default, and it is set to true to detect drifts.
   sqs_managed_sse_enabled = true


### PR DESCRIPTION
We agreed in [#t-crates-io > event based link between crates.io &amp; docs.rs @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/318791-t-crates-io/topic/event.20based.20link.20between.20crates.2Eio.20.26.20docs.2Ers/near/611612102) that we should use the default.