### PR TITLE
ansible: reload ssh earlier

### DIFF
--- a/ansible/roles/common/tasks/ssh.yml
+++ b/ansible/roles/common/tasks/ssh.yml
@@ -15,6 +15,7 @@
     src: ssh/sshd_config
     dest: /etc/ssh/sshd_config
 
+  # Notify is only triggered when there is a change.
   notify: reload-ssh
 
 - name: create authorized keys directory
@@ -34,3 +35,10 @@
   notify: reload-ssh
 
   loop: "{{ unprivileged_users + sudo_users }}"
+
+# Handlers run only when notified by a changed task, but are normally delayed
+# until the end of the play.
+# Flush them here so SSH changes take effect sooner.
+# We want to make sure ssh is reloaded even if there is a failure in the playbook later.
+- name: apply ssh changes
+  meta: flush_handlers


### PR DESCRIPTION
when applying Ansible, it happened that there was a failure after the SSH keys were uploaded and the SSH daemon wasn't restarted. 

This PR fixes it