### PR TITLE
provision rustc-perf m9g.metal-48xl

### DIFF
--- a/terragrunt/accounts/rustc-perf-prod/README.md
+++ b/terragrunt/accounts/rustc-perf-prod/README.md
@@ -1,0 +1,10 @@
+# rustc-perf production AWS account
+
+This account contains one Graviton 5 collector for rustc-perf. It is an
+`m9g.metal-48xl` bare-metal instance with 192 vCPUs and 768 GiB of memory in
+`us-east-2`. It gives the collector direct access to the physical Graviton 5
+server and its performance monitoring unit.
+
+Operators connect to the machine over SSH.
+Its Elastic IPv4 address stays stable across instance
+stop/start cycles. The instance also has a stable public IPv6 address.

--- a/terragrunt/accounts/rustc-perf-prod/collector/.terraform.lock.hcl
+++ b/terragrunt/accounts/rustc-perf-prod/collector/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.61.0"
+  constraints = "~> 6.61"
+  hashes = [
+    "h1:luPmlKygfw2SMKJkMQ++/J8rRR0ZgR0uJPupp8wy3pw=",
+    "zh:216566f0fbc506e107d3a961c87d88aed052ec2b4ced13388394d3cff30425ac",
+    "zh:4700ad141d0ad96465ac35a3900f2ff7c91a1e5528428ac687c8b5825c0be718",
+    "zh:6b79d2fa6550fc51e2fac04f1066c5cc96e957e7634ad86d2250240e637db205",
+    "zh:76f6227bf2bcd7422cf29d9868d8b517c8220ec3edd4e7c8434b867a71c03334",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a7be5814cf94a8e3869ec9fa7f5182223a11373a4510ce68b9bab431f9b83746",
+    "zh:b65392e24506fe99f8df7bd2b5d3940d7a234b64b79a890f1aabe2be91a827e5",
+    "zh:b68a5092203cf5a9d1a5f01f9f2e96fded3eb7cacfd49ae851c50b87bc610fe9",
+    "zh:b8fedfa62bac16592519e1bae0c82dd7cd1544b0637543d72e3597e46ad7db32",
+    "zh:bba8a35212c07e68b6c881aa011c4b26a284e42b971059579aca9ffb63a8faef",
+    "zh:bbd0391e3e2f21c8930872829df7cf7f4e35f84c4d6d7b7619a94f8078fe6f3d",
+    "zh:c9c921e8e466281c04cada8d336ec1ce978128ee153e9df7b451847fbea49d18",
+    "zh:c9cb0be3097f4392b977fa254d28efd0909d008f572e74a41ead6c0d84c0daaa",
+    "zh:cc7aeb23fa3775816e391d4668a9865f787993f9f8d6f5b7a9f7e4effdffb3cb",
+    "zh:e59e487220cec8999bbd120ba8f97b5e04b010fb9149e47d4c9032961614d7c7",
+    "zh:fa19a7571a99397120f2f2bdcf33bbcc2f39091b9b0c879cd7e5f9ebb1966c40",
+  ]
+}

--- a/terragrunt/accounts/rustc-perf-prod/collector/terragrunt.hcl
+++ b/terragrunt/accounts/rustc-perf-prod/collector/terragrunt.hcl
@@ -1,0 +1,8 @@
+terraform {
+  source = "../../../modules//rustc-perf-collector"
+}
+
+include {
+  path           = find_in_parent_folders()
+  merge_strategy = "deep"
+}

--- a/terragrunt/modules/rustc-perf-collector/_terraform.tf
+++ b/terragrunt/modules/rustc-perf-collector/_terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.61"
+    }
+  }
+}

--- a/terragrunt/modules/rustc-perf-collector/instance.tf
+++ b/terragrunt/modules/rustc-perf-collector/instance.tf
@@ -1,0 +1,45 @@
+resource "aws_instance" "collector" {
+  ami                    = data.aws_ami.ubuntu.id
+  instance_type          = local.instance_type
+  subnet_id              = aws_default_subnet.collector.id
+  vpc_security_group_ids = [aws_security_group.collector.id]
+  ipv6_address_count     = 1
+
+  // Don't assign a public IPv4, because we use Elastic IP to get a stable address.
+  associate_public_ip_address = false
+
+  // Enable EC2 Instance Termination Protection.
+  disable_api_termination = true
+  monitoring              = false
+
+  metadata_options {
+    http_endpoint = "enabled"
+    // Disable the IMDS IPv6 endpoint
+    http_protocol_ipv6 = "disabled"
+    // Limit IMDSv2 token responses to one network hop.
+    http_put_response_hop_limit = 1
+    // Reject tokenless IMDSv1 requests by requiring an IMDSv2 session token.
+    http_tokens            = "required"
+    instance_metadata_tags = "disabled"
+  }
+
+  root_block_device {
+    delete_on_termination = true
+    volume_size           = 500 # GiB
+  }
+
+  lifecycle {
+    # Do not replace the collector just because Canonical published a new AMI.
+    ignore_changes = [ami]
+  }
+}
+
+// Static IP.
+resource "aws_eip" "collector" {
+  domain = "vpc"
+}
+
+resource "aws_eip_association" "collector" {
+  allocation_id = aws_eip.collector.id
+  instance_id   = aws_instance.collector.id
+}

--- a/terragrunt/modules/rustc-perf-collector/locals.tf
+++ b/terragrunt/modules/rustc-perf-collector/locals.tf
@@ -1,0 +1,7 @@
+locals {
+  // Use the bare-metal M9g size so rustc-perf can access the Graviton 5
+  // hardware directly, without a hypervisor between the collector and its PMU.
+  instance_type = "m9g.metal-48xl"
+
+  availability_zone = "us-east-2a"
+}

--- a/terragrunt/modules/rustc-perf-collector/network.tf
+++ b/terragrunt/modules/rustc-perf-collector/network.tf
@@ -1,0 +1,84 @@
+resource "aws_default_vpc" "collector" {
+  assign_generated_ipv6_cidr_block = true
+}
+
+# Adopt the default subnet in the collector's availability zone, assign it an IPv6
+# /64, and use it as the network in which the collector instance is launched.
+resource "aws_default_subnet" "collector" {
+  availability_zone = local.availability_zone
+  ipv6_cidr_block   = cidrsubnet(aws_default_vpc.collector.ipv6_cidr_block, 8, 0)
+}
+
+# Look up the internet gateway that AWS creates for the default VPC so it can be
+# used as the target of the collector subnet's IPv6 default route.
+data "aws_internet_gateway" "collector" {
+  filter {
+    name   = "attachment.vpc-id"
+    values = [aws_default_vpc.collector.id]
+  }
+}
+
+# Route all IPv6 traffic through the default VPC's internet gateway, giving the
+# collector instance outbound IPv6 connectivity and making allowed ingress routable.
+resource "aws_route" "collector_ipv6" {
+  route_table_id              = aws_default_vpc.collector.default_route_table_id
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = data.aws_internet_gateway.collector.id
+}
+
+# Security group attached to the collector instance; with ingress and egress rule resources declared below.
+resource "aws_security_group" "collector" {
+  name        = "rustc-perf-collector"
+  description = "SSH access and egress for the rustc-perf collector"
+  vpc_id      = aws_default_vpc.collector.id
+}
+
+resource "aws_vpc_security_group_ingress_rule" "ssh" {
+  security_group_id = aws_security_group.collector.id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 22
+  to_port           = 22
+  ip_protocol       = "tcp"
+  description       = "SSH access"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "ssh_ipv6" {
+  security_group_id = aws_security_group.collector.id
+  cidr_ipv6         = "::/0"
+  from_port         = 22
+  to_port           = 22
+  ip_protocol       = "tcp"
+  description       = "SSH access"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "ping" {
+  security_group_id = aws_security_group.collector.id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 8
+  to_port           = -1
+  ip_protocol       = "icmp"
+  description       = "Ping access"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "ping_ipv6" {
+  security_group_id = aws_security_group.collector.id
+  cidr_ipv6         = "::/0"
+  from_port         = 128
+  to_port           = -1
+  ip_protocol       = "icmpv6"
+  description       = "Ping access"
+}
+
+resource "aws_vpc_security_group_egress_rule" "collector" {
+  security_group_id = aws_security_group.collector.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
+  description       = "Allow all IPv4 egress traffic."
+}
+
+resource "aws_vpc_security_group_egress_rule" "collector_ipv6" {
+  security_group_id = aws_security_group.collector.id
+  cidr_ipv6         = "::/0"
+  ip_protocol       = "-1"
+  description       = "Allow all IPv6 egress traffic."
+}

--- a/terragrunt/modules/rustc-perf-collector/outputs.tf
+++ b/terragrunt/modules/rustc-perf-collector/outputs.tf
@@ -1,0 +1,14 @@
+output "instance_id" {
+  description = "EC2 instance ID of the Graviton 5 collector"
+  value       = aws_instance.collector.id
+}
+
+output "public_ip" {
+  description = "Stable Elastic IPv4 address of the Graviton 5 collector"
+  value       = aws_eip.collector.public_ip
+}
+
+output "public_ipv6" {
+  description = "Stable public IPv6 address of the Graviton 5 collector"
+  value       = aws_instance.collector.ipv6_addresses[0]
+}

--- a/terragrunt/modules/rustc-perf-collector/ubuntu.tf
+++ b/terragrunt/modules/rustc-perf-collector/ubuntu.tf
@@ -1,0 +1,19 @@
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-arm64-server-*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["arm64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}


### PR DESCRIPTION
Instead of provisioning a dedicated host (see https://github.com/rust-lang/simpleinfra/pull/1173) we are evaluating provisioning a dedicated instance.

- [x] wait for quota request of #1199 to be approved by aws

## AI disclosure

I used GPT5.6-Sol with the codex harness to generate this change. I reviewed its output and changed it where necessary.