### PR TITLE
disable crates-io webapp cloudfront distribution

### DIFF
--- a/terragrunt/accounts/legacy/crates-io-prod/crates-io/terragrunt.hcl
+++ b/terragrunt/accounts/legacy/crates-io-prod/crates-io/terragrunt.hcl
@@ -34,6 +34,8 @@ inputs = {
   index_cloudfront_weight = 1
   index_fastly_weight = 255
 
+  # Disable cloudfront to ensure Fastly NGWAF is protecting crates.io.
+  webapp_cloudfront_enabled = false
   webapp_cloudfront_weight = 0
   webapp_fastly_weight = 100
 

--- a/terragrunt/accounts/legacy/crates-io-staging/crates-io/terragrunt.hcl
+++ b/terragrunt/accounts/legacy/crates-io-staging/crates-io/terragrunt.hcl
@@ -31,6 +31,7 @@ inputs = {
   index_cloudfront_weight = 50
   index_fastly_weight = 50
 
+  webapp_cloudfront_enabled = true
   webapp_cloudfront_weight = 0
   webapp_fastly_weight = 100
 

--- a/terragrunt/modules/crates-io/README.md
+++ b/terragrunt/modules/crates-io/README.md
@@ -14,13 +14,21 @@ These are documented in more detail in the following sections.
 
 ```mermaid
 flowchart LR
-    DNS --> CloudFront
-    CloudFront --> Heroku
+    DNS --> Fastly
+    Fastly --> Heroku
 ```
 
 The user-facing web application for [crates.io] is hosted on Heroku and is not
-managed with [Terraform]. But the module configures CloudFront as the CDN for
-the app and grants it access to the relevant S3 buckets.
+managed with [Terraform]. The module configures Fastly as the normal CDN path,
+including its Next-Gen WAF, and retains CloudFront as an alternative path.
+
+In production, the CloudFront distribution is disabled, and the direct `cloudfront-app.crates.io` hostname is not
+published. Set `webapp_cloudfront_enabled` to enable the distribution and
+publish its direct hostname, then set `webapp_cloudfront_weight` to a positive
+value to route traffic to it.
+In staging, CloudFront remains enabled and is available at
+`cloudfront-app.staging.crates.io` for direct testing, even if its DNS traffic
+weight is zero.
 
 ## `index.crates.io`
 

--- a/terragrunt/modules/crates-io/_terraform.tf
+++ b/terragrunt/modules/crates-io/_terraform.tf
@@ -97,6 +97,11 @@ variable "webapp_cloudfront_weight" {
   type        = number
 }
 
+variable "webapp_cloudfront_enabled" {
+  description = "Whether the CloudFront distribution for crates.io is enabled"
+  type        = bool
+}
+
 variable "webapp_fastly_weight" {
   description = "Weight of the traffic for crates.io that is routed through Fastly"
   type        = number

--- a/terragrunt/modules/crates-io/cloudfront-webapp.tf
+++ b/terragrunt/modules/crates-io/cloudfront-webapp.tf
@@ -85,15 +85,24 @@ resource "aws_cloudfront_origin_request_policy" "webapp" {
 resource "aws_cloudfront_distribution" "webapp" {
   comment = var.webapp_domain_name
 
-  enabled             = true
+  enabled             = var.webapp_cloudfront_enabled
   wait_for_deployment = false
   is_ipv6_enabled     = true
   price_class         = "PriceClass_All"
 
-  aliases = [
-    local.cloudfront_webapp_domain_name,
-    var.webapp_domain_name
-  ]
+  lifecycle {
+    precondition {
+      condition     = var.webapp_cloudfront_enabled || var.webapp_cloudfront_weight == 0
+      error_message = "webapp_cloudfront_weight must be zero when webapp_cloudfront_enabled is false."
+    }
+  }
+
+  # Expose the direct-to-CloudFront hostname only while the distribution is
+  # enabled.
+  aliases = concat(
+    [var.webapp_domain_name],
+    var.webapp_cloudfront_enabled ? [local.cloudfront_webapp_domain_name] : [],
+  )
   viewer_certificate {
     acm_certificate_arn = module.certificate.arn
     ssl_support_method  = "sni-only"
@@ -140,6 +149,8 @@ resource "aws_cloudfront_distribution" "webapp" {
 }
 
 resource "aws_route53_record" "cloudfront_webapp_domain" {
+  count = var.webapp_cloudfront_enabled ? 1 : 0
+
   zone_id = data.aws_route53_zone.webapp.id
   name    = local.cloudfront_webapp_domain_name
   type    = "CNAME"


### PR DESCRIPTION
People can go directly to `cloudfront-app.crates.io` bypassing Fastly NGWAF, therefore rate limits. We prevent this by disabling the cloudfront CDN for the crates-io app.