### PR TITLE
request m9g instance quota

### DIFF
--- a/terragrunt/modules/rustc-perf-quota/main.tf
+++ b/terragrunt/modules/rustc-perf-quota/main.tf
@@ -1,9 +1,17 @@
-// L-9F9F275C is the regional "Running Dedicated m9g Hosts" quota.
 // Dedicated hosts are limited by host count per instance family.
 // New accounts default to zero M9g hosts, so this request must be approved before AWS
 // can allocate the billable physical server.
 resource "aws_servicequotas_service_quota" "m9g_hosts" {
   service_code = "ec2"
-  quota_code   = "L-9F9F275C"
-  value        = 1
+  # Regional "Running Dedicated m9g Hosts" quota.
+  quota_code = "L-9F9F275C"
+  value      = 1
+}
+
+resource "aws_servicequotas_service_quota" "standard_ondemand_vcpus" {
+  service_code = "ec2"
+  # Regional "Running On-Demand Standard (A, C, D, H, I, M, R, T, Z) instances" quota.
+  quota_code = "L-1216C47A"
+  # vCPU of m9g.metal-48xl.
+  value = 192
 }


### PR DESCRIPTION
We are evaluating a dedicated instance instead of a dedicated host. 
<img width="2146" height="670" alt="image" src="https://github.com/user-attachments/assets/95e4bd9f-c29c-495a-b8b1-3ceae5dca0af" />
