### PR TITLE
remove monitoring pagerduty integration

### DIFF
--- a/ansible/envs/prod/group_vars/monitoring.yml
+++ b/ansible/envs/prod/group_vars/monitoring.yml
@@ -20,8 +20,6 @@ vars_grafana_admin_password: "{{ ssm_monitoring['grafana-admin-password'] }}"
 vars_alertmanager_zulip_url: "https://rust-lang.zulipchat.com/api/v1/external/slack_incoming?api_key={{ ssm_monitoring['alertmanager-receiver-zulip-token'] }}"
 vars_alertmanager_receiver_zulip_infra: "{{ vars_alertmanager_zulip_url }}&stream=t-infra%2Fprivate&topic=alertmanager"
 vars_alertmanager_receiver_zulip_docsrs: "{{ vars_alertmanager_zulip_url }}&stream=t-docs-rs%2Fprivate&topic=alertmanager"
-vars_alertmanager_receiver_pagerduty_cratesio: "{{ ssm_monitoring['alertmanager-receiver-pagerduty-cratesio'] }}"
-
 vars_prometheus_monitorbot_secret: "{{ lookup('aws_ssm', '/prod/monitorbot/secret', region='us-west-1') }}"
 vars_prometheus_cratesio_secret: "{{ ssm_monitoring['cratesio-scrape-secret'] }}"
 vars_prometheus_cratesio_heroku_metrics_secret: "{{ lookup('aws_ssm', '/prod/crates-io-heroku-metrics/password-metrics', region='us-west-1') }}"

--- a/ansible/playbooks/monitoring.yml
+++ b/ansible/playbooks/monitoring.yml
@@ -173,14 +173,6 @@
                 summary: "High RAM usage on {{ '{{ $labels.instance }}' }}"
                 description: "There is less than 20% available RAM on the {{ '{{ $labels.instance }}' }} instance, for more than 1 minute."
 
-        - name: cratesio
-          rules:
-            - alert: HerokuRouterError
-              expr: sum by (code) (increase(heroku_router_errors[1m])) > 100
-              for: 5m
-              labels:
-                dispatch: pagerduty-cratesio
-
         - name: crater
           rules:
             - alert: StuckAgent
@@ -222,11 +214,6 @@
         receiver: zulip-infra
 
         routes:
-          - receiver: pagerduty-cratesio
-            group_by: ['alertname']
-            match:
-              dispatch: pagerduty-cratesio
-
           # Suppress disk full alerts for Crater agents. They're supposed to go
           # near the limit and they're configured to handle things properly,
           # cleaning up unused files when they reach a threshold.
@@ -246,10 +233,6 @@
               title_link: "https://grafana.rust-lang.org"
               text: "{{ '{{ range .Alerts }}**{{ if eq .Status \"firing\" }}Fired{{ else }}Resolved{{ end }}: {{ .Annotations.summary }}**\n{{ .Annotations.description }}\n{{ end }}' }}"
               send_resolved: true
-
-        - name: pagerduty-cratesio
-          pagerduty_configs:
-            - service_key: "{{ vars_alertmanager_receiver_pagerduty_cratesio }}"
 
         - name: devnull
 


### PR DESCRIPTION
This alert is already in DataDog. We are switching to Datadog on call.

- [x] apply
- [x] remove the `alertmanager-receiver-pagerduty-cratesio` SSM parameter