### PR TITLE
set docs.rs NgWAF to blocking mode

### DIFF
--- a/terraform/docs-rs/fastly-ngwaf.tf
+++ b/terraform/docs-rs/fastly-ngwaf.tf
@@ -4,7 +4,7 @@ resource "fastly_ngwaf_workspace" "webapp" {
   description = "Next-Gen WAF workspace for ${local.domain_name}"
 
   # switch to blocking mode when rules are updated
-  mode = "log"
+  mode = "block"
 
   # Configure when the WAF should flag an IP address as potentially malicious based on cumulative attack signals over different time windows.
   #


### PR DESCRIPTION
I watched the rules i created for a couple of hours and believe we're good. 

Added two to start with: 
- directly block XSS, Backdoor, Command-Execution, Path traversal. I think the detection is quite reliable here. Also see [the system signals](https://www.fastly.com/documentation/guides/next-gen-waf/signals/using-system-signals/). 
- a global rate limit of 700 rpm. slightly different than with nginx, since fastly doesn't have the burst-setting. 

#### Generally about the rate-limit: 
This is to help relieve load from our server in DDOS cases. Generally I believe rate-limit should only be applied for uncached requests, I'll revisit that topic with the new infra. 

For now we have much more options to block / rate limit traffic, including fastly's bot detection which can differentiate between verified, AI or malicious bots. As a small hack I'm excluding some paths from the rate-limit counter that are cached most of the time (`/-/rustdoc.static/*`, `/-/static/*`)