### PR TITLE
add datadog permissions required by aws integration

### DIFF
--- a/terragrunt/modules/datadog-aws/main.tf
+++ b/terragrunt/modules/datadog-aws/main.tf
@@ -13,6 +13,7 @@ resource "aws_iam_policy" "datadog" {
     Statement = [
       {
         Action = [
+          "account:GetAccountInformation",
           "apigateway:GET",
           "autoscaling:Describe*",
           "backup:List*",
@@ -87,6 +88,7 @@ resource "aws_iam_policy" "datadog" {
           "tag:GetResources",
           "tag:GetTagKeys",
           "tag:GetTagValues",
+          "trustedadvisor:ListRecommendations",
           "xray:BatchGetTraces",
           "xray:GetTraceSummaries",
         ],


### PR DESCRIPTION
I saw this warning in Datadog
<img width="505" height="315" alt="image" src="https://github.com/user-attachments/assets/3752acb8-b79c-461a-934b-d0580e31b8e6" />
