### PR TITLE
ci-runners: Only list images for same architecture

### DIFF
--- a/terragrunt/modules/ci-runners/lambda/index.py
+++ b/terragrunt/modules/ci-runners/lambda/index.py
@@ -41,7 +41,8 @@ def update_ami(ami_name, arch):
     # Now that we should have an AMI, we want to place it's ID in an SSM parameter.
     # Getting the ID out of packer is annoying so just query EC2 for it from the name.
     ec2 = boto3.client("ec2", region_name="us-east-2")
-    images = ec2.describe_images(Owners=["self"])
+    ec2_arch = arch if arch == "x86_64" else "arm64"
+    images = ec2.describe_images(Owners=["self"], Architecture=[ec2_arch])
     for image in images["Images"]:
         creation_date = datetime.datetime.fromisoformat(image["CreationDate"])
         age_in_days = (
@@ -65,7 +66,7 @@ def update_ami(ami_name, arch):
                 DataType="aws:ec2:image",
                 Overwrite=True,
             )
-        elif age_in_days > 2:
+        elif age_in_days > 14:
             ec2.deregister_image(
                 ImageId=image["ImageId"], DeleteAssociatedSnapshots=True
             )


### PR DESCRIPTION
This should avoid deleting x86_64 images if those stop working but aarch64 is still available. Also bumps retention to 14 days (should be not strictly necessary). We should wire up some kind of failure notifications to (probably) Zulip as follow-up.

I think this should prevent recurrence of the CI trouble (https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Linux.20x64.20EC2.20not.20starting/with/621890769) while we figure out what actually broke in the x86 image builds...