### PR TITLE
remove infra team admin access from crates-io account

### DIFF
--- a/terragrunt/modules/aws-organization/groups.tf
+++ b/terragrunt/modules/aws-organization/groups.tf
@@ -365,7 +365,7 @@ locals {
             aws_ssoadmin_permission_set.administrator_access
         ] },
         { group : aws_identitystore_group.infra,
-        permissions : [aws_ssoadmin_permission_set.read_only_access, aws_ssoadmin_permission_set.administrator_access] },
+        permissions : [aws_ssoadmin_permission_set.read_only_access] },
         { group : aws_identitystore_group.crates_io,
         permissions : [aws_ssoadmin_permission_set.read_only_access] },
       ]


### PR DESCRIPTION
The regular infra group currently have AdministratorAccess in four accounts:
* `crates-io-staging`
* `crates-io-prod`
* `docs-rs-staging`
* `bors-staging`

`crates-io-prod` is the only production account with this grant. Other production accounts give infra read-only or view-only access.

https://github.com/rust-lang/simpleinfra/pull/396 probably gave admin access to the infra team by mistake.
Only infra admins should have admin access.