### PR TITLE
Add self-hosted runner configuration

### DIFF
--- a/terragrunt/accounts/bors-prod/app/terragrunt.hcl
+++ b/terragrunt/accounts/bors-prod/app/terragrunt.hcl
@@ -16,4 +16,5 @@ inputs = {
   zulip_username = "bors-bot@rust-lang.zulipchat.com"
   cpu = 1024
   memory = 2048
+  ec2_runner_role = "arn:aws:iam::008376430877:role/gha-runner-management"
 }

--- a/terragrunt/accounts/bors-staging/app/terragrunt.hcl
+++ b/terragrunt/accounts/bors-staging/app/terragrunt.hcl
@@ -16,4 +16,5 @@ inputs = {
   zulip_username = "bors-staging-bot@rust-lang.zulipchat.com"
   cpu = 256
   memory = 512
+  ec2_runner_role = "arn:aws:iam::442426873467:role/gha-runner-management"
 }

--- a/terragrunt/accounts/ci-prod/ci-runners/terragrunt.hcl
+++ b/terragrunt/accounts/ci-prod/ci-runners/terragrunt.hcl
@@ -10,4 +10,5 @@ include {
 inputs = {
   code_connection_name = "rust-lang-prod-gh-connection"
   repository           = "rust-lang/rust"
+  executor_account_id  = "351621253146"
 }

--- a/terragrunt/accounts/ci-staging/ci-runners/terragrunt.hcl
+++ b/terragrunt/accounts/ci-staging/ci-runners/terragrunt.hcl
@@ -10,4 +10,6 @@ include {
 inputs = {
   code_connection_name = "staging-gh-connection"
   repository           = "rust-lang/aws-runners-test"
+  // bors-staging account ID
+  executor_account_id  = "392478027976"
 }

--- a/terragrunt/modules/bors/ecs.tf
+++ b/terragrunt/modules/bors/ecs.tf
@@ -148,6 +148,10 @@ resource "aws_ecs_task_definition" "bors" {
         {
           name  = "ZULIP_USERNAME"
           value = "${var.zulip_username}"
+        },
+        {
+          name  = "CI_EC2_RUNNER_ROLE"
+          value = "${var.ec2_runner_role}"
         }
       ]
 

--- a/terragrunt/modules/bors/iam.tf
+++ b/terragrunt/modules/bors/iam.tf
@@ -61,3 +61,29 @@ resource "aws_iam_policy" "ssm_access" {
 
   })
 }
+
+resource "aws_iam_role_policy" "gha-self-hosted" {
+  name = "gha-self-hosted"
+  role = aws_iam_role.runtime.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Resource = [
+          // Allow assuming roles in both the staging and prod accounts.
+          // We allow both because it may be useful for prod to launch a subset
+          // of instances in staging (for verification that rust-lang/rust
+          // runners will work against changes to infrastructure).
+          //
+          // Note that right now only the corresponding target account actually
+          // allows access from bors.
+          "arn:aws:iam::442426873467:role/*",
+          "arn:aws:iam::008376430877:role/*",
+        ]
+      }
+    ]
+  })
+}

--- a/terragrunt/modules/bors/variables.tf
+++ b/terragrunt/modules/bors/variables.tf
@@ -29,3 +29,7 @@ variable "cpu" {
 variable "memory" {
   description = "How much memory should be allocated to the bors instance."
 }
+
+variable "ec2_runner_role" {
+  description = "Role to be assumed to run EC2 instances"
+}

--- a/terragrunt/modules/ci-runners/iam.tf
+++ b/terragrunt/modules/ci-runners/iam.tf
@@ -36,3 +36,98 @@ resource "aws_iam_role_policy" "codebuild_policy" {
     ]
   })
 }
+
+resource "aws_iam_role" "executor" {
+  name = "gha-runner-management"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = "AllowBors"
+        Principal = {
+          AWS = var.executor_account_id
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "executor" {
+  name = "gha-runner-management"
+  role = aws_iam_role.executor.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        // The management service (bors) needs to be able to find and terminate
+        // instances that have leaked (e.g. because our on-host software failed
+        // to terminate them properly after the GitHub Actions runner exited).
+        Effect = "Allow"
+        Action = [
+          "ec2:DescribeInstances",
+          "ec2:TerminateInstances",
+        ]
+        Resource = ["*"]
+      },
+      {
+        // Used to resolve the AMI used.
+        Effect = "Allow"
+        Action = [
+          "ssm:GetParameters",
+        ]
+        Resource = ["arn:aws:ssm:*::parameter/aws/service/canonical/ubuntu/*"]
+      },
+      // The management service (bors) needs to be able to start new instances.
+      //
+      // This uses the examples given in the AWS docs (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ExamplePolicies_EC2.html#iam-example-launch-templates).
+      //
+      // The effect is that the launch template we specify is used, and no
+      // properties in the launch template can be overriden by the run
+      // instances call.
+      //
+      // This is defense in depth to enforce that the infrastructure-level
+      // security properties we expect are configured on the instance.
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:RunInstances",
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            // Enforce that bors uses the launch template we asked it to when calling.
+            "ec2:LaunchTemplate" = aws_launch_template.runner.arn
+          }
+          Bool = {
+            // Enforce that any resource specified in the launch tempalte
+            // cannot be overriden by the caller. This somewhat duplicates the
+            // above (e.g., security group enforcement), but seems like good
+            // defense in depth.
+            "ec2:IsLaunchTemplateResource" = true
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:RunInstances",
+        ]
+        Resource = [
+          // Allow any subnet to be used.
+          //
+          // We don't specify subnets in the template because we don't know
+          // which AZ we're going to launch in, so we need to let AWS pick. As
+          // such it's not going to be a launch template resource.
+          "arn:aws:ec2:us-east-2:*:subnet/*",
+          // Same with the image (at least for now). This is dynamically
+          // picked by resolving an SSM parameter, we can't embed that into
+          // the policy.
+          "arn:aws:ec2:us-east-2:*:image/*",
+        ]
+      }
+    ]
+  })
+}

--- a/terragrunt/modules/ci-runners/instance.tf
+++ b/terragrunt/modules/ci-runners/instance.tf
@@ -1,0 +1,45 @@
+resource "aws_launch_template" "runner" {
+  name = "gha-runner"
+
+  block_device_mappings {
+    device_name = "/dev/sda1"
+    ebs {
+      delete_on_termination = true
+      volume_type           = "gp3"
+      volume_size           = 300
+      throughput            = 800
+      iops                  = 3500
+    }
+  }
+
+  ebs_optimized = true
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+    instance_metadata_tags      = "disabled"
+  }
+
+  network_interfaces {
+    // We use a public IP address rather than NAT gateways because it's both
+    // easier and cheaper. Each NAT gateway is a minimum of $32/month,
+    // whereas a public IPv4 IP is $3.6/month. And we typically want 3 NAT
+    // gateways (one per AZ) to avoid cross-AZ bandwidth charges. We also don't
+    // expect to always have live runner instances.
+    //
+    // In an ideal future GitHub will support IPv6 and we can have IPv6-only
+    // runners. But in practice the cost of the IP is small compared to the
+    // cost of the instances (~thousands of dollars a month).
+    associate_public_ip_address = true
+
+    delete_on_termination = true
+    security_groups       = [aws_security_group.runner.id]
+  }
+
+  private_dns_name_options {
+    hostname_type                        = "resource-name"
+    enable_resource_name_dns_a_record    = false
+    enable_resource_name_dns_aaaa_record = false
+  }
+}

--- a/terragrunt/modules/ci-runners/network.tf
+++ b/terragrunt/modules/ci-runners/network.tf
@@ -1,0 +1,34 @@
+resource "aws_default_vpc" "runner" {
+}
+
+resource "aws_security_group" "runner" {
+  name        = "gha-runner"
+  description = "Allows egress from GitHub actions runners"
+  vpc_id      = aws_default_vpc.runner.id
+}
+
+resource "aws_vpc_security_group_egress_rule" "anywhere" {
+  security_group_id = aws_security_group.runner.id
+  // apt-get uses port 80 to reach ec2.archive.ubuntu.com
+  for_each = toset(["443", "80"])
+
+  // Our runners currently need fairly broad access. At minimum it'll be the **records** from here:
+  // https://docs.github.com/en/actions/reference/runners/self-hosted-runners#requirements-for-communication-with-github
+  // but in practice we also need S3, CloudFront, etc. Since we couldn't list out the GitHub records as IP addresses anyway, don't bother trying to restrict outbound access.
+  //
+  // For now we don't bother enforcing anything here except that there's no
+  // outbound network access except TCP:443. If we run into needing more than
+  // that we can likely relax this restriction.
+  cidr_ipv4   = "0.0.0.0/0"
+  from_port   = each.key
+  to_port     = each.key
+  ip_protocol = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "simulacrum-ssh" {
+  security_group_id = aws_security_group.runner.id
+  cidr_ipv4         = "131.143.232.57/32"
+  from_port         = "22"
+  to_port           = "22"
+  ip_protocol       = "tcp"
+}

--- a/terragrunt/modules/ci-runners/variables.tf
+++ b/terragrunt/modules/ci-runners/variables.tf
@@ -11,3 +11,8 @@ variable "code_connection_name" {
   type        = string
   description = "The name of the code connection that will be created to connect the codebuild projects to GitHub."
 }
+
+variable "executor_account_id" {
+  type        = string
+  description = "The ID of the AWS account that will manage EC2 instances in this account"
+}


### PR DESCRIPTION
This adds a role in the CI accounts that bors can assume, which grants permission to describe instances, terminate instances, and run instances. It also allows resolving Ubuntu AMI IDs.

The instance launch is restricted to using a launch template which constraints some of the options available to bors. We might remove parts of that enforcement to make it easier to experiment with different CI configurations.

Depending on frequency of changes to the resources defined here, we may want to expose versions or test against the staging account from production (maybe limited to a subset of try builds). Otherwise once we apply terraform updates (infra-admin only) the next or ongoing build gets impacted immediately which is not amazing.

Right now the assumption made here is that bors will launch instances and then at boot initialize them via a user-data script to configure/install the dependencies needed (GitHub actions runner, docker, etc.). I'm still exploring our options for building an AMI instead -- my current sense is that if we do build AMIs it should probably be in rust-lang/rust CI and treated similar to docker (i.e., we rebuild on every use of this runner as a pre-step before launching it, caching against a ~hash of the inputs, which would include the base AMI ID). But I'm still not sure building AMIs actually buys us enough value to be worth it since the installation steps are pretty fast anyway.

cc https://github.com/rust-lang/simpleinfra/issues/1132

cc @Kobzol 