### PR TITLE
Add crates.io yank token to triagebot

### DIFF
--- a/terraform/shared/main.tf
+++ b/terraform/shared/main.tf
@@ -13,11 +13,11 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "rust-terraform"
-    key            = "simpleinfra/shared.tfstate"
-    region         = "us-west-1"
-    dynamodb_table = "terraform-state-lock"
-    encrypt        = true
+    bucket       = "rust-terraform"
+    key          = "simpleinfra/shared.tfstate"
+    region       = "us-west-1"
+    use_lockfile = true
+    encrypt      = true
   }
 }
 

--- a/terraform/shared/services/triagebot/main.tf
+++ b/terraform/shared/services/triagebot/main.tf
@@ -12,6 +12,7 @@ data "aws_ssm_parameter" "triagebot" {
     "zulip-token",
     "zulip-api-token",
     "github-app-private-key",
+    "crates-io-yank-token",
   ])
   name = "/prod/ecs/triagebot/${each.value}"
 }
@@ -106,6 +107,10 @@ module "ecs_task" {
       {
         "name": "DATABASE_URL",
         "valueFrom": "${data.aws_ssm_parameter.database_url.arn}"
+      },
+      {
+        "name": "CRATES_IO_API_TOKEN",
+        "valueFrom": "${data.aws_ssm_parameter.triagebot["crates-io-yank-token"].arn}"
       }
     ]
   }


### PR DESCRIPTION
Also moves the shared terraform to the new lockfile in S3 rather than DDB.