### PR TITLE
Provision the rustc-perf-prod AWS account

### DIFF
--- a/terragrunt/modules/aws-organization/accounts.tf
+++ b/terragrunt/modules/aws-organization/accounts.tf
@@ -79,3 +79,8 @@ resource "aws_organizations_account" "promote_release_prod" {
   name  = "promote-release-prod"
   email = "admin+promote-release-prod@rust-lang.org"
 }
+
+resource "aws_organizations_account" "rustc_perf_prod" {
+  name  = "rustc-perf-prod"
+  email = "admin+rustc-perf-prod@rust-lang.org"
+}

--- a/terragrunt/modules/aws-organization/groups.tf
+++ b/terragrunt/modules/aws-organization/groups.tf
@@ -495,6 +495,15 @@ locals {
         permissions : [aws_ssoadmin_permission_set.view_only_access] },
       ]
     },
+    {
+      account : aws_organizations_account.rustc_perf_prod,
+      groups : [
+        { group : aws_identitystore_group.infra-admins,
+        permissions : [aws_ssoadmin_permission_set.read_only_access, aws_ssoadmin_permission_set.administrator_access] },
+        { group : aws_identitystore_group.infra,
+        permissions : [aws_ssoadmin_permission_set.read_only_access] },
+      ]
+    },
   ]
 }
 


### PR DESCRIPTION
Creates the `rustc-perf-prod` AWS Organizations account.
Used for [#t-infra > rustc-perf on ARM machines](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/rustc-perf.20on.20ARM.20machines/with/616733076): we need to provision an EC2.


## AI disclosure

I used GPT5.6-Sol with the codex harness to generate this change. I reviewed its output and changed it where necessary.