### PR TITLE
solve drifts in team-members-access module

### DIFF
--- a/terraform/team-members-access/docs-rs.tf
+++ b/terraform/team-members-access/docs-rs.tf
@@ -20,10 +20,6 @@ data "aws_s3_bucket" "docs_rs_buckets" {
   bucket   = each.value
 }
 
-data "aws_cloudwatch_log_group" "docs_rs_web" {
-  name = "/prod/docs-rs-web"
-}
-
 resource "aws_iam_group_policy" "docs_rs" {
   group = aws_iam_group.docs_rs.name
   name  = "prod-access"
@@ -123,27 +119,6 @@ resource "aws_iam_group_policy" "docs_rs" {
           [for _, bucket in data.aws_s3_bucket.docs_rs_buckets : bucket.arn],
           [for _, bucket in data.aws_s3_bucket.docs_rs_buckets : "${bucket.arn}/*"],
         )
-      },
-
-      // CloudWatch logs access
-      //
-      // The following rules allow docs-rs team members to access the logs for
-      // the docs.rs app on ECS.
-      {
-        Sid    = "AllowLogs"
-        Effect = "Allow"
-        Action = [
-          "logs:GetLogEvents",
-          "logs:FilterLogEvents",
-          "logs:StartQuery",
-          "logs:StopQuery",
-          "logs:DescribeLogGroups",
-          "logs:DescribeLogStreams",
-        ]
-        Resource = [
-          "${data.aws_cloudwatch_log_group.docs_rs_web.arn}:*",
-          "${data.aws_cloudwatch_log_group.docs_rs_web.arn}:*:log-stream:*",
-        ]
       },
     ]
   })


### PR DESCRIPTION
* The cloudwatch resource was deleted in https://github.com/rust-lang/simpleinfra/pull/1017
* The `enforce_mfa` was edited manually in March. I'm reverting this change. If we see issues with SSO we can open a PR to add this back again.

Plan:
```
Terraform will perform the following actions:

  # aws_iam_group_policy.docs_rs will be updated in-place
  ~ resource "aws_iam_group_policy" "docs_rs" {
        id          = "docs-rs:prod-access"
        name        = "prod-access"
      ~ policy      = jsonencode(
          ~ {
              ~ Statement = [
                    # (5 unchanged elements hidden)
                    {
                        Action   = [
                            "s3:ListBucket",
                            "s3:AbortMultipartUpload",
                            "s3:GetObject",
                            "s3:GetObjectAcl",
                            "s3:PutObject",
                            "s3:PutObjectAcl",
                        ]
                        Effect   = "Allow"
                        Resource = [
                            "arn:aws:s3:::docs.rs-backups",
                            "arn:aws:s3:::rust-docs-rs",
                            "arn:aws:s3:::docs.rs-backups/*",
                            "arn:aws:s3:::rust-docs-rs/*",
                        ]
                        Sid      = "S3BucketAccess"
                    },
                  - {
                      - Action   = [
                          - "logs:GetLogEvents",
                          - "logs:FilterLogEvents",
                          - "logs:StartQuery",
                          - "logs:StopQuery",
                          - "logs:DescribeLogGroups",
                          - "logs:DescribeLogStreams",
                        ]
                      - Effect   = "Allow"
                      - Resource = [
                          - "arn:aws:logs:us-west-1:890664054962:log-group:/prod/docs-rs-web:*",
                          - "arn:aws:logs:us-west-1:890664054962:log-group:/prod/docs-rs-web:*:log-stream:*",
                        ]
                      - Sid      = "AllowLogs"
                    },
                ]
                # (1 unchanged attribute hidden)
            }
        )
        # (2 unchanged attributes hidden)
    }

  # aws_iam_policy.enforce_mfa will be updated in-place
  ~ resource "aws_iam_policy" "enforce_mfa" {
        id               = "arn:aws:iam::890664054962:policy/enforce-mfa"
        name             = "enforce-mfa"
      ~ policy           = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Condition = {
                          - ArnNotLike   = {
                              - "aws:PrincipalArn" = "arn:aws:iam::890664054962:role/aws-reserved/sso.amazonaws.com/*"
                            }
                            # (1 unchanged attribute hidden)
                        }
                        # (4 unchanged attributes hidden)
                    },
                ]
                # (1 unchanged attribute hidden)
            }
        )
        tags             = {}
        # (7 unchanged attributes hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.
```