### PR TITLE
Remove AWS access for Eric Huss

### DIFF
--- a/terragrunt/accounts/root/aws-organization/terragrunt.hcl
+++ b/terragrunt/accounts/root/aws-organization/terragrunt.hcl
@@ -69,12 +69,6 @@ inputs = {
       email = "adam@adamharvey.name"
       groups = ["crates-io"]
     }
-    "ehuss" = {
-      given_name = "Eric"
-      family_name = "Huss"
-      email = "eric@huss.org"
-      groups = ["triagebot"]
-    }
     "apiraino" = {
       given_name = "apiraino"
       family_name = "n/a"


### PR DESCRIPTION
Per https://github.com/rust-lang/team/pull/2693, Eric is moving to alumni status.