### PR TITLE
docs.rs fastly: update tracing log-format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,3 @@ members = [
     "setup-deploy-keys",
     "ansible/roles/dev-desktop/files/team_login",
 ]
-exclude = [
-    "terraform/docs-rs/fastly-compute-docs-rs",
-]

--- a/terraform/docs-rs/fastly-compute-docs-rs/Cargo.lock
+++ b/terraform/docs-rs/fastly-compute-docs-rs/Cargo.lock
@@ -167,6 +167,7 @@ dependencies = [
  "fastly",
  "serde",
  "serde_json",
+ "time",
  "tracing",
  "tracing-serde",
  "tracing-subscriber",

--- a/terraform/docs-rs/fastly-compute-docs-rs/Cargo.toml
+++ b/terraform/docs-rs/fastly-compute-docs-rs/Cargo.toml
@@ -1,3 +1,7 @@
+# this crate has to be built on its own, and only works in the WASM / fastly environment. 
+# This excludes the crate from the surrounding simpleinfra workspace.
+[workspace]
+
 [package]
 name = "fastly-compute-project"
 version = "0.1.0"

--- a/terraform/docs-rs/fastly-compute-docs-rs/Cargo.toml
+++ b/terraform/docs-rs/fastly-compute-docs-rs/Cargo.toml
@@ -16,6 +16,10 @@ uuid = { version = "1.25.0", features = ["v4", "fast-rng"] }
 tracing = "0.1"
 tracing-serde = "0.2"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "json"] }
+time = { version = "0.3.17", features = ["serde-human-readable"] }
+
+[dev-dependencies]
+time = { version = "0.3.17", features = ["serde-human-readable", "macros"] }
 
 [profile.fastly-release]
 inherits = "release"

--- a/terraform/docs-rs/fastly-compute-docs-rs/src/logging.rs
+++ b/terraform/docs-rs/fastly-compute-docs-rs/src/logging.rs
@@ -4,8 +4,8 @@ use serde_json::{Map, Value};
 use std::{
     io::{self, Write},
     sync::Mutex,
-    time::{SystemTime, UNIX_EPOCH},
 };
+use time::OffsetDateTime;
 use tracing::{
     Event, Subscriber,
     span::{Attributes, Id, Record},
@@ -21,6 +21,13 @@ use tracing_subscriber::{
 
 // Must match the logging endpoint name in Terraform.
 const APPLICATION_LOG_ENDPOINT: &str = "application_logs";
+
+// About `ddsource`
+// This corresponds to the integration name, the technology
+// from which the log originated. When it matches an integration
+// name, Datadog automatically installs the corresponding parsers
+// and facets. For example, nginx, postgresql, and so on.
+const LOG_SOURCE_FORMAT: &str = "docs-rs-fastly-wasm";
 
 pub(crate) fn setup() {
     let application_logs = Endpoint::from_name(APPLICATION_LOG_ENDPOINT);
@@ -115,24 +122,20 @@ where
         // Event fields override those inherited from spans.
         fields.extend(event_fields);
 
-        let timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis();
-
         let message = match fields.remove("message") {
             Some(Value::String(message)) => Some(message),
             _ => None,
         };
 
         let row = TraceLog {
-            ddsource: "fastly",
+            ddsource: LOG_SOURCE_FORMAT,
             ddtags: "env:production",
             hostname: fastly::compute_runtime::hostname(),
-            timestamp,
+            timestamp: OffsetDateTime::now_utc(),
             message: message.as_deref().unwrap_or_default(),
             service: "docs.rs fastly WASM",
             status: level_name(*event.metadata().level()),
+            target: event.metadata().target(),
             fields,
         };
 
@@ -172,14 +175,14 @@ struct TraceLog<'a> {
     ddsource: &'static str,
     ddtags: &'static str,
     hostname: &'static str,
-    /// Milliseconds since the Unix epoch.
-    /// Format / name:
-    /// https://docs.datadoghq.com/logs/log_configuration/processors/log_date_remapper/
-    timestamp: u128,
+    #[serde(with = "time::serde::rfc3339")]
+    timestamp: OffsetDateTime,
     message: &'a str,
     service: &'static str,
     /// Normalized tracing level.
     status: &'static str,
+    /// The tracing target, normally the Rust module containing the event.
+    target: &'a str,
     /// Additional `tracing` event fields.
     fields: Map<String, Value>,
 }
@@ -192,6 +195,7 @@ mod tests {
         str,
         sync::{Arc, Mutex},
     };
+    use time::macros::datetime;
 
     #[derive(Clone, Debug, Default)]
     struct CapturedOutput {
@@ -240,27 +244,31 @@ mod tests {
 
     #[test]
     fn trace_log_serializes_to_datadog_json() {
+        let timestamp = datetime!(2026-09-04 06:07:42 UTC);
+
         let row = TraceLog {
-            ddsource: "fastly",
+            ddsource: LOG_SOURCE_FORMAT,
             ddtags: "env:production",
             hostname: "docs.rs-fastly",
-            timestamp: 1_500,
+            timestamp,
             message: "handled request",
             service: "docs.rs fastly WASM",
             status: "info",
+            target: "docs_rs_fastly::ngwaf",
             fields: Map::from_iter([("status_code".into(), json!(200))]),
         };
 
         assert_eq!(
             serde_json::to_value(row).unwrap(),
             json!({
-                "ddsource": "fastly",
+                "ddsource": LOG_SOURCE_FORMAT,
                 "ddtags": "env:production",
                 "hostname": "docs.rs-fastly",
-                "timestamp": 1500,
+                "timestamp": "2026-09-04T06:07:42Z",
                 "message": "handled request",
                 "service": "docs.rs fastly WASM",
                 "status": "info",
+                "target": "docs_rs_fastly::ngwaf",
                 "fields": { "status_code": 200 },
             })
         );
@@ -329,5 +337,30 @@ mod tests {
 
         let log = json_lines(&output).pop().unwrap();
         assert_eq!(log["fields"]["backend"], "origin");
+    }
+
+    #[test]
+    fn formatter_preserves_message_with_a_debug_error_field() {
+        #[derive(Debug)]
+        struct InspectError;
+
+        let output = capture_logs(|| {
+            let request = tracing::info_span!("request", request_id = "request-123");
+            let _entered = request.enter();
+            let error = InspectError;
+
+            tracing::error!(
+                target: "docs_rs_fastly::ngwaf",
+                error = ?error,
+                "error inspecting request"
+            );
+        });
+
+        let log = json_lines(&output).pop().unwrap();
+        assert_eq!(log["message"], "error inspecting request");
+        assert_eq!(log["status"], "error");
+        assert_eq!(log["target"], "docs_rs_fastly::ngwaf");
+        assert_eq!(log["fields"]["error"], "InspectError");
+        assert_eq!(log["fields"]["request_id"], "request-123");
     }
 }


### PR DESCRIPTION
Example log from datadog: 
<img width="1858" height="1362" alt="image" src="https://github.com/user-attachments/assets/8e58c53a-ce0a-483f-9eaa-5786ab5bc631" />

### empty log message
What jumps to mind: "log message" just contains " -> ", nothing else. After checking that we actually emit the `message` field, some digging showed that we have a log processing pipeline configured that is attached to the `source:fastly` tag. The logic there assumes the request-log format we get from crates.io. 

<img width="1480" height="1106" alt="image" src="https://github.com/user-attachments/assets/fce8c5f8-4ef4-43c6-8ac3-d225003d9d1f" />

Looking [at the documentation for the `ddsource` attribute](https://docs.datadoghq.com/logs/log_configuration/attributes_naming_convention/#reserved-attributes), it should identify the _kind_ of service. And then, datadog will bind log processors to this, for example to process nginx log format when we have `ddsource:nginx`. 

That means, we just send another (custom) source, and then we'll have our message in the UI. 

### unix timestamp in json blob 

Even though datadog parses the datetime like this and shows it at the top, I think I like a human-readable timestamp much more. So I changed it. 

### missing tracing target 
The tracing "target" from the traving event metadata wan't in the output, but it should be there. 


### unrelated
- replace `exclude = []` in global workspace with empty `[workspace]` in our crate


