### PR TITLE
bump aws dev desktop instance type to c9g

### DIFF
--- a/terraform/dev-desktops/regions.tf
+++ b/terraform/dev-desktops/regions.tf
@@ -11,7 +11,7 @@ module "aws_eu_central_1" {
       storage       = 250
     }
     "dev-desktop-eu-1" = {
-      instance_type = "c6g.8xlarge"
+      instance_type = "c9g.8xlarge"
       instance_arch = "arm64"
       storage       = 6000
     }
@@ -26,7 +26,7 @@ module "aws_us_east_1" {
 
   instances = {
     "dev-desktop-us-1" = {
-      instance_type = "c7g.12xlarge"
+      instance_type = "c9g.12xlarge"
       instance_arch = "arm64"
       storage       = 3000
     }


### PR DESCRIPTION
c9g is ~30% faster than c7g. We have enough credits.