### PR TITLE
Timeout instances before and after job assignment

### DIFF
--- a/terragrunt/modules/ci-runners/lambda/ubuntu.pkr.hcl
+++ b/terragrunt/modules/ci-runners/lambda/ubuntu.pkr.hcl
@@ -66,18 +66,37 @@ EOF
 
   provisioner "file" {
     content     = <<EOF
+#!/bin/bash
+echo "Running run=$GITHUB_RUN_ID (run_number=$GITHUB_RUN_NUMBER) job=$GITHUB_JOB ref=$GITHUB_REF sha=$GITHUB_SHA"
+systemd-notify --ready
+EOF
+    destination = "/home/ubuntu/job-started.sh"
+  }
+
+  provisioner "file" {
+    content     = <<EOF
 [Unit]
 Description=gha-runner
 After=network-online.target
-# After we exit, successfully or not, kill the instance.
-OnSuccess=poweroff.target
-OnFailure=poweroff.target
+FailureAction=poweroff-immediate
+SuccessAction=poweroff-immediate
+JobTimeoutAction=poweroff-immediate
+JobTimeoutSec=7h
 
 [Service]
 ExitType=cgroup
+SyslogIdentifier=gha-runner
 ExecStart=bash -c '/home/ubuntu/actions-runner/run.sh --jitconfig "$(cat /home/ubuntu/jit-token)"'
 User=ubuntu
 WorkingDirectory=/home/ubuntu/actions-runner
+# Setup early kill if we don't get a job assigned. Note that bors will
+# automatically spin up a replacement runner if it sees pending tasks.
+# This hook is described here: https://github.com/actions/runner/blob/main/docs/adrs/1751-runner-job-hooks.md
+Environment=ACTIONS_RUNNER_HOOK_JOB_STARTED=/home/ubuntu/job-started.sh
+Type=notify
+NotifyAccess=all
+# If no job has been assigned in 3 minutes, we kill the instance.
+TimeoutStartSec=3min
 EOF
     destination = "/tmp/gha-runner.service"
   }
@@ -87,6 +106,9 @@ EOF
       "sudo mkdir -p /etc/containers/",
       "sudo mv /tmp/containers.conf /etc/containers/containers.conf",
       "sudo mv /tmp/gha-runner.service /etc/systemd/system/gha-runner.service",
+      "sudo chown root:root /etc/systemd/system/gha-runner.service",
+      "sudo chmod a+r /etc/systemd/system/gha-runner.service",
+      "sudo chmod a+x /home/ubuntu/job-started.sh",
       "sudo apt-get update",
       # https://github.com/actions/runner/blob/main/docs/start/envlinux.md
       "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y rustup gcc awscli liblttng-ust1t64 libkrb5-3 zlib1g libssl3 libicu78 docker.io docker-buildx jq python3-pip",
@@ -98,10 +120,20 @@ EOF
       # Make tmpfs mount on / rather than tmpfs, avoiding issues with running
       # out of space on small instances.
       "sudo systemctl mask tmp.mount",
+      # Remove ssm agent since we don't use it.
+      "sudo snap remove amazon-ssm-agent",
       # Recommended by @the8472 for performance given that we don't care about correctness.
       # Defaults as of writing are rw,relatime,discard,errors=remount-ro,commit=30
       # Check by `cat /proc/mounts | grep ext4`.
-      "echo GRUB_CMDLINE_LINUX=\"rootflags=lazytime,barrier=0,data=writeback,noauto_da_alloc,journal_async_commit\" | sudo tee /etc/default/grub.d/99-packer.cfg",
+      "echo GRUB_CMDLINE_LINUX=\"rootflags=lazytime,barrier=0,data=writeback,noauto_da_alloc,journal_async_commit\" | sudo tee /etc/default/grub.d/99-packer-1.cfg",
+      # Disable systemd getty - no point in providing console login since
+      # there's no password that works. Instead we stream journal output to the
+      # console for ssh-free viewing of current status (EC2 get-console-output
+      # is a bit out of date so it's not perfect, but better than nothing).
+      #
+      # We also disable color to make it easier to view get-console-output
+      # without escape codes interfering.
+      "echo 'GRUB_CMDLINE_LINUX=\"systemd.getty_auto=no systemd.journald.forward_to_console=yes systemd.log_color=no\"' | sudo tee /etc/default/grub.d/99-packer-2.cfg",
       "sudo update-grub",
       # Prepare the snapshot for being used by new AMIs.
       "sudo cloud-init clean --configs all --seed --machine-id --logs",


### PR DESCRIPTION
gha-runner instances now wait up to 3 minutes for a job to be assigned. This is managed via a systemd "start timeout", and is intended to avoid long-lived EC2 instances when something in GitHub, our runners, or elsewhere has gone wrong, causing runners to fail to start. The "job assigned" hook is managed by a GitHub-invoked script which is visible in the GitHub UI under "Set up runner".

We also setup an overall 7 hour timeout. This should be entirely redundant since bors should kill instances after 6 hours, but it's a reasonable defense in depth against bugs in that logic. Note that we still self-terminate after a job finishes (successfully or not), so this should only be hit if a job is running for >6 hours.

To make it easier to monitor all of this, we also now route the systemd journal into the serial console, which is available on our instances without SSH access being needed (and with ReadOnly credentials). Actual job output doesn't get sent there by GitHub, but this enables making sure that the runner has started and more broadly monitoring what happens on the instances.