### PR TITLE
crates.io: Redirect HTTP requests to HTTPS on Fastly

### DIFF
--- a/terragrunt/modules/crates-io/fastly-webapp.tf
+++ b/terragrunt/modules/crates-io/fastly-webapp.tf
@@ -66,6 +66,11 @@ resource "fastly_service_vcl" "webapp" {
     between_bytes_timeout = local.webapp_cdn_timeout_seconds * 1000
   }
 
+  request_setting {
+    name      = "Redirect HTTP to HTTPS"
+    force_ssl = true
+  }
+
   default_ttl = 0
 
   logging_datadog {


### PR DESCRIPTION
The webapp service uses Fastly’s native TLS redirect setting to return a 301 response for HTTP requests. This brings the staging and production Fastly services in line with the HTTPS redirect already configured for CloudFront.

r? @rust-lang/infra 

---

Disclaimer: This was analyzed and created by GPT Codex.