### PR TITLE
optimize crates-io compute-static binary

### DIFF
--- a/terragrunt/modules/crates-io/compute-static/Cargo.toml
+++ b/terragrunt/modules/crates-io/compute-static/Cargo.toml
@@ -13,6 +13,8 @@ publish = false
 
 [profile.release]
 debug = 1
+codegen-units = 1
+lto = "fat"
 
 [dependencies]
 derive_builder = "0.12.0"


### PR DESCRIPTION
as seen in Fastly starter kit: https://github.com/fastly/compute-starter-kits/blob/49753f41fe915ebbcb76275ed354c270ee7b7142/starter-kits/rust/default/Cargo.toml#L12