### PR TITLE
Increase CPU allocation for triagebot to one full CPU

### DIFF
--- a/terraform/shared/services/triagebot/main.tf
+++ b/terraform/shared/services/triagebot/main.tf
@@ -44,8 +44,8 @@ module "ecs_task" {
   source = "../../modules/ecs-task"
 
   name   = "triagebot"
-  cpu    = 256
-  memory = 512
+  cpu    = 1024
+  memory = 2048
 
   log_retention_days = 60
   ecr_repositories_arns = [


### PR DESCRIPTION
Apparently, we should be spending more credits :laughing: So why not give a whopping full CPU to triagebot, instead of a quarter (!) of a CPU that it had previously.

CC @rust-lang/triagebot