### PR TITLE
dev-desktops: fix issue when installing extra kernel modules

### DIFF
--- a/ansible/roles/dev-desktop/tasks/dependencies.yml
+++ b/ansible/roles/dev-desktop/tasks/dependencies.yml
@@ -131,13 +131,41 @@
     state: present
   when: ansible_architecture == "x86_64"
 
-- name: Install kernel modules on cloud machines
+
+# Starting with some version ubuntu-linux kernel 7.x.y, the packaging scheme
+# for extra modules changed : rather than packaging two extra modules according
+# to the kernel + flavor, canonical packages a single bundle.
+#
+# This task captures this change and enables support to both
+# kernel=6.x.y and kernel=7.x.y of ubuntu
+#
+# https://discourse.ubuntu.com/t/kernel-development-release-cadence-and-deprecation-of-linux-modules-extra/65176
+#
+- name: Check whether separate kernel extra modules package exists
+  command: "apt-cache show linux-modules-extra-{{ kernel.stdout }}"
+  register: kernel_modules_extra
+  changed_when: false
+  failed_when: false
+
+# So far, GCP machines running with kernel 6.x.y
+- name: Install split kernel modules on cloud machines
   apt:
     name:
       - "linux-modules-extra-{{ kernel_flavor.stdout }}"
       - "linux-modules-extra-{{ kernel.stdout }}"
     state: present
-  when: kernel_flavor.stdout != "generic"
+  when:
+    - kernel_flavor.stdout != "generic"
+    - kernel_modules_extra.rc == 0
+
+# As of now, AWS machines running with kernel 7.x.y
+- name: Install combined kernel modules package on cloud machines
+  apt:
+    name: "linux-modules-{{ kernel.stdout }}"
+    state: present
+  when:
+    - kernel_flavor.stdout != "generic"
+    - kernel_modules_extra.rc != 0
 
 - name: Install kernel modules on local Ubuntu VMs
   apt:


### PR DESCRIPTION
## AI disclosure 

I had a chat with chatgpt that helped me to get this PR sorted, especially finding links and prototyping the ansible changes.

----

After applying https://github.com/rust-lang/simpleinfra/pull/1182 I realized that following error

```
TASK [dev-desktop : Install kernel modules on cloud machines] ****************************************************************************************
fatal: [dev-desktop-eu-1.infra.rust-lang.org]: FAILED! => {"changed": false, "msg": "No package matching 'linux-modules-extra-7.0.0-1010-aws' is available"}
fatal: [dev-desktop-us-1.infra.rust-lang.org]: FAILED! => {"changed": false, "msg": "No package matching 'linux-modules-extra-7.0.0-1010-aws' is available"}
ok: [dev-desktop-us-2.infra.rust-lang.org]
ok: [dev-desktop-eu-2.infra.rust-lang.org]
```

I got a report that the disk quota did not increase for users using `<eu|us>-1` dev desktops, and confirmed that the new disk size quota did not apply

```
ubiratansoares@dev-desktop-eu-1:~$ sudo repquota -s /
*** Report for user quotas on device /dev/root
Block grace time: 7days; Inode grace time: 7days
                        Space limits                File limits
User            used    soft    hard  grace    used  soft  hard  grace
----------------------------------------------------------------------
root      --  16556M      0K      0K           630k     0     0
man       --   2136K      0K      0K            163     0     0
syslog    --  15268K      0K      0K             19     0     0
# more output
gh-Aaron1011 --     20K    150G    152G              5     0     0
gh-Aaron1011 --     20K    150G    152G              5     0     0
gh-Dajamante --     20K    150G    152G              5     0     0
gh-JoelMarcey --     20K    150G    152G              5     0     0
# more output
```
The reason is explained also in a comment for the ansible tasks, but in a nutshell, we now run an additional task to check whether the dev desktop os/kernal is compatible with the new bundling scheme for extra modules