### PR TITLE
Deploy an organization CloudTrail for Datadog Cloud SIEM

### DIFF
--- a/terragrunt/accounts/root/datadog-aws/terragrunt.hcl
+++ b/terragrunt/accounts/root/datadog-aws/terragrunt.hcl
@@ -7,6 +7,13 @@ include {
   merge_strategy = "deep"
 }
 
+# CloudTrail must be enabled before enabling log forwarding to Datadog.
+dependency "organization_cloudtrail" {
+  config_path = "../organization-cloudtrail"
+}
+
 inputs = {
-  env = "prod"
+  datadog_forwarder_arns = [dependency.organization_cloudtrail.outputs.datadog_forwarder_arn]
+  datadog_log_sources    = dependency.organization_cloudtrail.outputs.datadog_log_sources
+  env                    = "prod"
 }

--- a/terragrunt/accounts/root/organization-cloudtrail/.terraform.lock.hcl
+++ b/terragrunt/accounts/root/organization-cloudtrail/.terraform.lock.hcl
@@ -1,0 +1,46 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.61.0"
+  constraints = ">= 6.21.0, ~> 6.61"
+  hashes = [
+    "h1:luPmlKygfw2SMKJkMQ++/J8rRR0ZgR0uJPupp8wy3pw=",
+    "zh:216566f0fbc506e107d3a961c87d88aed052ec2b4ced13388394d3cff30425ac",
+    "zh:4700ad141d0ad96465ac35a3900f2ff7c91a1e5528428ac687c8b5825c0be718",
+    "zh:6b79d2fa6550fc51e2fac04f1066c5cc96e957e7634ad86d2250240e637db205",
+    "zh:76f6227bf2bcd7422cf29d9868d8b517c8220ec3edd4e7c8434b867a71c03334",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a7be5814cf94a8e3869ec9fa7f5182223a11373a4510ce68b9bab431f9b83746",
+    "zh:b65392e24506fe99f8df7bd2b5d3940d7a234b64b79a890f1aabe2be91a827e5",
+    "zh:b68a5092203cf5a9d1a5f01f9f2e96fded3eb7cacfd49ae851c50b87bc610fe9",
+    "zh:b8fedfa62bac16592519e1bae0c82dd7cd1544b0637543d72e3597e46ad7db32",
+    "zh:bba8a35212c07e68b6c881aa011c4b26a284e42b971059579aca9ffb63a8faef",
+    "zh:bbd0391e3e2f21c8930872829df7cf7f4e35f84c4d6d7b7619a94f8078fe6f3d",
+    "zh:c9c921e8e466281c04cada8d336ec1ce978128ee153e9df7b451847fbea49d18",
+    "zh:c9cb0be3097f4392b977fa254d28efd0909d008f572e74a41ead6c0d84c0daaa",
+    "zh:cc7aeb23fa3775816e391d4668a9865f787993f9f8d6f5b7a9f7e4effdffb3cb",
+    "zh:e59e487220cec8999bbd120ba8f97b5e04b010fb9149e47d4c9032961614d7c7",
+    "zh:fa19a7571a99397120f2f2bdcf33bbcc2f39091b9b0c879cd7e5f9ebb1966c40",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/http" {
+  version = "3.6.1"
+  hashes = [
+    "h1:uEqqVV3ui6Zr0k/lqyjvHM0Lg267qMMji+ux7wPfJXI=",
+    "zh:091d5009e05b7583d1883505d31ea354dbbd2ab6bcc1f9866e3fc40f708f74b2",
+    "zh:305c3e1c0f1e9e5c4bbf2a3a71c217b06146499a1815de0db052e5f277c7b5c1",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9c86821e99fcf1c9184087d73dd4940f14d10318d7229694fa61512c1216c279",
+    "zh:a0e08baf98384f7f20fe9beb2ca1acbbfb8bf71caaa33e49e35b584618648d46",
+    "zh:aaf767f5bf28a887c9c8f82a58b08275709642306b77c6b82c41c09aaa116390",
+    "zh:b0d189d11dbea1e2d2a31ee0c5cc215182e0448999bb5c1df0ef0e64e8aa3e74",
+    "zh:bdde65bcb27ba3f24a5ab7f455245709e8ae3dce2bcd8dbcb208ef4dc7f17a43",
+    "zh:c998032f00bb0cacc7f87e277f699ea3582ed86aee696a81af2eef8d5963b66b",
+    "zh:e40143fe7a2e8c4970190c77f82682a140a30de0340f0c8c57291ac22994d217",
+    "zh:e49ba3ff6244cbb30baa7a0e455d5652e4b650bf2a5459f9e6d349ef4503edeb",
+    "zh:e4ae6b4af472f90cd08a267f7120ac0f6e95af46486c3031564dd2a065aeda48",
+    "zh:f832598bbf437ea9d1dcfeeb527ca55c23137c724bb5400ff196a10e3bb3e53b",
+  ]
+}

--- a/terragrunt/accounts/root/organization-cloudtrail/terragrunt.hcl
+++ b/terragrunt/accounts/root/organization-cloudtrail/terragrunt.hcl
@@ -1,0 +1,13 @@
+terraform {
+  source = "../../../modules//organization-cloudtrail"
+}
+
+include {
+  path           = find_in_parent_folders()
+  merge_strategy = "deep"
+}
+
+# CloudTrail trusted access must be enabled before creating an organization trail.
+dependencies {
+  paths = ["../aws-organization"]
+}

--- a/terragrunt/modules/datadog-aws/README.md
+++ b/terragrunt/modules/datadog-aws/README.md
@@ -10,6 +10,12 @@ following variables:
 
 - `env`: The environment of the account, either `prod` or `staging`
 
+## Log forwarding
+
+The optional `datadog_forwarder_arns` and `datadog_log_sources` inputs register
+Datadog Forwarder Lambda functions and enable automatic log subscriptions for
+the specified AWS sources.
+
 [datadog]: https://datadoghq.com
 [datadog-aws]: https://docs.datadoghq.com/integrations/amazon_web_services/
 [terraform module]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/integration_aws_account

--- a/terragrunt/modules/datadog-aws/main.tf
+++ b/terragrunt/modules/datadog-aws/main.tf
@@ -127,6 +127,25 @@ resource "aws_iam_role_policy_attachment" "datadog" {
   policy_arn = aws_iam_policy.datadog.arn
 }
 
+resource "aws_iam_role_policy" "datadog_forwarders" {
+  count = length(var.datadog_forwarder_arns) > 0 ? 1 : 0
+  name  = "DatadogForwarderInvoke"
+  role  = aws_iam_role.datadog.id
+
+  # Datadog requires permission to invoke registered Forwarders when automatic
+  # log collection is enabled.
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action   = "lambda:InvokeFunction"
+        Effect   = "Allow"
+        Resource = var.datadog_forwarder_arns
+      }
+    ]
+  })
+}
+
 resource "datadog_integration_aws_account" "aws" {
   account_tags   = ["env:${var.env}"]
   aws_account_id = data.aws_caller_identity.current.account_id
@@ -142,8 +161,10 @@ resource "datadog_integration_aws_account" "aws" {
   }
 
   logs_config {
-    // Leave empty to disable Datadog Forwarder log autosubscription.
-    lambda_forwarder {}
+    lambda_forwarder {
+      lambdas = var.datadog_forwarder_arns
+      sources = var.datadog_log_sources
+    }
   }
 
   metrics_config {

--- a/terragrunt/modules/datadog-aws/variables.tf
+++ b/terragrunt/modules/datadog-aws/variables.tf
@@ -5,3 +5,25 @@ variable "env" {
     error_message = "The environment must be 'staging' or 'prod'."
   }
 }
+
+variable "datadog_forwarder_arns" {
+  description = "ARNs of Datadog Forwarder Lambda functions registered for automatic log subscription"
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition     = alltrue([for arn in var.datadog_forwarder_arns : length(trimspace(arn)) > 0])
+    error_message = "Datadog Forwarder ARNs must be non-empty strings."
+  }
+}
+
+variable "datadog_log_sources" {
+  description = "AWS log sources for which Datadog should configure automatic Forwarder subscriptions"
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition     = alltrue([for source in var.datadog_log_sources : length(trimspace(source)) > 0])
+    error_message = "Datadog log sources must be non-empty strings."
+  }
+}

--- a/terragrunt/modules/organization-cloudtrail/README.md
+++ b/terragrunt/modules/organization-cloudtrail/README.md
@@ -1,0 +1,17 @@
+# Organization CloudTrail
+
+This module creates one multi-Region organization trail. The trail records read
+and write management events in a private, versioned S3 bucket. CloudTrail
+delivers signed digest files that can be used to validate log-file integrity.
+The bucket expires current log objects after 365 days and permanently deletes
+their noncurrent versions 30 days later.
+
+The module also deploys the official Datadog Forwarder using Datadog's
+[`log-lambda-forwarder-datadog` Terraform module][forwarder-module]. The
+[`datadog-aws`](../datadog-aws) module reads the output to
+register the Forwarder and enable CloudTrail logs auto-subscription.
+
+The Forwarder assigns the `cloudtrail` source to the logs.
+Datadog Cloud SIEM can analyze these logs filtering by source.
+
+[forwarder-module]: https://registry.terraform.io/modules/DataDog/log-lambda-forwarder-datadog/aws/latest

--- a/terragrunt/modules/organization-cloudtrail/_terraform.tf
+++ b/terragrunt/modules/organization-cloudtrail/_terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.9, < 2.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.61"
+    }
+  }
+}

--- a/terragrunt/modules/organization-cloudtrail/main.tf
+++ b/terragrunt/modules/organization-cloudtrail/main.tf
@@ -1,0 +1,225 @@
+locals {
+  trail_name = "rust-organization"
+  trail_arn  = "arn:${data.aws_partition.current.partition}:cloudtrail:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:trail/${local.trail_name}"
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_organizations_organization" "current" {}
+data "aws_partition" "current" {}
+data "aws_region" "current" {}
+data "aws_secretsmanager_secret" "datadog_api_key" {
+  name = "/prod/datadog/cloudtrail-api-key"
+}
+
+# Bucket to store CloudTrail logs.
+resource "aws_s3_bucket" "cloudtrail" {
+  bucket = "rust-organization-cloudtrail"
+
+  # Audit logs should never be deleted implicitly when this resource is removed from Terraform.
+  force_destroy = false
+}
+
+resource "aws_s3_bucket_ownership_controls" "cloudtrail" {
+  bucket = aws_s3_bucket.cloudtrail.id
+
+  rule {
+    # Disable ACLs for authorization. Manage bucket access centrally, through IAM and bucket policies.
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+# Disable public access to the bucket.
+resource "aws_s3_bucket_public_access_block" "cloudtrail" {
+  bucket = aws_s3_bucket.cloudtrail.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "cloudtrail" {
+  bucket = aws_s3_bucket.cloudtrail.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      # Encrypt all log objects at rest without the need of managing a key.
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "cloudtrail" {
+  bucket = aws_s3_bucket.cloudtrail.id
+
+  versioning_configuration {
+    # Preserve prior object versions so accidental overwrites or deletes are recoverable.
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "cloudtrail" {
+  bucket = aws_s3_bucket.cloudtrail.id
+
+  # Configure versioning before applying version-aware lifecycle rules.
+  depends_on = [aws_s3_bucket_versioning.cloudtrail]
+
+  rule {
+    id     = "expire-cloudtrail-logs"
+    status = "Enabled"
+
+    # An empty filter applies the retention policy to every object in the bucket.
+    filter {}
+
+    expiration {
+      # Expire the current version after one year. S3 retains it temporarily as
+      # a noncurrent version according to the rule below.
+      days = 365
+    }
+
+    noncurrent_version_expiration {
+      # Keep replaced/deleted versions long enough for operational recovery without retaining them
+      # for the full audit-log period.
+      noncurrent_days = 30
+    }
+
+    abort_incomplete_multipart_upload {
+      # Failed uploads are not usable audit records. Remove their orphaned parts.
+      days_after_initiation = 7
+    }
+  }
+}
+
+# Policy described in https://docs.aws.amazon.com/awscloudtrail/latest/userguide/create-s3-bucket-policy-for-cloudtrail.html#org-trail-bucket-policy
+resource "aws_s3_bucket_policy" "cloudtrail" {
+  bucket = aws_s3_bucket.cloudtrail.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        # Protect all bucket and object operations from accidental plaintext HTTP access.
+        Sid       = "DenyInsecureTransport"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          aws_s3_bucket.cloudtrail.arn,
+          "${aws_s3_bucket.cloudtrail.arn}/*",
+        ]
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
+          }
+        }
+      },
+      {
+        # Allow CloudTrail to check bucket ownership and permissions.
+        Sid    = "AWSCloudTrailAclCheck20150319"
+        Effect = "Allow"
+        Principal = {
+          Service = "cloudtrail.amazonaws.com"
+        }
+        Action   = "s3:GetBucketAcl"
+        Resource = aws_s3_bucket.cloudtrail.arn
+        Condition = {
+          StringEquals = {
+            "aws:SourceArn" = local.trail_arn
+          }
+        }
+      },
+      {
+        # Allows logging in the event the trail is changed from an organization trail to a trail for that account only.
+        Sid    = "AWSCloudTrailWrite20150319"
+        Effect = "Allow"
+        Principal = {
+          Service = "cloudtrail.amazonaws.com"
+        }
+        Action   = "s3:PutObject"
+        Resource = "${aws_s3_bucket.cloudtrail.arn}/AWSLogs/${data.aws_caller_identity.current.account_id}/*"
+        Condition = {
+          StringEquals = {
+            "aws:SourceArn" = local.trail_arn
+            "s3:x-amz-acl"  = "bucket-owner-full-control"
+          }
+        }
+      },
+      {
+        # Allow logging for an organization trail.
+        Sid    = "AWSCloudTrailOrganizationWrite20150319"
+        Effect = "Allow"
+        Principal = {
+          Service = "cloudtrail.amazonaws.com"
+        }
+        Action   = "s3:PutObject"
+        Resource = "${aws_s3_bucket.cloudtrail.arn}/AWSLogs/${data.aws_organizations_organization.current.id}/*"
+        Condition = {
+          StringEquals = {
+            "aws:SourceArn" = local.trail_arn
+            "s3:x-amz-acl"  = "bucket-owner-full-control"
+          }
+        }
+      },
+    ]
+  })
+}
+
+# The Datadog Forwarder is declared in this module because moving it into the datadog-aws module
+# would add its transitive provider dependencies to every account's lock file, even when the
+# Forwarder is disabled.
+module "datadog_forwarder" {
+  # Datadog module: https://registry.terraform.io/modules/DataDog/log-lambda-forwarder-datadog/aws
+  source  = "DataDog/log-lambda-forwarder-datadog/aws"
+  version = "2.0.1"
+
+  # The secret is provisioned independently.
+  create_dd_api_key_secret = false
+  dd_api_key_secret_arn    = data.aws_secretsmanager_secret.datadog_api_key.arn
+  # Schedule retries for payloads the Forwarder stored after Datadog delivery failures.
+  dd_schedule_retry_failed_events = true
+  # Limit the Forwarder to CloudTrail logs to avoid giving Datadog access to other S3 buckets.
+  dd_s3_log_bucket_arns = ["${aws_s3_bucket.cloudtrail.arn}/*"]
+  dd_site               = "datadoghq.com"
+  # Retain failed payloads so they remain available for replay and investigation.
+  dd_store_failed_events = true
+  function_name          = "DatadogCloudTrailForwarder"
+  # https://github.com/DataDog/datadog-serverless-functions/releases
+  layer_version = "110" # Datadog Forwarder 5.4.11
+  # Retain operational Lambda logs long enough to investigate delayed forwarding failures.
+  log_retention_in_days = 30
+}
+
+# Record activity from the management account and every member account in the
+# organization, then deliver it to the protected bucket above.
+resource "aws_cloudtrail" "organization" {
+  name           = local.trail_name
+  s3_bucket_name = aws_s3_bucket.cloudtrail.id
+  # Digest files make it possible to verify that delivered logs were not modified or deleted.
+  enable_log_file_validation = true
+  # Start recording as soon as the trail is created.
+  enable_logging = true
+  # Include global services such as IAM whose events are not tied to a single Region.
+  include_global_service_events = true
+  # Capture activity in all current and future enabled Regions.
+  is_multi_region_trail = true
+  # Extend the trail from the management account to every account in the AWS organization.
+  is_organization_trail = true
+
+  event_selector {
+    # This trail captures control-plane activity only; high-volume data events such
+    # as S3 object access and Lambda invocations require separate, explicitly scoped selectors.
+    include_management_events = true
+    # Keep both read and write management calls for complete investigations and detections.
+    read_write_type = "All"
+  }
+
+  # Start logging only after the destination policy and all bucket protections are active.
+  depends_on = [
+    aws_s3_bucket_lifecycle_configuration.cloudtrail,
+    aws_s3_bucket_ownership_controls.cloudtrail,
+    aws_s3_bucket_policy.cloudtrail,
+    aws_s3_bucket_public_access_block.cloudtrail,
+    aws_s3_bucket_server_side_encryption_configuration.cloudtrail,
+    aws_s3_bucket_versioning.cloudtrail,
+  ]
+}

--- a/terragrunt/modules/organization-cloudtrail/outputs.tf
+++ b/terragrunt/modules/organization-cloudtrail/outputs.tf
@@ -1,0 +1,19 @@
+output "bucket_name" {
+  description = "S3 bucket receiving organization CloudTrail logs"
+  value       = aws_s3_bucket.cloudtrail.id
+}
+
+output "datadog_forwarder_arn" {
+  description = "Lambda function forwarding CloudTrail logs to Datadog"
+  value       = module.datadog_forwarder.datadog_forwarder_arn
+}
+
+output "datadog_log_sources" {
+  description = "AWS log sources to auto-subscribe to the Datadog Forwarder"
+  value       = ["cloudtrail"]
+}
+
+output "trail_arn" {
+  description = "Organization CloudTrail ARN"
+  value       = aws_cloudtrail.organization.arn
+}


### PR DESCRIPTION
Needed for https://github.com/rust-lang/infra-team/issues/290

Docs: https://docs.datadoghq.com/security/cloud_siem/guide/aws-config-guide-for-cloud-siem/

## tasks

- [x] set secret at `/prod/datadog/cloudtrail-api-key`

```shell
aws secretsmanager create-secret \
  --profile rust-root \
  --region us-east-1 \
  --name /prod/datadog/cloudtrail-api-key \
  --secret-string "$DD_API_KEY"
```

## How to apply

```shell
cd terragrunt/accounts/root/aws-organization
terragrunt apply

cd ../organization-cloudtrail
terragrunt apply

cd ../datadog-aws
terragrunt apply
```

## After apply

After deployment, enable Cloud SIEM and its AWS content pack in Datadog. Then
check whether the Log Explorer query `source:cloudtrail` returns recent events.

## AI disclosure

I used GPT5.6-Sol with the codex harness to generate this change. I reviewed its output and changed it where necessary.


<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>