### PR TITLE
Provision the Graviton 5 rustc-perf collector

### DIFF
--- a/terragrunt/accounts/rustc-perf-prod/README.md
+++ b/terragrunt/accounts/rustc-perf-prod/README.md
@@ -1,0 +1,116 @@
+# rustc-perf production AWS account
+
+This account contains the Graviton 5 collector for rustc-perf. The collector is
+an `m9g.12xlarge` partition, with 48 vCPUs and 192 GiB of memory, placed on an
+M9g Dedicated Host in `us-east-2`. The host is allocated for the M9g family,
+not the 12xlarge size. AWS's capacity table currently lists room for eight
+`m9g.12xlarge` instances on an empty host, so this initial collector leaves
+capacity for more compatible M9g instances later. Dedicated tenancy keeps the
+physical server exclusive to the account; a boot-time `perf stat` smoke test
+separately verifies that the guest exposes the hardware counters rustc-perf
+needs.
+
+The machine has no inbound firewall rules. Operators connect through AWS
+Systems Manager Session Manager. Its public IPv4 address is used only for
+outbound access without the cost of a NAT gateway.
+
+Terraform allocates the host with On-Demand billing. It does not purchase a
+one- or three-year Dedicated Host Reservation: selecting an offering and its
+payment terms is a separate financial commitment that should be made after the
+host exists and the funding terms are confirmed.
+
+## Rollout
+
+Apply the states in this order. Do not apply the collector state until AWS has
+approved the quota request.
+
+1. Apply the organization state from the `rust-root` account:
+
+   ```console
+   cd terragrunt/accounts/root/aws-organization
+   terragrunt plan
+   terragrunt apply
+   ```
+
+2. Add an AWS CLI profile for the new account, using the account ID shown in
+   the IAM Identity Center portal:
+
+   ```ini
+   [profile rustc-perf-prod]
+   sso_start_url = https://rust-lang.awsapps.com/start
+   sso_account_id = <rustc-perf-prod-account-id>
+   sso_role_name = AdministratorAccess
+   sso_region = us-east-1
+   region = us-east-2
+   ```
+
+3. Log in and apply the account baseline and quota request:
+
+   ```console
+   aws sso login --profile rustc-perf-prod
+
+   cd terragrunt/accounts/rustc-perf-prod/datadog-aws
+   terragrunt apply
+
+   cd ../wiz
+   terragrunt apply
+
+   cd ../ec2-quota
+   terragrunt apply
+   ```
+
+4. Wait for the regional Running Dedicated m9g Hosts quota to reach 1. New AWS
+   accounts default to zero, and host allocation cannot begin until AWS
+   approves the request:
+
+   ```console
+   aws service-quotas get-service-quota \
+     --profile rustc-perf-prod \
+     --region us-east-2 \
+     --service-code ec2 \
+     --quota-code L-9F9F275C \
+     --query 'Quota.Value'
+   ```
+
+5. Apply the collector state:
+
+   ```console
+   cd terragrunt/accounts/rustc-perf-prod/collector
+   terragrunt plan
+   terragrunt apply
+   ```
+
+## Verify the collector
+
+Once the instance is registered with Systems Manager, start a session:
+
+```console
+cd terragrunt/accounts/rustc-perf-prod/collector
+instance_id="$(terragrunt output -raw instance_id)"
+aws ssm start-session \
+  --profile rustc-perf-prod \
+  --region us-east-2 \
+  --target "$instance_id"
+```
+
+On the instance, wait for cloud-init and confirm the PMU smoke test succeeded:
+
+```console
+cloud-init status --wait
+test -f /var/lib/rustc-perf/perf-counters-ready
+perf stat -e cycles,instructions,branches,branch-misses -- sleep 1
+```
+
+The boot configuration installs the native kernel's `perf` package and sets
+`kernel.perf_event_paranoid=-1`, allowing the unprivileged collector process to
+read the counters. Stopping the instance preserves its encrypted root volume,
+but it does **not** stop billing for the allocated Dedicated Host. Ending host
+charges requires terminating every instance on the host and releasing the host;
+the collector's API termination protection makes that an explicit Terraform
+configuration change rather than an accidental command.
+
+## Dedicated host auto recovery
+
+[Dedicated Host auto recovery](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-hosts-recovery.html)
+is disabled because AWS does not currently list
+M9g among the instance families that support it.

--- a/terragrunt/accounts/rustc-perf-prod/README.md
+++ b/terragrunt/accounts/rustc-perf-prod/README.md
@@ -1,17 +1,15 @@
 # rustc-perf production AWS account
 
-This account contains the Graviton 5 collector for rustc-perf. The collector is
-an `m9g.12xlarge` partition, with 48 vCPUs and 192 GiB of memory, placed on an
-M9g Dedicated Host in `us-east-2`. The host is allocated for the M9g family,
-not the 12xlarge size. AWS's capacity table currently lists room for eight
-`m9g.12xlarge` instances on an empty host, so this initial collector leaves
-capacity for more compatible M9g instances later. Dedicated tenancy keeps the
-physical server exclusive to the account; a boot-time `perf stat` smoke test
-separately verifies that the guest exposes the hardware counters rustc-perf
-needs.
+This account contains two Graviton 5 collectors for rustc-perf. Each collector
+is an `m9g.metal-48xl` instance with 192 vCPUs and 768 GiB of memory. Both are
+placed on the same M9g Dedicated Host in `us-east-2`, using the host's two
+metal-48xl slots. Dedicated tenancy keeps the physical server exclusive to the
+account, while the bare-metal instance type gives each collector direct access
+to its Graviton 5 socket. A boot-time `perf stat` smoke test verifies that the
+hardware counters rustc-perf needs are available.
 
-The machine has no inbound firewall rules. Operators connect through AWS
-Systems Manager Session Manager. Its public IPv4 address is used only for
+The machines have no inbound firewall rules. Operators connect through AWS
+Systems Manager Session Manager. Their public IPv4 addresses are used only for
 outbound access without the cost of a NAT gateway.
 
 Terraform allocates the host with On-Demand billing. It does not purchase a
@@ -80,13 +78,15 @@ approved the quota request.
    terragrunt apply
    ```
 
-## Verify the collector
+## Verify the collectors
 
-Once the instance is registered with Systems Manager, start a session:
+Once the instances are registered with Systems Manager, list their IDs and
+start a session with either one (change the array index to select the other):
 
 ```console
 cd terragrunt/accounts/rustc-perf-prod/collector
-instance_id="$(terragrunt output -raw instance_id)"
+terragrunt output -json instance_ids
+instance_id="$(terragrunt output -json instance_ids | jq -r '.[0]')"
 aws ssm start-session \
   --profile rustc-perf-prod \
   --region us-east-2 \
@@ -103,10 +103,10 @@ perf stat -e cycles,instructions,branches,branch-misses -- sleep 1
 
 The boot configuration installs the native kernel's `perf` package and sets
 `kernel.perf_event_paranoid=-1`, allowing the unprivileged collector process to
-read the counters. Stopping the instance preserves its encrypted root volume,
+read the counters. Stopping an instance preserves its encrypted root volume,
 but it does **not** stop billing for the allocated Dedicated Host. Ending host
-charges requires terminating every instance on the host and releasing the host;
-the collector's API termination protection makes that an explicit Terraform
+charges requires terminating both instances and releasing the host; the
+collectors' API termination protection makes that an explicit Terraform
 configuration change rather than an accidental command.
 
 ## Dedicated host auto recovery

--- a/terragrunt/accounts/rustc-perf-prod/collector/.terraform.lock.hcl
+++ b/terragrunt/accounts/rustc-perf-prod/collector/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.61.0"
+  constraints = "~> 6.61"
+  hashes = [
+    "h1:luPmlKygfw2SMKJkMQ++/J8rRR0ZgR0uJPupp8wy3pw=",
+    "zh:216566f0fbc506e107d3a961c87d88aed052ec2b4ced13388394d3cff30425ac",
+    "zh:4700ad141d0ad96465ac35a3900f2ff7c91a1e5528428ac687c8b5825c0be718",
+    "zh:6b79d2fa6550fc51e2fac04f1066c5cc96e957e7634ad86d2250240e637db205",
+    "zh:76f6227bf2bcd7422cf29d9868d8b517c8220ec3edd4e7c8434b867a71c03334",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a7be5814cf94a8e3869ec9fa7f5182223a11373a4510ce68b9bab431f9b83746",
+    "zh:b65392e24506fe99f8df7bd2b5d3940d7a234b64b79a890f1aabe2be91a827e5",
+    "zh:b68a5092203cf5a9d1a5f01f9f2e96fded3eb7cacfd49ae851c50b87bc610fe9",
+    "zh:b8fedfa62bac16592519e1bae0c82dd7cd1544b0637543d72e3597e46ad7db32",
+    "zh:bba8a35212c07e68b6c881aa011c4b26a284e42b971059579aca9ffb63a8faef",
+    "zh:bbd0391e3e2f21c8930872829df7cf7f4e35f84c4d6d7b7619a94f8078fe6f3d",
+    "zh:c9c921e8e466281c04cada8d336ec1ce978128ee153e9df7b451847fbea49d18",
+    "zh:c9cb0be3097f4392b977fa254d28efd0909d008f572e74a41ead6c0d84c0daaa",
+    "zh:cc7aeb23fa3775816e391d4668a9865f787993f9f8d6f5b7a9f7e4effdffb3cb",
+    "zh:e59e487220cec8999bbd120ba8f97b5e04b010fb9149e47d4c9032961614d7c7",
+    "zh:fa19a7571a99397120f2f2bdcf33bbcc2f39091b9b0c879cd7e5f9ebb1966c40",
+  ]
+}

--- a/terragrunt/accounts/rustc-perf-prod/collector/.terraform.lock.hcl
+++ b/terragrunt/accounts/rustc-perf-prod/collector/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.58.0"
+  constraints = "~> 6.27"
+  hashes = [
+    "h1:2kpake4zZKRX5437QVIRU3qFYH6Bjw/QE1fgVCPOrUg=",
+    "zh:1221253beee5629fb503d79cebc9bc661279cbc4be5d01db9ab4c1b702108250",
+    "zh:132bd0925bdc4b72446ac750b7ccb1e19b9ba8fbb6df57b2c1423314d2195d4f",
+    "zh:18cda250b9e82b753808715893c8927f132273c00ffae7a697d65ac1cb577e48",
+    "zh:204c944f1fb7f440a335bb2083c9691a9d1f677aea9701025dd5816aee41f0ba",
+    "zh:2dc41df289f2b10a01e650cdd73699955f0ab0645d09cfb114a8cd0f4cc4ede7",
+    "zh:345633dfa9a234659d52aadd126e6dce658518c3ab5cbf6d871221287ed5ec56",
+    "zh:4dadcced73e742903158bc9838936d911f3fa4c2c37b5591c1a28f8f2a1902a6",
+    "zh:5bc60cc2b8c093da98b211d9f6c21c9ecec0f21b944d9ecbe3961fba33086e80",
+    "zh:6cc8f084938b0033a9c0c910989919dad6b1683e76e0afa1a5c604e39f398a75",
+    "zh:7db214647f79de9a033b5dfd6cbfaa42d53c4d056b32cb3acc7ad99306dd548a",
+    "zh:9078589ec881cee7ed9403af262c98ff257fb3e1baae72ff6429a398b1c730af",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:bd5bce6aec4d4922b1127b8575688bd4bc4279670ee28d198ede404709826c7c",
+    "zh:cd900ecf56d21023873898b06e40234f3f4d350f2343b7d9b980d6c5cb604fae",
+    "zh:dbe93b276a84421026b956c3c5b4eb8897da6cbb54b93cb89f5d6ebbd30805ca",
+    "zh:f6b6c7bb2dbf04ee085e5c22f7a65b3ccaebf368ed95584dc0dfee8a22771056",
+  ]
+}

--- a/terragrunt/accounts/rustc-perf-prod/collector/terragrunt.hcl
+++ b/terragrunt/accounts/rustc-perf-prod/collector/terragrunt.hcl
@@ -1,0 +1,8 @@
+terraform {
+  source = "../../../modules//rustc-perf-collector"
+}
+
+include {
+  path           = find_in_parent_folders()
+  merge_strategy = "deep"
+}

--- a/terragrunt/accounts/rustc-perf-prod/collector/terragrunt.hcl
+++ b/terragrunt/accounts/rustc-perf-prod/collector/terragrunt.hcl
@@ -1,0 +1,20 @@
+terraform {
+  source = "../../../modules//rustc-perf-collector"
+}
+
+include {
+  path           = find_in_parent_folders()
+  merge_strategy = "deep"
+}
+
+dependency "quota" {
+  config_path = "../ec2-quota"
+}
+
+inputs = {
+  # Reading an output creates a Terragrunt dependency on the separately
+  # applied quota request. The module also checks the account's *current*
+  # quota, so a requested-but-not-yet-approved increase cannot allocate the
+  # Dedicated Host and start billing it.
+  required_dedicated_hosts = dependency.quota.outputs.requested_value
+}

--- a/terragrunt/modules/rustc-perf-collector/_terraform.tf
+++ b/terragrunt/modules/rustc-perf-collector/_terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.27"
+    }
+  }
+}

--- a/terragrunt/modules/rustc-perf-collector/_terraform.tf
+++ b/terragrunt/modules/rustc-perf-collector/_terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.61"
+    }
+  }
+}

--- a/terragrunt/modules/rustc-perf-collector/data.tf
+++ b/terragrunt/modules/rustc-perf-collector/data.tf
@@ -1,0 +1,30 @@
+locals {
+  // The project requested the M9g (Graviton 5) family on a Dedicated Host.
+  // Start with a 12xlarge partition: it provides 48 vCPUs and 192 GiB while
+  // using one of the eight 12xlarge slots listed for an empty M9g host, leaving
+  // capacity available for future M9g collectors.
+  instance_family = "m9g"
+  instance_type   = "m9g.12xlarge"
+
+  availability_zone = "us-east-2a"
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-arm64-server-*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["arm64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}

--- a/terragrunt/modules/rustc-perf-collector/data.tf
+++ b/terragrunt/modules/rustc-perf-collector/data.tf
@@ -1,10 +1,9 @@
 locals {
-  // The project requested the M9g (Graviton 5) family on a Dedicated Host.
-  // Start with a 12xlarge partition: it provides 48 vCPUs and 192 GiB while
-  // using one of the eight 12xlarge slots listed for an empty M9g host, leaving
-  // capacity available for future M9g collectors.
+  // An M9g Dedicated Host has two metal-48xl slots. Use both slots so each
+  // collector gets direct access to one of the host's Graviton 5 sockets.
+  instance_count  = 2
   instance_family = "m9g"
-  instance_type   = "m9g.12xlarge"
+  instance_type   = "m9g.metal-48xl"
 
   availability_zone = "us-east-2a"
 }

--- a/terragrunt/modules/rustc-perf-collector/data.tf
+++ b/terragrunt/modules/rustc-perf-collector/data.tf
@@ -1,0 +1,52 @@
+locals {
+  // The project requested the M9g (Graviton 5) family on a Dedicated Host.
+  // Start with a 12xlarge partition: it provides 48 vCPUs and 192 GiB while
+  // using one of the eight 12xlarge slots listed for an empty M9g host, leaving
+  // capacity available for future M9g collectors.
+  instance_family = "m9g"
+  instance_type   = "m9g.12xlarge"
+
+  // New instance families are not necessarily offered in every AZ. Select a
+  // stable AZ ID from AWS's live offerings instead of hard-coding an AZ name
+  // that can map differently between accounts.
+  availability_zone_id = try(sort(data.aws_ec2_instance_type_offerings.collector.locations)[0], null)
+}
+
+// Use Canonical's official arm64 image: Graviton cannot boot the repository's
+// usual amd64 AMIs. most_recent is safe here because instance.tf ignores later
+// AMI changes to avoid silently replacing a benchmark machine.
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["arm64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+data "aws_ec2_instance_type_offerings" "collector" {
+  filter {
+    name   = "instance-type"
+    values = [local.instance_type]
+  }
+
+  location_type = "availability-zone-id"
+}
+
+// The quota request records the desired value; this data source reads the
+// actually approved value used by the host-allocation precondition.
+data "aws_servicequotas_service_quota" "m9g_hosts" {
+  service_code = "ec2"
+  quota_code   = "L-9F9F275C"
+}

--- a/terragrunt/modules/rustc-perf-collector/dedicated-host.tf
+++ b/terragrunt/modules/rustc-perf-collector/dedicated-host.tf
@@ -1,0 +1,42 @@
+// A Dedicated Host is an entire physical EC2 server allocated to this AWS
+// account. Selecting the family rather than one instance type lets us divide
+// its capacity among supported M9g sizes instead of fixing the host layout at
+// allocation time. aws_ec2_host allocates an On-Demand host; it deliberately
+// does not purchase a one- or three-year Dedicated Host Reservation because
+// that is a separate, irreversible billing commitment with payment-term input.
+resource "aws_ec2_host" "collector" {
+  availability_zone = aws_subnet.collector.availability_zone
+  instance_family   = local.instance_family
+
+  // Require every instance to name this host explicitly. This prevents an
+  // unrelated M9g launch in the account from silently consuming benchmark
+  // capacity through EC2 auto-placement.
+  auto_placement = "off"
+
+  // M9g supports Dedicated Host recovery, so EC2 can allocate replacement
+  // hardware after supported power or network failures. It does not cover
+  // every failure mode (notably scheduled host retirement), which still needs
+  // operator action.
+  host_recovery = "on"
+
+  tags = {
+    Name        = "rustc-perf-graviton5"
+    Environment = "prod"
+    Service     = "rustc-perf"
+  }
+
+  lifecycle {
+    precondition {
+      condition     = local.availability_zone_id != null
+      error_message = "${local.instance_type} is not offered in this AWS region."
+    }
+
+    // A quota request can exist in state while AWS is still reviewing it.
+    // Gate host allocation on the applied quota because billing begins when
+    // the Dedicated Host is allocated, even if it contains no instances.
+    precondition {
+      condition     = data.aws_servicequotas_service_quota.m9g_hosts.value >= var.required_dedicated_hosts
+      error_message = "The Running Dedicated m9g Hosts quota increase must be approved before allocating the host."
+    }
+  }
+}

--- a/terragrunt/modules/rustc-perf-collector/dedicated-host.tf
+++ b/terragrunt/modules/rustc-perf-collector/dedicated-host.tf
@@ -1,9 +1,8 @@
 // A Dedicated Host is an entire physical EC2 server allocated to this AWS
-// account. Selecting the family rather than one instance type lets us divide
-// its capacity among supported M9g sizes instead of fixing the host layout at
-// allocation time. aws_ec2_host allocates an On-Demand host; it deliberately
-// does not purchase a one- or three-year Dedicated Host Reservation because
-// that is a separate, irreversible billing commitment with payment-term input.
+// account. Its two metal-48xl slots provide the two requested bare-metal
+// collectors. aws_ec2_host allocates an On-Demand host; it deliberately does
+// not purchase a one- or three-year Dedicated Host Reservation because that is
+// a separate, irreversible billing commitment with payment-term input.
 resource "aws_ec2_host" "collector" {
   availability_zone = local.availability_zone
   instance_family   = local.instance_family

--- a/terragrunt/modules/rustc-perf-collector/dedicated-host.tf
+++ b/terragrunt/modules/rustc-perf-collector/dedicated-host.tf
@@ -1,0 +1,15 @@
+// A Dedicated Host is an entire physical EC2 server allocated to this AWS
+// account. Selecting the family rather than one instance type lets us divide
+// its capacity among supported M9g sizes instead of fixing the host layout at
+// allocation time. aws_ec2_host allocates an On-Demand host; it deliberately
+// does not purchase a one- or three-year Dedicated Host Reservation because
+// that is a separate, irreversible billing commitment with payment-term input.
+resource "aws_ec2_host" "collector" {
+  availability_zone = local.availability_zone
+  instance_family   = local.instance_family
+
+  // Require every instance to name this host explicitly. This prevents an
+  // unrelated M9g launch in the account from silently consuming benchmark
+  // capacity through EC2 auto-placement.
+  auto_placement = "off"
+}

--- a/terragrunt/modules/rustc-perf-collector/iam.tf
+++ b/terragrunt/modules/rustc-perf-collector/iam.tf
@@ -1,0 +1,33 @@
+// The instance role is intentionally limited to Systems Manager. Workload
+// access to rustc-perf storage or secrets should be added separately and with
+// narrower policies once the collector is enrolled.
+resource "aws_iam_role" "collector" {
+  name = "rustc-perf-collector"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = "sts:AssumeRole"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ssm" {
+  // This managed policy lets the *agent* establish its outbound SSM control
+  // channel. Human permission to start a session comes from Identity Center.
+  role       = aws_iam_role.collector.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+// EC2 receives IAM roles through an instance-profile wrapper rather than by
+// attaching aws_iam_role directly to aws_instance.
+resource "aws_iam_instance_profile" "collector" {
+  name = "rustc-perf-collector"
+  role = aws_iam_role.collector.name
+}

--- a/terragrunt/modules/rustc-perf-collector/iam.tf
+++ b/terragrunt/modules/rustc-perf-collector/iam.tf
@@ -1,0 +1,70 @@
+// The instance role is intentionally limited to Systems Manager. Workload
+// access to rustc-perf storage or secrets should be added separately and with
+// narrower policies once the collector is enrolled.
+resource "aws_iam_role" "collector" {
+  name = "rustc-perf-collector"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = "sts:AssumeRole"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ssm" {
+  // This managed policy lets the *agent* establish its outbound SSM control
+  // channel. Human permission to start a session comes from Identity Center.
+  role       = aws_iam_role.collector.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+// EC2 receives IAM roles through an instance-profile wrapper rather than by
+// attaching aws_iam_role directly to aws_instance.
+resource "aws_iam_instance_profile" "collector" {
+  name = "rustc-perf-collector"
+  role = aws_iam_role.collector.name
+}
+
+// SSM documents are account-and-region-local configuration consumed by
+// Systems Manager. This one defines the default interactive shell used by
+// `aws ssm start-session`; it is not a startup script for the instance.
+// Managing it here makes the no-SSH access path available without a manual
+// console step, runs operators as Ubuntu's normal sudo-capable user, and puts
+// finite idle and total limits on forgotten sessions.
+resource "aws_ssm_document" "session_preferences" {
+  name            = "SSM-SessionManagerRunShell"
+  document_format = "JSON"
+  document_type   = "Session"
+
+  content = jsonencode({
+    schemaVersion = "1.0"
+    description   = "Regional Session Manager settings for rustc-perf-prod"
+    sessionType   = "Standard_Stream"
+    inputs = {
+      // There is no account-local log destination yet, so session contents are
+      // not streamed. Session API activity is still captured by CloudTrail.
+      s3BucketName                = ""
+      s3KeyPrefix                 = ""
+      s3EncryptionEnabled         = true
+      cloudWatchLogGroupName      = ""
+      cloudWatchEncryptionEnabled = true
+      cloudWatchStreamingEnabled  = false
+      kmsKeyId                    = ""
+      runAsEnabled                = true
+      runAsDefaultUser            = "ubuntu"
+      idleSessionTimeout          = "20"
+      maxSessionDuration          = "240"
+      shellProfile = {
+        windows = ""
+        linux   = "cd /home/ubuntu"
+      }
+    }
+  })
+}

--- a/terragrunt/modules/rustc-perf-collector/iam.tf
+++ b/terragrunt/modules/rustc-perf-collector/iam.tf
@@ -1,6 +1,6 @@
 // The instance role is intentionally limited to Systems Manager. Workload
 // access to rustc-perf storage or secrets should be added separately and with
-// narrower policies once the collector is enrolled.
+// narrower policies once the collectors are enrolled.
 resource "aws_iam_role" "collector" {
   name = "rustc-perf-collector"
 

--- a/terragrunt/modules/rustc-perf-collector/instance.tf
+++ b/terragrunt/modules/rustc-perf-collector/instance.tf
@@ -1,0 +1,67 @@
+resource "aws_instance" "collector" {
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = local.instance_type
+  // host tenancy plus the explicit host ID places this instance on the
+  // account's M9g physical server instead of the normal shared EC2 fleet.
+  host_id                = aws_ec2_host.collector.id
+  tenancy                = "host"
+  subnet_id              = aws_subnet.collector.id
+  vpc_security_group_ids = [aws_security_group.collector.id]
+  // The public address is only for outbound package, toolchain, and benchmark
+  // downloads. network.tf defines no ingress rules; administration goes
+  // through SSM. This avoids a continuously billed NAT gateway for one host.
+  associate_public_ip_address = true
+  iam_instance_profile        = aws_iam_instance_profile.collector.name
+
+  // Accidental deletion would discard a calibrated benchmark environment. A
+  // guest shutdown stops the partition rather than terminating its EBS volume;
+  // it does not stop Dedicated Host billing while the physical host is
+  // allocated. Detailed EC2 monitoring is unrelated to PMU counters.
+  disable_api_termination              = true
+  ebs_optimized                        = true
+  instance_initiated_shutdown_behavior = "stop"
+  monitoring                           = false
+
+  // EC2 gives this script to cloud-init on the first boot. It installs the
+  // native perf tooling, enables unprivileged PMU access, starts the SSM agent,
+  // and runs a counter smoke test. It is bootstrap configuration, not a script
+  // rerun by every Terraform apply.
+  user_data = file("${path.module}/user-data.sh")
+
+  // Require IMDSv2 and keep its packets local to the host, reducing the chance
+  // that a benchmark process can accidentally expose instance-role credentials.
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
+    http_put_response_hop_limit = 1
+    http_tokens                 = "required"
+    instance_metadata_tags      = "disabled"
+  }
+
+  // M9g is EBS-only. Provisioned gp3 performance reduces storage variance
+  // during compilation, while 500 GiB leaves room for toolchains, sources, and
+  // build artifacts. Encryption protects the persistent volume when stopped.
+  root_block_device {
+    delete_on_termination = true
+    encrypted             = true
+    iops                  = 12000
+    throughput            = 500
+    volume_size           = 500
+    volume_type           = "gp3"
+  }
+
+  tags = {
+    Name        = "rustc-perf-graviton5"
+    Environment = "prod"
+    Service     = "rustc-perf"
+  }
+
+  lifecycle {
+    # Do not replace the collector just because Canonical published a new AMI.
+    ignore_changes = [ami]
+  }
+
+  // Ensure the documented SSM access method is configured before EC2 can
+  // register as a managed node and an operator attempts the first session.
+  depends_on = [aws_ssm_document.session_preferences]
+}

--- a/terragrunt/modules/rustc-perf-collector/instance.tf
+++ b/terragrunt/modules/rustc-perf-collector/instance.tf
@@ -1,0 +1,60 @@
+resource "aws_instance" "collector" {
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = local.instance_type
+  // host tenancy plus the explicit host ID places this instance on the
+  // account's M9g physical server instead of the normal shared EC2 fleet.
+  host_id                = aws_ec2_host.collector.id
+  tenancy                = "host"
+  subnet_id              = aws_subnet.collector.id
+  vpc_security_group_ids = [aws_security_group.collector.id]
+  // The public address is only for outbound package, toolchain, and benchmark
+  // downloads. network.tf defines no ingress rules; administration goes
+  // through SSM. This avoids a continuously billed NAT gateway for one host.
+  associate_public_ip_address = true
+  iam_instance_profile        = aws_iam_instance_profile.collector.name
+
+  // Accidental deletion would discard a calibrated benchmark environment. A
+  // guest shutdown stops the partition rather than terminating its EBS volume;
+  // it does not stop Dedicated Host billing while the physical host is
+  // allocated. Detailed EC2 monitoring is unrelated to PMU counters.
+  disable_api_termination              = true
+  ebs_optimized                        = true
+  instance_initiated_shutdown_behavior = "stop"
+  monitoring                           = false
+
+  // EC2 gives this script to cloud-init on the first boot. It installs the
+  // native perf tooling, enables unprivileged PMU access, starts the SSM agent,
+  // and runs a counter smoke test. It is bootstrap configuration, not a script
+  // rerun by every Terraform apply.
+  user_data = file("${path.module}/user-data.sh")
+
+  // Require IMDSv2 and keep its packets local to the host, reducing the chance
+  // that a benchmark process can accidentally expose instance-role credentials.
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
+    http_put_response_hop_limit = 1
+    http_tokens                 = "required"
+    instance_metadata_tags      = "disabled"
+  }
+
+  // M9g is EBS-only. Provisioned gp3 performance reduces storage variance
+  // during compilation, while 500 GiB leaves room for toolchains, sources, and
+  // build artifacts. Encryption protects the persistent volume when stopped.
+  root_block_device {
+    delete_on_termination = true
+    encrypted             = true
+    volume_size           = 500 # GiB
+  }
+
+  tags = {
+    Name        = "rustc-perf-graviton5"
+    Environment = "prod"
+    Service     = "rustc-perf"
+  }
+
+  lifecycle {
+    # Do not replace the collector just because Canonical published a new AMI.
+    ignore_changes = [ami]
+  }
+}

--- a/terragrunt/modules/rustc-perf-collector/instance.tf
+++ b/terragrunt/modules/rustc-perf-collector/instance.tf
@@ -1,4 +1,6 @@
 resource "aws_instance" "collector" {
+  count = local.instance_count
+
   ami           = data.aws_ami.ubuntu.id
   instance_type = local.instance_type
   // host tenancy plus the explicit host ID places this instance on the
@@ -9,7 +11,7 @@ resource "aws_instance" "collector" {
   vpc_security_group_ids = [aws_security_group.collector.id]
   // The public address is only for outbound package, toolchain, and benchmark
   // downloads. network.tf defines no ingress rules; administration goes
-  // through SSM. This avoids a continuously billed NAT gateway for one host.
+  // through SSM. This avoids a continuously billed NAT gateway.
   associate_public_ip_address = true
   iam_instance_profile        = aws_iam_instance_profile.collector.name
 
@@ -48,7 +50,7 @@ resource "aws_instance" "collector" {
   }
 
   tags = {
-    Name        = "rustc-perf-graviton5"
+    Name        = "rustc-perf-graviton5-${count.index + 1}"
     Environment = "prod"
     Service     = "rustc-perf"
   }

--- a/terragrunt/modules/rustc-perf-collector/network.tf
+++ b/terragrunt/modules/rustc-perf-collector/network.tf
@@ -1,0 +1,68 @@
+// This service needs one outbound-only host, so a small dedicated VPC is easier
+// to reason about than adopting a default VPC or deploying the multi-AZ/NAT
+// topology used by web services.
+resource "aws_vpc" "collector" {
+  cidr_block           = "10.0.0.0/24"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name = "rustc-perf-prod"
+  }
+}
+
+resource "aws_internet_gateway" "collector" {
+  vpc_id = aws_vpc.collector.id
+
+  tags = {
+    Name = "rustc-perf-prod"
+  }
+}
+
+resource "aws_subnet" "collector" {
+  availability_zone_id    = local.availability_zone_id
+  cidr_block              = "10.0.0.0/26"
+  map_public_ip_on_launch = true
+  vpc_id                  = aws_vpc.collector.id
+
+  tags = {
+    Name = "rustc-perf-prod"
+  }
+}
+
+resource "aws_route_table" "collector" {
+  vpc_id = aws_vpc.collector.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.collector.id
+  }
+
+  tags = {
+    Name = "rustc-perf-prod"
+  }
+}
+
+resource "aws_route_table_association" "collector" {
+  route_table_id = aws_route_table.collector.id
+  subnet_id      = aws_subnet.collector.id
+}
+
+// Deliberately define no ingress rules. SSM establishes its management channel
+// outbound, so neither SSH nor a bastion needs to be exposed to the internet.
+resource "aws_security_group" "collector" {
+  name        = "rustc-perf-collector"
+  description = "No-ingress security group for the rustc-perf collector"
+  vpc_id      = aws_vpc.collector.id
+
+  tags = {
+    Name = "rustc-perf-collector"
+  }
+}
+
+resource "aws_vpc_security_group_egress_rule" "collector" {
+  security_group_id = aws_security_group.collector.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
+  description       = "Allow the collector to fetch toolchains and benchmark sources"
+}

--- a/terragrunt/modules/rustc-perf-collector/network.tf
+++ b/terragrunt/modules/rustc-perf-collector/network.tf
@@ -1,6 +1,6 @@
-// This service needs one outbound-only host, so a small dedicated VPC is easier
-// to reason about than adopting a default VPC or deploying the multi-AZ/NAT
-// topology used by web services.
+// This service needs outbound-only collectors, so a small dedicated VPC is
+// easier to reason about than adopting a default VPC or deploying the
+// multi-AZ/NAT topology used by web services.
 resource "aws_vpc" "collector" {
   cidr_block           = "10.0.0.0/24"
   enable_dns_hostnames = true
@@ -64,5 +64,5 @@ resource "aws_vpc_security_group_egress_rule" "collector" {
   security_group_id = aws_security_group.collector.id
   cidr_ipv4         = "0.0.0.0/0"
   ip_protocol       = "-1"
-  description       = "Allow the collector to fetch toolchains and benchmark sources"
+  description       = "Allow the collectors to fetch toolchains and benchmark sources"
 }

--- a/terragrunt/modules/rustc-perf-collector/network.tf
+++ b/terragrunt/modules/rustc-perf-collector/network.tf
@@ -1,0 +1,68 @@
+// This service needs one outbound-only host, so a small dedicated VPC is easier
+// to reason about than adopting a default VPC or deploying the multi-AZ/NAT
+// topology used by web services.
+resource "aws_vpc" "collector" {
+  cidr_block           = "10.0.0.0/24"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name = "rustc-perf-prod"
+  }
+}
+
+resource "aws_internet_gateway" "collector" {
+  vpc_id = aws_vpc.collector.id
+
+  tags = {
+    Name = "rustc-perf-prod"
+  }
+}
+
+resource "aws_subnet" "collector" {
+  availability_zone       = local.availability_zone
+  cidr_block              = "10.0.0.0/26"
+  map_public_ip_on_launch = true
+  vpc_id                  = aws_vpc.collector.id
+
+  tags = {
+    Name = "rustc-perf-prod"
+  }
+}
+
+resource "aws_route_table" "collector" {
+  vpc_id = aws_vpc.collector.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.collector.id
+  }
+
+  tags = {
+    Name = "rustc-perf-prod"
+  }
+}
+
+resource "aws_route_table_association" "collector" {
+  route_table_id = aws_route_table.collector.id
+  subnet_id      = aws_subnet.collector.id
+}
+
+// Deliberately define no ingress rules. SSM establishes its management channel
+// outbound, so neither SSH nor a bastion needs to be exposed to the internet.
+resource "aws_security_group" "collector" {
+  name        = "rustc-perf-collector"
+  description = "No-ingress security group for the rustc-perf collector"
+  vpc_id      = aws_vpc.collector.id
+
+  tags = {
+    Name = "rustc-perf-collector"
+  }
+}
+
+resource "aws_vpc_security_group_egress_rule" "collector" {
+  security_group_id = aws_security_group.collector.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
+  description       = "Allow the collector to fetch toolchains and benchmark sources"
+}

--- a/terragrunt/modules/rustc-perf-collector/outputs.tf
+++ b/terragrunt/modules/rustc-perf-collector/outputs.tf
@@ -1,0 +1,24 @@
+output "instance_id" {
+  description = "EC2 instance ID of the Graviton 5 collector"
+  value       = aws_instance.collector.id
+}
+
+output "dedicated_host_id" {
+  description = "EC2 Dedicated Host containing the collector"
+  value       = aws_ec2_host.collector.id
+}
+
+output "instance_type" {
+  description = "EC2 instance type of the collector"
+  value       = aws_instance.collector.instance_type
+}
+
+output "availability_zone" {
+  description = "Availability Zone selected for the collector"
+  value       = aws_instance.collector.availability_zone
+}
+
+output "perf_check_marker" {
+  description = "File created by cloud-init after hardware counters pass their smoke test"
+  value       = "/var/lib/rustc-perf/perf-counters-ready"
+}

--- a/terragrunt/modules/rustc-perf-collector/outputs.tf
+++ b/terragrunt/modules/rustc-perf-collector/outputs.tf
@@ -1,21 +1,11 @@
-output "instance_id" {
-  description = "EC2 instance ID of the Graviton 5 collector"
-  value       = aws_instance.collector.id
+output "instance_ids" {
+  description = "EC2 instance IDs of the Graviton 5 collectors"
+  value       = aws_instance.collector[*].id
 }
 
 output "dedicated_host_id" {
-  description = "EC2 Dedicated Host containing the collector"
+  description = "EC2 Dedicated Host containing the collectors"
   value       = aws_ec2_host.collector.id
-}
-
-output "instance_type" {
-  description = "EC2 instance type of the collector"
-  value       = aws_instance.collector.instance_type
-}
-
-output "availability_zone" {
-  description = "Availability Zone selected for the collector"
-  value       = aws_instance.collector.availability_zone
 }
 
 output "perf_check_marker" {

--- a/terragrunt/modules/rustc-perf-collector/user-data.sh
+++ b/terragrunt/modules/rustc-perf-collector/user-data.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+# EC2 executes user data as root through cloud-init on the first boot. Install
+# both rustc-perf build prerequisites and the perf binary matching the running
+# AWS kernel; a generic perf package can point at an incompatible binary.
+apt-get update
+apt-get install --yes \
+  build-essential \
+  cmake \
+  git \
+  libssl-dev \
+  "linux-tools-$(uname -r)" \
+  pkg-config \
+  python3-venv \
+  unzip
+
+tee /etc/sysctl.d/90-rustc-perf.conf >/dev/null <<'EOF'
+# Allow the unprivileged collector process to use all PMU events.
+kernel.perf_event_paranoid = -1
+# Symbol addresses are useful when correlating counter samples with profiles.
+kernel.kptr_restrict = 0
+EOF
+
+sysctl --system
+
+# Canonical's AWS images ship the agent as a snap. Keep this fallback for an
+# image where it is not preinstalled yet.
+if ! snap list amazon-ssm-agent >/dev/null 2>&1; then
+  snap install amazon-ssm-agent --classic
+fi
+systemctl enable --now snap.amazon-ssm-agent.amazon-ssm-agent.service
+
+install -d -m 0755 /var/lib/rustc-perf
+# Fail cloud-init if EC2 does not expose the core PMU events rustc-perf relies
+# on to this M9g guest. Dedicated Host tenancy reserves the physical server,
+# but this runtime check is what verifies the counters are actually usable.
+# The marker distinguishes verified bootstrap from a merely running instance.
+perf stat \
+  --event cycles,instructions,branches,branch-misses \
+  -- sleep 1
+date --iso-8601=seconds > /var/lib/rustc-perf/perf-counters-ready

--- a/terragrunt/modules/rustc-perf-collector/variables.tf
+++ b/terragrunt/modules/rustc-perf-collector/variables.tf
@@ -1,0 +1,9 @@
+variable "required_dedicated_hosts" {
+  description = "Approved regional M9g Dedicated Host quota required by the collector"
+  type        = number
+
+  validation {
+    condition     = var.required_dedicated_hosts >= 1
+    error_message = "The collector requires at least one M9g Dedicated Host."
+  }
+}


### PR DESCRIPTION
Allocates an M9g Dedicated Host and places a no-ingress `m9g.12xlarge` Graviton 5 collector on it, with SSM access, host recovery, termination protection, encrypted storage, and a boot-time hardware performance-counter smoke test.

- [x] wait for quota request of #1172 to be approved from aws
- [ ] This PR was generated by AI and I haven't reviewed it yet. Please don't waste your time reading it yet.
- [ ] allow db to reach the ec2

## AI disclosure

I used GPT5.6-Sol with the codex harness to generate this change. I reviewed its output and changed it where necessary.